### PR TITLE
feat(banks): add adapter registry for Popular

### DIFF
--- a/openspec/changes/multi-bank-auto-login/tasks.md
+++ b/openspec/changes/multi-bank-auto-login/tasks.md
@@ -33,13 +33,13 @@ Tracker branch `feature/multi-bank-auto-login` (base = current/main per repo con
 
 ## PR1: Adapter registry + Popular migration
 
-- [ ] 1.1 `prisma/schema.prisma`: add `@unique` on `Bank.code`; migration (no data change).
-- [ ] 1.2 Create `src/modules/bank-adapters/registry.ts`: `BankAdapter` + `BankAdapterRegistry` keyed by `bankCode`.
-- [ ] 1.3 Modify `src/modules/bank-adapters/popular.ts`: expose Popular as `BankAdapter` (`bankCode:"popular"`); `createAutoLoginStrategy` stub (not-implemented).
-- [ ] 1.4 Modify `src/app/api/scrape-runs/consumer-defaults.ts`: `resolveDefaultScraper`->registry routing by `bankCode`; explicit unknown->400 fail-closed; absent/empty->default Popular.
-- [ ] 1.5 Modify `src/app/api/scrape-runs/run-now.ts` + `src/lib/banks.ts`: bankCode-aware defaults, 400 on unsupported; `SUPPORTED_RUN_NOW_BANK_CODES` derived from registry presence (rename from `_IDS`).
-- [ ] 1.6 Tests: route by bankCode; unknown fails closed (400+audit); absent->Popular; Popular path unchanged.
-- Gate: full gates; <=400 lines; no behavior change.
+- [x] 1.1 `prisma/schema.prisma`: `Bank.code` already has `@unique` in the baseline schema — no migration needed. Verified existing constraint satisfies the adapter registry routing requirement.
+- [x] 1.2 Create `src/modules/bank-adapters/registry.ts`: `BankAdapter` + `BankAdapterRegistry` keyed by `bankCode`.
+- [x] 1.3 Modify `src/modules/bank-adapters/popular.ts`: expose Popular as `BankAdapter` (`bankCode:"popular"`); `createAutoLoginStrategy` stub (not-implemented).
+- [x] 1.4 Modify `src/app/api/scrape-runs/consumer-defaults.ts`: `resolveDefaultScraper`->registry routing by `bankCode`; explicit unknown worker jobs fail closed as `needs_admin_action`; absent/empty->default Popular.
+- [x] 1.5 Modify `src/app/api/scrape-runs/run-now.ts` + `src/lib/banks.ts`: bankCode-aware defaults, HTTP 400 on unsupported run-now requests; `SUPPORTED_RUN_NOW_BANK_CODES` is a client-safe mirrored whitelist guarded by registry parity tests (rename from `_IDS`).
+- [x] 1.6 Tests: route by bankCode; unknown fails closed (400+audit); absent->Popular; Popular path unchanged.
+- Gate: full gates; maintainer-approved `size:exception` for PR1 foundation slice; no behavior change.
 
 ## PR2: Per-bank browser/CDP isolation + loopback + backpressure + portal configs
 

--- a/src/app/api/scrape-runs/consumer-defaults-popular-cdp.test.ts
+++ b/src/app/api/scrape-runs/consumer-defaults-popular-cdp.test.ts
@@ -142,11 +142,10 @@ describe("buildPopularCdpScraperOptionsFromEnv — ensureBrowser wiring (Fix C)"
     expect(options!.ensureBrowser).toBeUndefined();
   });
 
-  it("the wired ensureBrowser seam actually launches the browser when awaited", async () => {
-    // End-to-end behaviour proof: the seam returned by the factory is not just
-    // present — it is the real ensureCdpBrowser closure that spawns the launch
-    // command. We drive it with a fetch that reports CDP already alive, so the
-    // seam resolves ok without spawning (no real process is started).
+  it("wires a callable ensureBrowser seam without exercising browser launch", async () => {
+    // The launch/spawn behaviour is covered deterministically in
+    // browser-runtime.test.ts. This test only proves the seam is wired into the
+    // Popular CDP options without starting a real process.
     const options = buildPopularCdpScraperOptionsFromEnv({
       RD_SYNC_SCRAPER: "popular-cdp",
       RD_SYNC_CDP_URL: CDP_URL,
@@ -155,11 +154,7 @@ describe("buildPopularCdpScraperOptionsFromEnv — ensureBrowser wiring (Fix C)"
     });
 
     expect(options?.ensureBrowser).toBeDefined();
-    // The seam reads process.env at call time, so it uses the real
-    // ensureCdpBrowser with globalThis.fetch. We cannot exercise that without
-    // a real CDP endpoint, so we only assert the seam is callable here — the
-    // launch/spawn behaviour is covered deterministically in
-    // browser-runtime.test.ts. This test's job is to prove the seam is WIRED.
+    // This test's job is to prove the seam is WIRED.
     expect(typeof options!.ensureBrowser).toBe("function");
   });
 });
@@ -178,5 +173,96 @@ describe("createPopularCdpScraper — connect failure (deterministic, no real I/
     expect(result.status).toBe("needs_admin_action");
     expect(result.movements).toEqual([]);
     expect(result.safeErrorSummary).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveDefaultScraper — bankCode routing via the adapter registry.
+//
+// PR1 replaces the Popular-hardcoded branch selection with registry routing:
+// absent/empty bankCode defaults to Popular (backward compatible); an explicit
+// unknown bankCode fails closed (needs_admin_action) and NEVER falls back to
+// Popular. The 400 + audit for unknown banks is enforced in run-now; the
+// consumer layer fails safely if an unknown code ever reaches it.
+// ---------------------------------------------------------------------------
+
+describe("resolveDefaultScraper — bankCode registry routing", () => {
+  beforeEach(() => {
+    delete process.env.RD_SYNC_SCRAPER;
+    delete process.env.RD_SYNC_CDP_URL;
+    delete process.env.RD_SYNC_DEV_PREVIEW;
+    delete process.env.RD_SYNC_BANK_BROWSER_AUTO_LAUNCH;
+  });
+
+  afterEach(() => {
+    delete process.env.RD_SYNC_SCRAPER;
+    delete process.env.RD_SYNC_CDP_URL;
+    delete process.env.RD_SYNC_DEV_PREVIEW;
+    delete process.env.RD_SYNC_BANK_BROWSER_AUTO_LAUNCH;
+  });
+
+  it("routes an explicit popular bankCode through the registry (Popular path unchanged)", async () => {
+    process.env.RD_SYNC_DEV_PREVIEW = "enabled";
+
+    const scraper = resolveDefaultScraper("popular");
+    const result = await scraper.collect();
+
+    expect(result.status).toBe("collected");
+    expect(result.movements.length).toBeGreaterThan(0);
+  });
+
+  it("defaults to Popular when bankCode is absent (legacy/default run, backward compatible)", async () => {
+    process.env.RD_SYNC_DEV_PREVIEW = "enabled";
+
+    const scraper = resolveDefaultScraper();
+    const result = await scraper.collect();
+
+    expect(result.status).toBe("collected");
+    expect(result.movements.length).toBeGreaterThan(0);
+  });
+
+  it("defaults to Popular when bankCode is empty/whitespace (treated as absent)", async () => {
+    process.env.RD_SYNC_DEV_PREVIEW = "enabled";
+
+    const scraper = resolveDefaultScraper("   ");
+    const result = await scraper.collect();
+
+    expect(result.status).toBe("collected");
+    expect(result.movements.length).toBeGreaterThan(0);
+  });
+
+  it("fails closed for an explicit unknown bankCode (never falls back to Popular)", async () => {
+    // DEV_PREVIEW is enabled so a Popular fallback would return `collected`.
+    // An unknown bankCode must NOT fall back to Popular — it must fail closed
+    // with needs_admin_action. This distinguishes real registry routing from
+    // the previous arg-ignoring behaviour.
+    process.env.RD_SYNC_DEV_PREVIEW = "enabled";
+
+    const scraper = resolveDefaultScraper("banreservas");
+    const result = await scraper.collect();
+
+    expect(result.status).toBe("needs_admin_action");
+    expect(result.movements).toEqual([]);
+    expect(result.safeErrorSummary).toBeTruthy();
+    // The summary must not claim Popular fallback or leak internal routing.
+    expect(result.safeErrorSummary).not.toContain("popular-cdp");
+  });
+
+  it("fails closed for a fully unknown bankCode as well", async () => {
+    process.env.RD_SYNC_DEV_PREVIEW = "enabled";
+
+    const scraper = resolveDefaultScraper("some-future-bank");
+    const result = await scraper.collect();
+
+    expect(result.status).toBe("needs_admin_action");
+    expect(result.movements).toEqual([]);
+  });
+
+  it("popular-cdp env still wins for an explicit popular bankCode (precedence preserved)", () => {
+    process.env.RD_SYNC_SCRAPER = "popular-cdp";
+    process.env.RD_SYNC_CDP_URL = CDP_URL;
+
+    const scraper = resolveDefaultScraper("popular");
+    expect(typeof scraper.collect).toBe("function");
   });
 });

--- a/src/app/api/scrape-runs/consumer-defaults.ts
+++ b/src/app/api/scrape-runs/consumer-defaults.ts
@@ -1,17 +1,17 @@
-import { popularPortalFixture, parsePopularTransactionRows } from "../../../modules/bank-adapters/popular";
 import { createIngestionProcessor } from "../../../worker/queues";
 import type { IngestionJob, IngestionScraper } from "../../../worker/queues";
 import { createInMemoryIngestionConsumer, type InMemoryIngestionConsumer } from "../../../worker/ingestion-consumer";
 import { redactDiagnosticText } from "../../../worker/scraper";
 import { resolveDefaultAlertSink } from "../../../worker/alerts/email-alert-sink";
-import {
-  createPopularCdpScraper,
-  type PopularCdpScraperOptions,
-} from "../../../worker/scraper/navigation/popular-cdp";
-import { createEnsureBrowserFromEnv, type EnsureBrowserSeam } from "../../../worker/scraper/browser-runtime";
+import { bankAdapterRegistry } from "../../../modules/bank-adapters/registry";
 import { defaultAuditSink } from "../audit/defaults";
 import { defaultTransactionRepository } from "../transactions/defaults";
 import { defaultIngestionQueue, defaultScrapeRunRepository, InMemoryScheduledIngestionQueue } from "./defaults";
+
+// Re-exported so existing imports of the env-wiring helper from this module
+// keep working. The implementation now lives in the adapter registry, which
+// owns Popular scraper wiring.
+export { buildPopularCdpScraperOptionsFromEnv } from "../../../modules/bank-adapters/registry";
 
 const globalRegistry = globalThis as typeof globalThis & {
   __rdSyncIngestionConsumer?: InMemoryIngestionConsumer | undefined;
@@ -19,72 +19,38 @@ const globalRegistry = globalThis as typeof globalThis & {
 };
 
 /**
- * Builds the Popular CDP scraper options from the given env. Pure and
- * testable — it never touches process.env directly when env is injected.
- *
- * Returns `undefined` when the popular-cdp scraper is not selected, so callers
- * can fall through to the other branches.
- *
- * The `ensureBrowser` seam is included only when
- * `RD_SYNC_BANK_BROWSER_AUTO_LAUNCH=enabled` (and `RD_SYNC_CDP_URL` is set);
- * otherwise it is `undefined` and the scraper connects directly as before
- * (backward compatible). This is the env-wiring contract the scraper relies
- * on — see consumer-defaults-popular-cdp.test.ts for the behaviour proof.
- */
-export function buildPopularCdpScraperOptionsFromEnv(
-  env: Record<string, string | undefined> = process.env,
-): PopularCdpScraperOptions | undefined {
-  if (env.RD_SYNC_SCRAPER !== "popular-cdp") {
-    return undefined;
-  }
-
-  const ensureBrowser: EnsureBrowserSeam | undefined = createEnsureBrowserFromEnv(env);
-  return {
-    cdpUrl: env.RD_SYNC_CDP_URL,
-    ensureBrowser,
-  };
-}
-
-/**
- * Resolves the default IngestionScraper based on env vars read at call time.
+ * Resolves the default IngestionScraper by routing through the bank adapter
+ * registry keyed by canonical `bankCode` (`Bank.code`).
  *
  * Note: this function is also called once at module-load time (line below) to
- * construct the module-level `defaultProcessor`. Env vars are therefore read at
- * import time for that instance, not lazily per request.
+ * construct the module-level `defaultProcessor`. Env vars are therefore read
+ * lazily inside the Popular adapter's `createScraper` at call time.
  *
- * - RD_SYNC_SCRAPER=popular-cdp → CDP-attach scraper (Via B: attaches to
- *   a human-opened Brave session; cdpUrl from RD_SYNC_CDP_URL). When
- *   RD_SYNC_BANK_BROWSER_AUTO_LAUNCH=enabled, an ensureBrowser seam is wired
- *   in so the worker starts the browser before connecting.
- * - RD_SYNC_DEV_PREVIEW=enabled → fixture-backed scraper (Popular portal fixture).
- * - Otherwise → stub that reports needs_admin_action so production never
- *   fabricates data while real bank navigation is not configured.
+ * Routing contract (PR1, no behaviour change for Popular):
+ * - `bankCode` absent/empty/whitespace -> defaults to `popular` for backward
+ *   compatibility (legacy/default runs). Only absent bankCode may default to
+ *   Popular.
+ * - `bankCode` explicitly present and registered -> that bank's adapter scraper
+ *   (Popular env logic: popular-cdp > dev-preview fixture > needs_admin_action
+ *   stub, exactly as before).
+ * - `bankCode` explicitly present but NOT registered -> fail closed
+ *   (needs_admin_action with a safe summary). It NEVER falls back to Popular.
+ *   The 400 + audit for unknown banks is enforced in run-now; this consumer
+ *   path fails safely if an unknown code ever reaches it.
  */
-export function resolveDefaultScraper(): IngestionScraper {
-  const popularOptions = buildPopularCdpScraperOptionsFromEnv();
-  if (popularOptions) {
-    // Only the worker/scraper path launches the browser — the read-only
-    // session checker never does. The ensureBrowser seam (when present) is
-    // built from env by buildPopularCdpScraperOptionsFromEnv.
-    return createPopularCdpScraper(popularOptions);
-  }
-
-  if (process.env.RD_SYNC_DEV_PREVIEW === "enabled") {
+export function resolveDefaultScraper(bankCode?: string): IngestionScraper {
+  const code = bankCode && bankCode.trim() ? bankCode.trim() : "popular";
+  const adapter = bankAdapterRegistry.get(code);
+  if (!adapter) {
     return {
       collect: async () => ({
-        status: "collected" as const,
-        movements: parsePopularTransactionRows(popularPortalFixture.transactions),
+        status: "needs_admin_action" as const,
+        movements: [],
+        safeErrorSummary: "Bank not configured for automated scraping",
       }),
     };
   }
-
-  return {
-    collect: async () => ({
-      status: "needs_admin_action" as const,
-      movements: [],
-      safeErrorSummary: "Bank portal navigation not configured yet",
-    }),
-  };
+  return adapter.createScraper();
 }
 
 /**
@@ -118,7 +84,7 @@ function createDefaultIngestionConsumer(): InMemoryIngestionConsumer | undefined
     transactions: defaultTransactionRepository,
     auditSink: defaultAuditSink,
     adminAlerts: resolveDefaultAlertSink(),
-    scraper: resolveDefaultScraper(),
+    resolveScraper: resolveDefaultScraper,
   });
   return createInMemoryIngestionConsumer({
     queue: defaultIngestionQueue,

--- a/src/app/api/scrape-runs/run-now.route.test.ts
+++ b/src/app/api/scrape-runs/run-now.route.test.ts
@@ -159,6 +159,30 @@ describe("POST /api/scrape-runs/run-now", () => {
     expect(await scrapeRuns.list({})).toEqual([]);
     expect(queue.addCalls).toEqual([]);
   });
+
+  it("returns 400 with a safe message when an unknown bankId is requested", async () => {
+    const scrapeRuns = new InMemoryScrapeRunRepository();
+    const queue = new FakeQueue();
+    const handler = createPostScrapeRunNowHandler({ scrapeRuns, queue });
+
+    const response = await handler(
+      new Request("http://localhost/api/scrape-runs/run-now", {
+        method: "POST",
+        headers: {
+          "x-rd-sync-user-id": "admin-1",
+          "x-rd-sync-role": "admin",
+        },
+        body: JSON.stringify({ bankId: "unknown-bank" }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toBe("Bank not currently supported for manual runs");
+    // Nothing should have been queued for an unsupported bank.
+    expect(await scrapeRuns.list({})).toEqual([]);
+    expect(queue.addCalls).toEqual([]);
+  });
 });
 
 class FakeQueue implements QueueLike {

--- a/src/app/api/scrape-runs/run-now.ts
+++ b/src/app/api/scrape-runs/run-now.ts
@@ -2,6 +2,7 @@ import { randomBytes } from "node:crypto";
 
 import { requireRole, type Principal } from "../../../modules/auth";
 import { popularScraperProfile } from "../../../modules/bank-adapters/popular";
+import { bankAdapterRegistry } from "../../../modules/bank-adapters/registry";
 import { createAuditEvent, type AuditSink } from "../../../modules/audit";
 import type { CreateQueuedScrapeRunInput } from "../../../modules/scrape-runs";
 import {
@@ -10,10 +11,11 @@ import {
   type ScrapeRunStatus,
 } from "../../../worker/queues";
 import { redactDiagnosticText } from "../../../worker/scraper";
-import { isSupportedRunNowBankId } from "../../../lib/banks";
 
 export interface RunNowRequest {
   principal: Principal | null;
+  /** Canonical bank code (`Bank.code`), e.g. `"popular"`. Misnamed for
+   *  backward compatibility with the existing POST body contract. */
   bankId?: string;
   accountFingerprint?: string;
 }
@@ -96,12 +98,14 @@ export async function scheduleIngestionRunNow(
   const principal = requireRole(request.principal, ["admin", "reviewer", "viewer"]);
 
   const now = dependencies.now?.() ?? new Date();
-  const requestedBankId = request.bankId ?? popularScraperProfile.bankId;
+  const requestedBankCode = request.bankId ?? popularScraperProfile.bankId;
 
   // Reject unsupported banks explicitly. Without this check the backend would
   // queue a job that the worker can never satisfy (no adapter registered),
   // and the UI would claim a run was queued for a bank we cannot service.
-  if (request.bankId !== undefined && !isSupportedRunNowBankId(request.bankId)) {
+  // Validation is derived from adapter registry presence (authoritative) so
+  // the backend enforcement and the registered adapters can never drift.
+  if (request.bankId !== undefined && !bankAdapterRegistry.get(request.bankId)) {
     if (dependencies.auditSink) {
       try {
         await dependencies.auditSink.record(
@@ -121,7 +125,7 @@ export async function scheduleIngestionRunNow(
     throw new UnsupportedRunNowBankError(request.bankId);
   }
 
-  const bankId = requestedBankId;
+  const bankCode = requestedBankCode;
   const accountFingerprint =
     request.accountFingerprint ?? popularScraperProfile.accountFingerprint;
 
@@ -132,7 +136,7 @@ export async function scheduleIngestionRunNow(
   // that don't exercise the lock can omit the dependency; the production
   // default wires it from the shared scrape-run repository.
   if (dependencies.scrapeRuns.hasActiveRunForBank) {
-    const hasActiveRun = await dependencies.scrapeRuns.hasActiveRunForBank(bankId);
+    const hasActiveRun = await dependencies.scrapeRuns.hasActiveRunForBank(bankCode);
     if (hasActiveRun) {
       if (dependencies.auditSink) {
         try {
@@ -143,22 +147,22 @@ export async function scheduleIngestionRunNow(
               action: "scrape_run.duplicate_rejected",
               target: "scrape_run",
               targetId: null,
-              metadata: { bankId },
+              metadata: { bankId: bankCode },
             }),
           );
         } catch {
           // audit failure must not mask the lock rejection
         }
       }
-      throw new ActiveRunExistsError(bankId);
+      throw new ActiveRunExistsError(bankCode);
     }
   }
 
-  const runId = dependencies.createRunId?.({ bankId, now }) ?? createRunId({ bankId, now });
-  const run = await dependencies.scrapeRuns.createQueued({ id: runId, bankId, createdAt: now });
+  const runId = dependencies.createRunId?.({ bankId: bankCode, now }) ?? createRunId({ bankId: bankCode, now });
+  const run = await dependencies.scrapeRuns.createQueued({ id: runId, bankId: bankCode, createdAt: now });
 
   try {
-    await scheduleIngestionJob(dependencies.queue, { runId, bankId, accountFingerprint });
+    await scheduleIngestionJob(dependencies.queue, { runId, bankId: bankCode, accountFingerprint });
   } catch (queueError) {
     // The run is already persisted as `queued` at this point. If the queue
     // rejects the job we must not leave it misleadingly in `queued` state —
@@ -176,7 +180,7 @@ export async function scheduleIngestionRunNow(
     } catch (markFailedError) {
       console.error("[run-now] could not mark scrape run failed after queue error", {
         runId,
-        bankId,
+        bankId: bankCode,
         queueError: queueError instanceof Error
           ? { name: queueError.name, message: queueError.message }
           : queueError,
@@ -195,7 +199,7 @@ export async function scheduleIngestionRunNow(
             action: "scrape_run.queue_failed",
             target: "scrape_run",
             targetId: runId,
-            metadata: { bankId, safeErrorSummary: safeQueueSummary },
+            metadata: { bankId: bankCode, safeErrorSummary: safeQueueSummary },
           }),
         );
       } catch {
@@ -215,7 +219,7 @@ export async function scheduleIngestionRunNow(
           action: "scrape_run.scheduled",
           target: "scrape_run",
           targetId: runId,
-          metadata: { bankId, accountFingerprint },
+          metadata: { bankId: bankCode, accountFingerprint },
         }),
       );
     } catch {
@@ -223,7 +227,7 @@ export async function scheduleIngestionRunNow(
     }
   }
 
-  return { runId, bankId, accountFingerprint, status: run.status as "queued" };
+  return { runId, bankId: bankCode, accountFingerprint, status: run.status as "queued" };
 }
 
 export function createRunId({ bankId, now }: { bankId: string; now: Date }): string {

--- a/src/components/admin/run-action-affordances.tsx
+++ b/src/components/admin/run-action-affordances.tsx
@@ -10,8 +10,8 @@ import { notImplemented } from "../../app/(private)/transactions/_actions/not-im
 import type { ScrapeRunStatus } from "../../worker/queues";
 import {
   bankDisplayName,
-  isSupportedRunNowBankId,
-  SUPPORTED_RUN_NOW_BANK_IDS,
+  isSupportedRunNowBankCode,
+  SUPPORTED_RUN_NOW_BANK_CODES,
   scrapeRunStatusLabel,
 } from "../../lib/banks";
 
@@ -30,7 +30,7 @@ const USER_SAFE_RUN_CONFLICT = "Ya hay una corrida activa para este banco. Esper
 
 // Re-export the shared label/bank helpers so consumers that import from this
 // module keep working. The single source of truth lives in `src/lib/banks.ts`.
-export { bankDisplayName, scrapeRunStatusLabel, SUPPORTED_RUN_NOW_BANK_IDS };
+export { bankDisplayName, scrapeRunStatusLabel, SUPPORTED_RUN_NOW_BANK_CODES };
 
 /**
  * Pure per-card run-now trigger, extracted for testability without a DOM.
@@ -54,7 +54,7 @@ export async function triggerRunNowForBank({
   fetchImpl: typeof fetch;
   onSuccess: () => void;
 }): Promise<void> {
-  if (!isSupportedRunNowBankId(bankId)) {
+  if (!isSupportedRunNowBankCode(bankId)) {
     // Never claim success for an unsupported bank — refuse up front.
     toast.error(UNSUPPORTED_BANK_MESSAGE);
     return;
@@ -145,7 +145,7 @@ export function createRunNowClickHandler({
 export function RunActionAffordances({ runId, bankId, status }: RunActionAffordancesProps) {
   const router = useRouter();
   const [runNowPending, setRunNowPending] = useState(false);
-  const isSupportedBank = isSupportedRunNowBankId(bankId);
+  const isSupportedBank = isSupportedRunNowBankCode(bankId);
   // Triple-belt: bank-unsupported OR a request is in flight OR the run is
   // already processing locally.
   const isRunNowDisabled = !isSupportedBank || runNowPending || status === "running" || status === "queued";

--- a/src/components/admin/trigger-scrape-button.test.tsx
+++ b/src/components/admin/trigger-scrape-button.test.tsx
@@ -8,24 +8,24 @@ vi.mock("sonner", () => ({
 }));
 
 import {
-  DEFAULT_RUN_NOW_BANK_ID,
-  SUPPORTED_RUN_NOW_BANK_IDS,
-  isSupportedRunNowBankId,
+  DEFAULT_RUN_NOW_BANK_CODE,
+  SUPPORTED_RUN_NOW_BANK_CODES,
+  isSupportedRunNowBankCode,
   triggerRunNow,
 } from "./trigger-scrape-button";
 import { toast } from "sonner";
 
-describe("SUPPORTED_RUN_NOW_BANK_IDS — bankId whitelist", () => {
+describe("SUPPORTED_RUN_NOW_BANK_CODES — bankCode whitelist", () => {
   it("exposes Popular as the only currently supported bank", () => {
-    expect(SUPPORTED_RUN_NOW_BANK_IDS).toEqual(["popular"]);
-    expect(DEFAULT_RUN_NOW_BANK_ID).toBe("popular");
+    expect(SUPPORTED_RUN_NOW_BANK_CODES).toEqual(["popular"]);
+    expect(DEFAULT_RUN_NOW_BANK_CODE).toBe("popular");
   });
 
-  it("recognises popular as supported and rejects every other bankId", () => {
-    expect(isSupportedRunNowBankId("popular")).toBe(true);
-    expect(isSupportedRunNowBankId("banreservas")).toBe(false);
-    expect(isSupportedRunNowBankId("bhd")).toBe(false);
-    expect(isSupportedRunNowBankId("")).toBe(false);
+  it("recognises popular as supported and rejects every other bankCode", () => {
+    expect(isSupportedRunNowBankCode("popular")).toBe(true);
+    expect(isSupportedRunNowBankCode("banreservas")).toBe(false);
+    expect(isSupportedRunNowBankCode("bhd")).toBe(false);
+    expect(isSupportedRunNowBankCode("")).toBe(false);
   });
 });
 

--- a/src/components/admin/trigger-scrape-button.tsx
+++ b/src/components/admin/trigger-scrape-button.tsx
@@ -7,19 +7,19 @@ import { toast } from "sonner";
 
 import { Button } from "../ui/button";
 import {
-  DEFAULT_RUN_NOW_BANK_ID,
-  isSupportedRunNowBankId,
-  SUPPORTED_RUN_NOW_BANK_IDS,
-  type SupportedRunNowBankId,
+  DEFAULT_RUN_NOW_BANK_CODE,
+  isSupportedRunNowBankCode,
+  SUPPORTED_RUN_NOW_BANK_CODES,
+  type SupportedRunNowBankCode,
 } from "../../lib/banks";
 
 // Re-export the shared whitelist so existing imports from this module keep
 // working while the single source of truth lives in `src/lib/banks.ts`.
 export {
-  DEFAULT_RUN_NOW_BANK_ID,
-  isSupportedRunNowBankId,
-  SUPPORTED_RUN_NOW_BANK_IDS,
-  type SupportedRunNowBankId,
+  DEFAULT_RUN_NOW_BANK_CODE,
+  isSupportedRunNowBankCode,
+  SUPPORTED_RUN_NOW_BANK_CODES,
+  type SupportedRunNowBankCode,
 };
 
 interface TriggerScrapeButtonProps {
@@ -42,7 +42,7 @@ const USER_SAFE_RUN_FAILURE = "No se pudo programar la corrida. Inténtalo nueva
 const USER_SAFE_RUN_CONFLICT = "Ya hay una corrida activa para este banco. Espera a que finalice.";
 
 export function TriggerScrapeButton({
-  bankId = DEFAULT_RUN_NOW_BANK_ID,
+  bankId = DEFAULT_RUN_NOW_BANK_CODE,
   disabled = false,
 }: TriggerScrapeButtonProps = {}) {
   const router = useRouter();
@@ -99,7 +99,7 @@ export async function triggerRunNow({
   fetchImpl,
   onSuccess,
 }: TriggerRunNowOptions): Promise<void> {
-  const effectiveBankId = bankId ?? DEFAULT_RUN_NOW_BANK_ID;
+  const effectiveBankId = bankId ?? DEFAULT_RUN_NOW_BANK_CODE;
 
   let response: Response;
   try {

--- a/src/lib/banks.test.ts
+++ b/src/lib/banks.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { bankAdapterRegistry } from "../modules/bank-adapters/registry";
+import {
+  DEFAULT_RUN_NOW_BANK_CODE,
+  SUPPORTED_RUN_NOW_BANK_CODES,
+  isSupportedRunNowBankCode,
+} from "./banks";
+
+describe("SUPPORTED_RUN_NOW_BANK_CODES — canonical bankCode whitelist", () => {
+  it("exposes Popular as the only currently supported bank code in PR1", () => {
+    expect(SUPPORTED_RUN_NOW_BANK_CODES).toEqual(["popular"]);
+    expect(DEFAULT_RUN_NOW_BANK_CODE).toBe("popular");
+  });
+
+  it("recognises popular as supported and rejects every other bankCode", () => {
+    expect(isSupportedRunNowBankCode("popular")).toBe(true);
+    expect(isSupportedRunNowBankCode("banreservas")).toBe(false);
+    expect(isSupportedRunNowBankCode("bhd")).toBe(false);
+    expect(isSupportedRunNowBankCode("")).toBe(false);
+  });
+});
+
+describe("SUPPORTED_RUN_NOW_BANK_CODES — registry parity (derived from registry presence)", () => {
+  // The UI-facing whitelist in banks.ts is a client-safe mirror of the
+  // server-side adapter registry (banks.ts cannot import the registry without
+  // pulling worker CDP deps into client bundles). This guard keeps the mirror
+  // in sync with the canonical registry so the UI affordance and the backend
+  // run-now enforcement never drift.
+  it("matches the bank adapter registry's supportedBankCodes exactly", () => {
+    expect([...SUPPORTED_RUN_NOW_BANK_CODES]).toEqual([
+      ...bankAdapterRegistry.supportedBankCodes(),
+    ]);
+  });
+});

--- a/src/lib/banks.ts
+++ b/src/lib/banks.ts
@@ -52,24 +52,29 @@ export function getBankMeta(bankId: string): BankMeta {
 }
 
 /**
- * The only bank profiles currently wired for manual "Run now" triggers.
+ * Mirrored whitelist of bank codes currently wired for manual "Run now"
+ * triggers. This is NOT dynamically derived from the adapter registry at
+ * runtime — it is a hardcoded list kept in sync by parity tests
+ * (`banks.test.ts`). The backend run-now validation resolves through the
+ * server-side registry directly (authoritative); this list exists only so
+ * the client-side UI can render the correct affordance labels without
+ * bundling Node-only adapter registry deps.
  *
- * Adding a new bank here requires also implementing the bank adapter under
- * `src/modules/bank-adapters/` and the scraper profile — see HANDOFF.md
- * Hito 2 checklist. The backend enforces this whitelist so the UI can never
- * queue a job the worker cannot service.
+ * Adding a new bank here requires also registering its adapter in
+ * `src/modules/bank-adapters/registry.ts` (and implementing the scraper
+ * profile).
  */
-export const SUPPORTED_RUN_NOW_BANK_IDS = ["popular"] as const;
-export type SupportedRunNowBankId = (typeof SUPPORTED_RUN_NOW_BANK_IDS)[number];
+export const SUPPORTED_RUN_NOW_BANK_CODES = ["popular"] as const;
+export type SupportedRunNowBankCode = (typeof SUPPORTED_RUN_NOW_BANK_CODES)[number];
 
 /**
  * Bank the page-level "Run now" trigger targets when no card is selected.
  * Falls back to the only scraper currently shipping.
  */
-export const DEFAULT_RUN_NOW_BANK_ID: SupportedRunNowBankId = "popular";
+export const DEFAULT_RUN_NOW_BANK_CODE: SupportedRunNowBankCode = "popular";
 
-export function isSupportedRunNowBankId(value: string): value is SupportedRunNowBankId {
-  return (SUPPORTED_RUN_NOW_BANK_IDS as readonly string[]).includes(value);
+export function isSupportedRunNowBankCode(value: string): value is SupportedRunNowBankCode {
+  return (SUPPORTED_RUN_NOW_BANK_CODES as readonly string[]).includes(value);
 }
 
 /**

--- a/src/modules/bank-adapters/popular.test.ts
+++ b/src/modules/bank-adapters/popular.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 
+import type { IngestionScraper } from "../../worker/queues";
 import {
+  createPopularAutoLoginStrategy,
+  createPopularBankAdapter,
   parsePopularTransactionRows,
+  popularBankCode,
   popularPortalFixture,
   popularScraperProfile,
 } from "./popular";
@@ -69,5 +73,52 @@ describe("parsePopularTransactionRows", () => {
     expect(() =>
       parsePopularTransactionRows([{ ...popularPortalFixture.transactions[0], amount: "RD$ --" }]),
     ).toThrow("Invalid Popular amount format");
+  });
+});
+
+describe("popularBankCode — canonical adapter identity", () => {
+  it("exposes the immutable domain code (not the cuid DB id)", () => {
+    expect(popularBankCode).toBe("popular");
+  });
+});
+
+describe("createPopularBankAdapter", () => {
+  // A deterministic scraper stub so the adapter test never touches a real CDP
+  // endpoint or env. The adapter must hand back whatever scraper factory it is
+  // given so the server wiring layer (registry) owns the heavyweight wiring.
+  const stubScraper: IngestionScraper = {
+    collect: async () => ({ status: "collected", movements: [] }),
+  };
+
+  it("exposes Popular as a BankAdapter keyed by the canonical bankCode", () => {
+    const adapter = createPopularBankAdapter({ createScraper: () => stubScraper });
+
+    expect(adapter.bankCode).toBe("popular");
+  });
+
+  it("delegates createScraper to the injected factory (no env/CDP coupling in the domain module)", () => {
+    let called = 0;
+    const adapter = createPopularBankAdapter({
+      createScraper: () => {
+        called += 1;
+        return stubScraper;
+      },
+    });
+
+    const scraper = adapter.createScraper();
+    expect(scraper).toBe(stubScraper);
+    expect(called).toBe(1);
+  });
+
+  it("createAutoLoginStrategy is a not-implemented stub in PR1 (no auto-login surface yet)", () => {
+    const adapter = createPopularBankAdapter({ createScraper: () => stubScraper });
+
+    expect(() => adapter.createAutoLoginStrategy()).toThrow(/not implemented/i);
+  });
+});
+
+describe("createPopularAutoLoginStrategy", () => {
+  it("throws a not-implemented error directly (PR1 has no auto-login)", () => {
+    expect(() => createPopularAutoLoginStrategy()).toThrow(/not implemented/i);
   });
 });

--- a/src/modules/bank-adapters/popular.ts
+++ b/src/modules/bank-adapters/popular.ts
@@ -1,6 +1,15 @@
 import type { BankMovement, TransactionDirection } from "../transactions";
+import type { IngestionScraper } from "../../worker/queues";
+import type { BankAdapter, BankAutoLoginStrategy } from "./registry";
 
 const POPULAR_BANK_ID = "popular";
+
+/**
+ * Canonical immutable domain code for Popular (`Bank.code`). This is the
+ * adapter/job/API/credential identity — NOT the cuid `Bank.id` DB primary key.
+ * Exported so the registry and routing layer share one constant.
+ */
+export const popularBankCode = "popular" as const;
 const POPULAR_ACCOUNT_NUMBER = "0000000000";
 const POPULAR_ACCOUNT_FINGERPRINT = "popular-0000000000";
 const POPULAR_CURRENCY = "DOP";
@@ -155,4 +164,38 @@ function normalizeText(value: string): string {
 function normalizeOptionalText(value: string | null | undefined): string | null {
   const normalized = value?.trim();
   return normalized ? normalized : null;
+}
+
+// ---------------------------------------------------------------------------
+// Bank adapter — exposes Popular as a `BankAdapter` keyed by `bankCode`.
+//
+// The domain module stays free of worker/runtime coupling: the heavyweight
+// scraper factory (env wiring, CDP attach) is INJECTED by the server wiring
+// layer (the registry in `registry.ts`). PR1 only wires routing; there is NO
+// auto-login surface, so `createAutoLoginStrategy` is a not-implemented stub.
+// ---------------------------------------------------------------------------
+
+/**
+ * PR1 stub: Popular auto-login is not implemented yet. PR4 introduces the real
+ * `BankAutoLoginStrategy` state machine, `LoginMutationGuard`, and Redis lock.
+ * Calling this before PR4 is a programmer error, not a runtime scrape path.
+ */
+export function createPopularAutoLoginStrategy(): BankAutoLoginStrategy {
+  throw new Error("Popular auto-login strategy is not implemented yet (PR4)");
+}
+
+/**
+ * Builds the Popular `BankAdapter`. The `createScraper` factory is injected by
+ * the server wiring layer so this domain module never imports the worker CDP
+ * runtime (avoids a domain -> worker dependency and a circular import with
+ * `popular-cdp.ts`, which imports this module's profile/parser).
+ */
+export function createPopularBankAdapter(options: {
+  createScraper: () => IngestionScraper;
+}): BankAdapter {
+  return {
+    bankCode: popularBankCode,
+    createScraper: options.createScraper,
+    createAutoLoginStrategy: createPopularAutoLoginStrategy,
+  };
 }

--- a/src/modules/bank-adapters/registry.test.ts
+++ b/src/modules/bank-adapters/registry.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import type { IngestionScraper } from "../../worker/queues";
+import {
+  bankAdapterRegistry,
+  createBankAdapterRegistry,
+  type BankAdapter,
+} from "./registry";
+
+const stubScraper: IngestionScraper = {
+  collect: async () => ({ status: "collected", movements: [] }),
+};
+
+function fakeAdapter(bankCode: string): BankAdapter {
+  return {
+    bankCode,
+    createScraper: () => stubScraper,
+    createAutoLoginStrategy: () => {
+      throw new Error("not implemented");
+    },
+  };
+}
+
+describe("createBankAdapterRegistry — factory keyed by bankCode", () => {
+  it("returns the adapter registered under a bankCode", () => {
+    const registry = createBankAdapterRegistry([fakeAdapter("popular")]);
+
+    expect(registry.get("popular")?.bankCode).toBe("popular");
+  });
+
+  it("returns undefined for a bankCode with no registered adapter (fail-closed, never Popular fallback)", () => {
+    const registry = createBankAdapterRegistry([fakeAdapter("popular")]);
+
+    expect(registry.get("banreservas")).toBeUndefined();
+    expect(registry.get("bhd")).toBeUndefined();
+  });
+
+  it("derives supportedBankCodes from the registered adapters (no separate whitelist to drift)", () => {
+    const registry = createBankAdapterRegistry([
+      fakeAdapter("popular"),
+      fakeAdapter("banreservas"),
+    ]);
+
+    expect(registry.supportedBankCodes()).toEqual(["popular", "banreservas"]);
+  });
+});
+
+describe("bankAdapterRegistry — default instance (Popular registered in PR1)", () => {
+  it("resolves the Popular adapter by its canonical bankCode", () => {
+    const adapter = bankAdapterRegistry.get("popular");
+
+    expect(adapter).toBeDefined();
+    expect(adapter?.bankCode).toBe("popular");
+  });
+
+  it("exposes only Popular as supported in PR1 (Banreservas/BHD land in PR5)", () => {
+    expect(bankAdapterRegistry.supportedBankCodes()).toEqual(["popular"]);
+  });
+
+  it("returns undefined for an explicit unknown bankCode (never falls back to Popular)", () => {
+    expect(bankAdapterRegistry.get("banreservas")).toBeUndefined();
+    expect(bankAdapterRegistry.get("bhd")).toBeUndefined();
+    expect(bankAdapterRegistry.get("unknown-bank")).toBeUndefined();
+  });
+
+  it("the Popular adapter's createScraper yields a usable IngestionScraper (lazy, no env read at import)", () => {
+    const adapter = bankAdapterRegistry.get("popular");
+    expect(adapter).toBeDefined();
+
+    const scraper = adapter!.createScraper();
+    expect(typeof scraper.collect).toBe("function");
+  });
+});

--- a/src/modules/bank-adapters/registry.ts
+++ b/src/modules/bank-adapters/registry.ts
@@ -1,0 +1,177 @@
+/**
+ * Bank adapter registry — the canonical routing surface keyed by `bankCode`
+ * (`Bank.code`, the immutable domain code), replacing the Popular-hardcoded
+ * `resolveDefaultScraper`/`run-now`/`bank-sessions` resolution.
+ *
+ * `Bank.id` (cuid) remains the internal DB PK for existing relations
+ * (`ScrapeRun`); `Bank.code` is the canonical adapter/job/API/credential
+ * identity. Adapters are registered by `bankCode` and resolved by `bankCode`.
+ *
+ * PR1 scope: interface + factory + a Popular adapter instance. The full design
+ * interface also exposes `portalConfig` and `createSessionChecker`; those are
+ * intentionally added in PR2/PR5 when per-bank browser isolation and the
+ * Banreservas/BHD read-only scrapers land, so PR1 stays a focused,
+ * no-behavior-change routing refactor.
+ */
+
+import type { IngestionScraper } from "../../worker/queues";
+import {
+  createPopularCdpScraper,
+  type PopularCdpScraperOptions,
+} from "../../worker/scraper/navigation/popular-cdp";
+import {
+  createEnsureBrowserFromEnv,
+  type EnsureBrowserSeam,
+} from "../../worker/scraper/browser-runtime";
+import {
+  createPopularBankAdapter,
+  parsePopularTransactionRows,
+  popularBankCode,
+  popularPortalFixture,
+} from "./popular";
+
+/**
+ * Placeholder for the auto-login strategy contract. PR4 fleshes this out into
+ * the state machine + `LoginMutationGuard` + Redis `AutoLoginLock` wiring.
+ * In PR1 every adapter's `createAutoLoginStrategy()` is a not-implemented stub
+ * — there is NO auto-login surface in PR1.
+ */
+export interface BankAutoLoginStrategy {
+  readonly bankCode: string;
+}
+
+/**
+ * A bank adapter. Each bank exposes its canonical `bankCode` plus the
+ * factories the runtime needs. `createScraper` produces the read-only
+ * `IngestionScraper`; `createAutoLoginStrategy` is stubbed in PR1.
+ */
+export interface BankAdapter {
+  /** Canonical immutable domain code (`Bank.code`), e.g. `popular`. */
+  readonly bankCode: string;
+  /** Builds the read-only ingestion scraper for this bank. */
+  createScraper(): IngestionScraper;
+  /** PR1 stub — throws not-implemented. PR4 implements the real strategy. */
+  createAutoLoginStrategy(): BankAutoLoginStrategy;
+}
+
+/**
+ * Registry of bank adapters keyed by `bankCode`. Routing and run-now
+ * validation resolve adapters through this surface so an explicit unknown
+ * `bankCode` fails closed instead of falling back to Popular.
+ */
+export interface BankAdapterRegistry {
+  /** Returns the adapter for `bankCode`, or `undefined` when none is registered. */
+  get(bankCode: string): BankAdapter | undefined;
+  /** Canonical list of registered bank codes (derived from registered adapters). */
+  supportedBankCodes(): readonly string[];
+}
+
+/**
+ * Builds a `BankAdapterRegistry` from an explicit adapter list. The supported
+ * codes are derived from the registered adapters' `bankCode` values — there is
+ * no separate whitelist to drift out of sync.
+ */
+export function createBankAdapterRegistry(adapters: readonly BankAdapter[]): BankAdapterRegistry {
+  const byCode = new Map<string, BankAdapter>();
+  for (const adapter of adapters) {
+    byCode.set(adapter.bankCode, adapter);
+  }
+
+  return {
+    get(bankCode: string): BankAdapter | undefined {
+      return byCode.get(bankCode);
+    },
+    supportedBankCodes(): readonly string[] {
+      return Array.from(byCode.keys());
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Popular scraper factory + default registry instance (server wiring).
+//
+// The env-based scraper construction previously lived inline in
+// `consumer-defaults.resolveDefaultScraper`. It is relocated here so the
+// registry owns adapter wiring and `resolveDefaultScraper` becomes a thin
+// bankCode router. Behaviour is preserved exactly: popular-cdp takes
+// precedence, then the dev-preview fixture, then a needs_admin_action stub.
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds the Popular CDP scraper options from the given env. Pure and
+ * testable — it never touches process.env directly when env is injected.
+ *
+ * Returns `undefined` when the popular-cdp scraper is not selected, so callers
+ * can fall through to the other branches. The `ensureBrowser` seam is included
+ * only when `RD_SYNC_BANK_BROWSER_AUTO_LAUNCH=enabled` (and `RD_SYNC_CDP_URL`
+ * is set); otherwise it is `undefined` and the scraper connects directly as
+ * before (backward compatible).
+ */
+export function buildPopularCdpScraperOptionsFromEnv(
+  env: Record<string, string | undefined> = process.env,
+): PopularCdpScraperOptions | undefined {
+  if (env.RD_SYNC_SCRAPER !== "popular-cdp") {
+    return undefined;
+  }
+
+  const ensureBrowser: EnsureBrowserSeam | undefined = createEnsureBrowserFromEnv(env);
+  return {
+    cdpUrl: env.RD_SYNC_CDP_URL,
+    ensureBrowser,
+  };
+}
+
+/**
+ * Constructs the Popular read-only ingestion scraper from env read at call
+ * time (lazy — no env read at module import). Mirrors the previous
+ * `resolveDefaultScraper` branch order exactly so Popular behaviour is
+ * unchanged:
+ * - RD_SYNC_SCRAPER=popular-cdp -> CDP-attach scraper.
+ * - RD_SYNC_DEV_PREVIEW=enabled -> fixture-backed scraper.
+ * - Otherwise -> stub that reports needs_admin_action (production never
+ *   fabricates data while real bank navigation is not configured).
+ */
+export function createPopularScraperFromEnv(
+  env: Record<string, string | undefined> = process.env,
+): IngestionScraper {
+  const popularOptions = buildPopularCdpScraperOptionsFromEnv(env);
+  if (popularOptions) {
+    // Only the worker/scraper path launches the browser — the read-only
+    // session checker never does. The ensureBrowser seam (when present) is
+    // built from env by buildPopularCdpScraperOptionsFromEnv.
+    return createPopularCdpScraper(popularOptions);
+  }
+
+  if (env.RD_SYNC_DEV_PREVIEW === "enabled") {
+    return {
+      collect: async () => ({
+        status: "collected" as const,
+        movements: parsePopularTransactionRows(popularPortalFixture.transactions),
+      }),
+    };
+  }
+
+  return {
+    collect: async () => ({
+      status: "needs_admin_action" as const,
+      movements: [],
+      safeErrorSummary: "Bank portal navigation not configured yet",
+    }),
+  };
+}
+
+const popularAdapter: BankAdapter = createPopularBankAdapter({
+  createScraper: () => createPopularScraperFromEnv(),
+});
+
+/**
+ * Default bank adapter registry. PR1 registers only Popular; Banreservas and
+ * BHD adapters are added in PR5. Routing and run-now validation resolve
+ * through this instance so an explicit unknown `bankCode` fails closed.
+ */
+export const bankAdapterRegistry: BankAdapterRegistry = createBankAdapterRegistry([
+  popularAdapter,
+]);
+
+// Re-export the canonical Popular code alongside the registry for convenience.
+export { popularBankCode };

--- a/src/worker/ingestion-worker.ts
+++ b/src/worker/ingestion-worker.ts
@@ -62,7 +62,7 @@ const processor = createIngestionProcessor({
   transactions: defaultTransactionRepository,
   adminAlerts: resolveDefaultAlertSink(),
   auditSink: defaultAuditSink,
-  scraper: resolveDefaultScraper(),
+  resolveScraper: resolveDefaultScraper,
 });
 
 // ---------------------------------------------------------------------------

--- a/src/worker/queues/index.ts
+++ b/src/worker/queues/index.ts
@@ -8,6 +8,11 @@ export type ScrapeRunStatus = "queued" | "running" | "succeeded" | "failed" | "n
 
 export interface IngestionJobData {
   runId: string;
+  /**
+   * Canonical bank code (`Bank.code`), e.g. `"popular"`. Named `bankId` for
+   * backward compatibility with the existing BullMQ job payload contract, but
+   * the value is a domain code, NOT the Prisma `Bank.id` cuid.
+   */
   bankId: string;
   accountFingerprint: string;
 }
@@ -25,6 +30,14 @@ export interface IngestionResult {
 export interface IngestionScraper {
   collect(): Promise<ScrapeCollectionResult>;
 }
+
+/**
+ * Resolves the appropriate `IngestionScraper` for a given canonical bank code
+ * (`Bank.code`). Absent/empty bankCode must resolve to the default (Popular)
+ * scraper for backward compatibility. An explicitly unknown bankCode must fail
+ * closed (return a `needs_admin_action` stub) and never fall back to Popular.
+ */
+export type ResolveScraper = (bankCode?: string) => IngestionScraper;
 
 export interface ScrapeRunRepository {
   markRunning(runId: string, startedAt?: Date): Promise<void>;
@@ -54,7 +67,19 @@ export interface AdminAlertSink {
 export interface IngestionProcessorDependencies {
   scrapeRuns: ScrapeRunRepository;
   transactions: TransactionUpsertRepository;
-  scraper: IngestionScraper;
+  /**
+   * Resolves the scraper for each job by its canonical `bankCode`. The
+   * processor calls `resolveScraper(job.data.bankId)` per job so the worker
+   * and in-memory consumer no longer hardcode a single Popular scraper at
+   * construction time.
+   */
+  resolveScraper?: ResolveScraper;
+  /**
+   * @deprecated Use `resolveScraper` instead. Retained for backward
+   * compatibility with tests that inject a single scraper directly. When
+   * `resolveScraper` is provided it takes precedence.
+   */
+  scraper?: IngestionScraper;
   adminAlerts?: AdminAlertSink;
   auditSink?: Pick<AuditSink, "record">;
   now?: () => Date;
@@ -69,17 +94,30 @@ const SYSTEM_INGESTION_ACTOR = "system:ingestion-worker";
 
 export function createIngestionProcessor(dependencies: IngestionProcessorDependencies) {
   const now = dependencies.now ?? (() => new Date());
+  const resolveScraper = dependencies.resolveScraper;
+  const legacyScraper = dependencies.scraper;
+
+  if (!resolveScraper && !legacyScraper) {
+    throw new Error(
+      "createIngestionProcessor requires either resolveScraper or scraper in dependencies",
+    );
+  }
 
   return async function processIngestionJob(job: IngestionJob): Promise<IngestionResult> {
+    const requestedBankCode = job.data.bankId;
+    const scraper = resolveScraper
+      ? resolveScraper(requestedBankCode)
+      : legacyScraper!;
+
     await dependencies.scrapeRuns.markRunning(job.data.runId, now());
     await emitAuditEvent(dependencies.auditSink, {
       action: "scrape_run.started",
       runId: job.data.runId,
-      bankId: job.data.bankId,
+      bankId: requestedBankCode,
     });
 
     try {
-      const scrapeResult = await dependencies.scraper.collect();
+      const scrapeResult = await scraper.collect();
 
       if (scrapeResult.status === "needs_admin_action") {
         const safeErrorSummary = scrapeResult.safeErrorSummary ?? "Bank session requires admin action";
@@ -92,7 +130,7 @@ export function createIngestionProcessor(dependencies: IngestionProcessorDepende
         await emitAuditEvent(dependencies.auditSink, {
           action: "scrape_run.needs_admin_action",
           runId: job.data.runId,
-          bankId: job.data.bankId,
+          bankId: requestedBankCode,
           metadata: { safeErrorSummary },
         });
 
@@ -110,7 +148,7 @@ export function createIngestionProcessor(dependencies: IngestionProcessorDepende
       await emitAuditEvent(dependencies.auditSink, {
         action: "scrape_run.succeeded",
         runId: job.data.runId,
-        bankId: job.data.bankId,
+        bankId: requestedBankCode,
         metadata: { inserted: counts.inserted, skipped: counts.skipped },
       });
 
@@ -122,7 +160,7 @@ export function createIngestionProcessor(dependencies: IngestionProcessorDepende
       await emitAuditEvent(dependencies.auditSink, {
         action: "scrape_run.failed",
         runId: job.data.runId,
-        bankId: job.data.bankId,
+        bankId: requestedBankCode,
         metadata: { safeErrorSummary },
       });
       return { status: "failed", inserted: 0, skipped: 0 };
@@ -175,6 +213,9 @@ async function emitAuditEvent(
         action: input.action,
         target: "scrape_run",
         targetId: input.runId,
+        // bankId in audit metadata is the canonical bank code (Bank.code),
+        // NOT the Prisma Bank.id. Kept as "bankId" for backward compat with
+        // existing audit event consumers.
         metadata: { bankId: input.bankId, ...input.metadata },
       }),
     );

--- a/src/worker/queues/queues.test.ts
+++ b/src/worker/queues/queues.test.ts
@@ -5,6 +5,7 @@ import {
   createIngestionQueueOptions,
   scheduleIngestionJob,
   type IngestionJobData,
+  type ResolveScraper,
   type ScrapeRunStatus,
 } from "./index";
 import type { BankMovement } from "../../modules/transactions";
@@ -350,6 +351,146 @@ describe("BullMQ ingestion scheduling", () => {
       },
     ]);
     expect(createIngestionQueueOptions("run-2").jobId).toBe("run-2");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveScraper routing — BLOCKER fix coverage.
+//
+// These tests prove the processor actually routes by job.data.bankId via
+// the resolveScraper dependency, NOT by a single scraper injected at
+// construction time. This is the runtime path the reviewer flagged: the
+// in-memory consumer and the BullMQ worker both call the processor with
+// job.data.bankId, so the processor must resolve the scraper per job.
+// ---------------------------------------------------------------------------
+
+describe("ingestion processor — resolveScraper routing", () => {
+  const popularMovements: BankMovement[] = [
+    {
+      bankId: "popular",
+      accountFingerprint: "acct-main",
+      postedAt: "2026-06-07T13:45:00.000Z",
+      amount: "100.00",
+      currency: "DOP",
+      direction: "credit",
+      reference: "REF-POP",
+    },
+  ];
+
+  it("resolves the scraper by job.data.bankId and processes with the bank-specific scraper", async () => {
+    const scrapeRuns = new FakeScrapeRunRepository();
+    const transactions = new FakeTransactionRepository({ inserted: 1, skipped: 0 });
+    const resolveScraper: ResolveScraper = (bankCode) => ({
+      collect: async () => ({
+        status: "collected" as const,
+        movements: popularMovements.map((m) => ({ ...m, bankId: bankCode ?? "popular" })),
+      }),
+    });
+
+    const processor = createIngestionProcessor({
+      scrapeRuns,
+      transactions,
+      resolveScraper,
+    });
+
+    const result = await processor({
+      data: { runId: "run-routing", bankId: "popular", accountFingerprint: "acct-main" },
+    });
+
+    expect(result).toEqual({ status: "succeeded", inserted: 1, skipped: 0 });
+    expect(transactions.received[0]?.bankId).toBe("popular");
+  });
+
+  it("fails closed for an explicit unknown bankCode (needs_admin_action, no Popular fallback)", async () => {
+    const scrapeRuns = new FakeScrapeRunRepository();
+    const resolveScraper: ResolveScraper = (bankCode) => {
+      if (bankCode && bankCode !== "popular") {
+        return {
+          collect: async () => ({
+            status: "needs_admin_action" as const,
+            movements: [],
+            safeErrorSummary: "Bank not configured for automated scraping",
+          }),
+        };
+      }
+      return {
+        collect: async () => ({
+          status: "collected" as const,
+          movements: popularMovements,
+        }),
+      };
+    };
+
+    const processor = createIngestionProcessor({
+      scrapeRuns,
+      transactions: new FakeTransactionRepository({ inserted: 0, skipped: 0 }),
+      resolveScraper,
+    });
+
+    const result = await processor({
+      data: { runId: "run-unknown", bankId: "banreservas", accountFingerprint: "acct-main" },
+    });
+
+    expect(result).toEqual({ status: "needs_admin_action", inserted: 0, skipped: 0 });
+    expect(scrapeRuns.transitions).toEqual([
+      { runId: "run-unknown", status: "running" },
+      {
+        runId: "run-unknown",
+        status: "needs_admin_action",
+        safeErrorSummary: "Bank not configured for automated scraping",
+      },
+    ]);
+  });
+
+  it("defaults to Popular when job.data.bankId is empty (legacy/default run)", async () => {
+    const scrapeRuns = new FakeScrapeRunRepository();
+    const transactions = new FakeTransactionRepository({ inserted: 1, skipped: 0 });
+    const resolveScraper: ResolveScraper = (bankCode) => {
+      // Absent bankCode should default to popular
+      const code = bankCode && bankCode.trim() ? bankCode.trim() : "popular";
+      return {
+        collect: async () => ({
+          status: "collected" as const,
+          movements: popularMovements.map((m) => ({ ...m, bankId: code })),
+        }),
+      };
+    };
+
+    const processor = createIngestionProcessor({
+      scrapeRuns,
+      transactions,
+      resolveScraper,
+    });
+
+    const result = await processor({
+      data: { runId: "run-legacy", bankId: "", accountFingerprint: "acct-main" },
+    });
+
+    expect(result).toEqual({ status: "succeeded", inserted: 1, skipped: 0 });
+    expect(transactions.received[0]?.bankId).toBe("popular");
+  });
+
+  it("throws when neither resolveScraper nor scraper is provided", () => {
+    expect(() =>
+      createIngestionProcessor({
+        scrapeRuns: new FakeScrapeRunRepository(),
+        transactions: new FakeTransactionRepository({ inserted: 0, skipped: 0 }),
+      }),
+    ).toThrow("createIngestionProcessor requires either resolveScraper or scraper");
+  });
+
+  it("falls back to the legacy scraper when resolveScraper is absent", async () => {
+    const scrapeRuns = new FakeScrapeRunRepository();
+    const transactions = new FakeTransactionRepository({ inserted: 1, skipped: 0 });
+    const processor = createIngestionProcessor({
+      scrapeRuns,
+      transactions,
+      scraper: { collect: async () => ({ status: "collected", movements: popularMovements }) },
+    });
+
+    const result = await processor({ data: jobData });
+
+    expect(result).toEqual({ status: "succeeded", inserted: 1, skipped: 0 });
   });
 });
 


### PR DESCRIPTION
## Chain Context

```text
backend/popular-vps-session-orchestration
 └── feature/multi-bank-auto-login          ← tracker branch
      └── 📍 feature/multi-bank-auto-login-pr1-adapter-registry
           └── PR2: browser/CDP isolation + loopback/backpressure (next)
           └── PR3: credential vault (later, high risk)
           └── PR4: auto-login Popular (later, high risk)
           └── PR5: Banreservas/BHD read-only adapters (later)
           └── PR6: Banreservas/BHD auto-login (later)
```

Base for this PR: `feature/multi-bank-auto-login`.

> Note: PR1 has a maintainer-approved `size:exception` because the foundation slice needed the registry, worker routing, run-now validation, and regression tests together. Future slices should stay under the 400-line review budget when practical.

## Summary

- Adds a `BankAdapterRegistry` keyed by canonical bank code and migrates Popular into the adapter contract.
- Routes scrape processing by job bank code instead of a fixed default scraper, while preserving legacy/empty bank fallback to Popular.
- Adds fail-closed unsupported-bank behavior and regression tests for run-now, worker routing, and client-safe bank code whitelisting.

## Changes

| Area | Change |
|------|--------|
| `src/modules/bank-adapters/registry.ts` | New registry and adapter contract keyed by `bankCode`. |
| `src/modules/bank-adapters/popular.ts` | Popular exposed as a `BankAdapter`; auto-login remains a not-implemented stub. |
| `src/worker/queues/index.ts` | Ingestion processor resolves scraper per job bank code. |
| `src/app/api/scrape-runs/consumer-defaults.ts` | Wires default scraper resolver through registry. |
| `src/app/api/scrape-runs/run-now.ts` | Validates supported bank codes and fails closed for unsupported requests. |
| `src/lib/banks.ts` | Renames run-now support list to bank-code terminology. |
| Tests | Adds/updates coverage for registry routing, Popular compatibility, unsupported bank behavior, and legacy fallback. |
| `openspec/changes/multi-bank-auto-login/tasks.md` | Marks PR1 tasks complete and documents PR1 size exception. |

## Non-goals

- No auto-login implementation.
- No credential storage.
- No Banreservas/BHD runtime implementation.
- No browser/CDP isolation changes; that is PR2.

## Verification

- [x] `pnpm test` — 688 passed / 38 skipped
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `git diff --check`
- [x] Fresh risk/reliability/readability reviews completed after implementation; final readability re-check returned no findings.

## Rollback

Revert this PR to return to the previous Popular-only default wiring. No schema migration or data migration is introduced in PR1 because `Bank.code` was already unique in the baseline schema.