### PR TITLE
feat(bank-browser): isolate per-bank CDP with loopback enforcement (PR2A)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,19 +15,26 @@ RD_SYNC_DEV_PREVIEW="disabled"
 # server. An admin logs in manually (including MFA) in that browser; the
 # worker only performs read-only navigation/scrape.
 #
-# Canonical CDP endpoint default is http://127.0.0.1:9222 — CDP must NEVER be
-# bound to 0.0.0.0.
+# Shared default CDP endpoint is http://127.0.0.1:9222 — used by BOTH the worker
+# and the launch script when no CDP URL is configured. CDP must NEVER be bound to
+# 0.0.0.0. The CDP URL is the single source of truth for the debug port; there is
+# no DEBUG_PORT knob.
 #
 # RD_SYNC_SCRAPER             — "popular-cdp" enables the CDP-attach scraper
-# RD_SYNC_CDP_URL             — CDP endpoint (bind to 127.0.0.1 only)
+# RD_SYNC_CDP_URL             — global CDP endpoint (bind to 127.0.0.1 only). This
+#                               fallback is single-bank-only; when more than one
+#                               bank is registered each MUST set a distinct
+#                               RD_SYNC_BANK_<BANK>_CDP_URL with a unique port.
 # RD_SYNC_BANK_BROWSER_AUTO_LAUNCH — "enabled" lets the worker start the
 #                                    browser via the launch command below
 # RD_SYNC_BANK_BROWSER_LAUNCH_COMMAND — trusted local command that starts the
 #                                       bank browser (NEVER set from untrusted input)
 # RD_SYNC_BANK_BROWSER_READY_TIMEOUT_MS — how long to wait for CDP after launch (default 30000)
 # RD_SYNC_BANK_BROWSER_POLL_INTERVAL_MS — poll interval while waiting (default 500)
-# RD_SYNC_BANK_BROWSER_PROFILE_DIR — persistent browser profile dir (used by the launch script)
-# RD_SYNC_BANK_BROWSER_DEBUG_PORT — CDP debug port (used by the launch script, default 9222)
+# RD_SYNC_BANK_BROWSER_PROFILE_DIR — GLOBAL persistent browser profile dir (used by the launch
+#                                    script). When a bank code is passed it is bank-SCOPED by
+#                                    appending "/<bank>" so two banks never share one profile.
+#                                    A per-bank RD_SYNC_BANK_<BANK>_PROFILE_DIR is used verbatim.
 #
 # Optional advanced overrides (used by scripts/launch-bank-browser.sh):
 # RD_SYNC_BANK_BROWSER_BIN        — override the browser binary path

--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,6 @@ test-results/
 .engram/
 .claude/
 .captures/
+.codegraph/
 /src/generated/prisma/
 

--- a/docs/runbooks/bank-session.md
+++ b/docs/runbooks/bank-session.md
@@ -23,16 +23,18 @@ The script:
 
 ### Linux server (production)
 
-Use the provided Bash script to open Brave/Chromium with an isolated profile:
+Use the provided Bash script to open Brave/Chromium with an isolated profile. **Pase siempre el código de banco** como argumento para que el perfil y el puerto CDP queden asociados al banco correcto:
 
 ```bash
-./scripts/launch-bank-browser.sh
+./scripts/launch-bank-browser.sh popular
 ```
+
+> **Importante (multi-banco):** cuando configure un endpoint por banco con `RD_SYNC_BANK_<BANCO>_CDP_URL`, **debe** lanzar el script con el mismo código de banco (`./scripts/launch-bank-browser.sh <banco>`). Solo así el lanzador abre el navegador en el mismo puerto loopback que el worker consulta para ese banco. Si ejecuta el script sin código de banco, la configuración por banco se ignora y se usa la URL CDP global/por defecto — el lanzador imprime una advertencia en stderr para avisarle.
 
 The script:
 - Detects the first available browser binary in this order: `brave-browser`, `brave`, `chromium-browser`, `chromium`, `google-chrome` (override with `RD_SYNC_BANK_BROWSER_BIN`)
-- Creates a persistent profile at `~/.local/share/rd-sync/bank-browser` (override with `RD_SYNC_BANK_BROWSER_PROFILE_DIR`)
-- Binds CDP to **127.0.0.1 only** on port 9222 (override with `RD_SYNC_BANK_BROWSER_DEBUG_PORT`) — never exposes CDP to the network
+- Creates a persistent profile at `~/.local/share/rd-sync/bank-browser` — bank-scoped to `…/bank-browser/<bank_code>` when a bank code is passed so each bank stays isolated. A **global** `RD_SYNC_BANK_BROWSER_PROFILE_DIR` is also bank-scoped (it gets `/<bank_code>` appended); only a per-bank `RD_SYNC_BANK_<BANK>_PROFILE_DIR` is used verbatim
+- Binds CDP to **127.0.0.1 only**; the debug port ALWAYS comes from the resolved CDP URL (`RD_SYNC_BANK_<BANK>_CDP_URL` / `RD_SYNC_CDP_URL`) so it always matches the worker. There is no `DEBUG_PORT` knob. When no CDP URL is configured, the launcher and worker share one default (`http://127.0.0.1:9222`) — never exposes CDP to the network
 - Opens the bank portal at `https://ib.bpd.com.do` (override with `RD_SYNC_BANK_BROWSER_START_URL`)
 - If CDP is already alive on the port, prints a message and exits without relaunching
 - Writes browser logs to `~/.local/share/rd-sync/bank-browser/browser.log` (override with `RD_SYNC_BANK_BROWSER_LOG_FILE`)
@@ -80,7 +82,7 @@ Si el auto-lanzamiento causa problemas (procesos duplicados, navegador en mal es
    curl -fsS http://127.0.0.1:9222/json/version >/dev/null && echo "CDP activo" || echo "CDP caído"
    ```
    Y consulte `GET /api/bank-sessions/status` (requiere principal admin). Debe reportar `active` tras un relanzamiento manual limpio, o `browser_unavailable` si decide dejarlo caído hasta que un admin inicie sesión de nuevo.
-5. **Relance manualmente** solo cuando esté listo: `./scripts/launch-bank-browser.sh` y complete el login/MFA.
+5. **Relance manualmente** solo cuando esté listo: `./scripts/launch-bank-browser.sh <banco>` (p. ej. `popular`) y complete el login/MFA. Use el mismo código de banco configurado en `RD_SYNC_BANK_<BANCO>_CDP_URL`.
 
 ## Logging in
 
@@ -147,7 +149,7 @@ Response shape:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `RD_SYNC_SCRAPER` | — | Set to `popular-cdp` to enable the CDP-backed scraper and session checker |
-| `RD_SYNC_CDP_URL` | `http://127.0.0.1:9222` | CDP endpoint for the running Brave session (bind to 127.0.0.1 only) |
+| `RD_SYNC_CDP_URL` | `http://127.0.0.1:9222` | Global CDP endpoint for the running Brave session (bind to 127.0.0.1 only). Single-bank-only fallback — with 2+ registered banks each must set a distinct `RD_SYNC_BANK_<BANK>_CDP_URL` |
 | `RD_SYNC_SESSION_MONITOR` | — | Set to `enabled` to start the background session monitor |
 | `RD_SYNC_SESSION_CHECK_INTERVAL_MS` | `300000` (5 min) | Poll interval in milliseconds; minimum 60000 (1 min) |
 | `RD_SYNC_ALERT_SMTP_URL` | — | SMTP URL for alert emails; falls back to console.warn if absent |
@@ -156,12 +158,12 @@ Response shape:
 | `RD_SYNC_BANK_BROWSER_LAUNCH_COMMAND` | — | Trusted local command that starts the bank browser (server config only) |
 | `RD_SYNC_BANK_BROWSER_READY_TIMEOUT_MS` | `30000` | Max wait for CDP after launching the browser |
 | `RD_SYNC_BANK_BROWSER_POLL_INTERVAL_MS` | `500` | Poll interval while waiting for CDP |
-| `RD_SYNC_BANK_BROWSER_PROFILE_DIR` | `~/.local/share/rd-sync/bank-browser` | Persistent browser profile dir (used by the launch script) |
-| `RD_SYNC_BANK_BROWSER_DEBUG_PORT` | `9222` | CDP debug port (used by the launch script) |
+| `RD_SYNC_BANK_BROWSER_PROFILE_DIR` | `~/.local/share/rd-sync/bank-browser[/<bank_code>]` | GLOBAL persistent browser profile dir (used by the launch script). Bank-scoped by appending `/<bank_code>` when a bank code is given. A per-bank `RD_SYNC_BANK_<BANK>_PROFILE_DIR` is used verbatim |
 
 ## Security warnings
 
 - **CDP bound to 127.0.0.1 only.** El script de lanzamiento siempre usa `--remote-debugging-address=127.0.0.1`. Nunca exponga CDP a Internet o a la red local — cualquiera con acceso al endpoint CDP podría controlar la sesión bancaria autenticada.
+- **Distinct CDP URL/port per registered bank.** Cada banco registrado debe usar un puerto CDP loopback distinto vía `RD_SYNC_BANK_<BANK>_CDP_URL`. Si dos bancos comparten el mismo puerto, el worker podría adjuntarse a la sesión del banco equivocado; por eso el registro de adaptadores falla de forma cerrada al arrancar si detecta una colisión de puerto. El fallback global `RD_SYNC_CDP_URL` es solo para un único banco.
 - **No automated credential entry.** RD-Sync no introduce credenciales ni completa MFA. El administrador inicia sesión manualmente en el navegador del servidor.
 - **No Imperva/anti-bot bypass.** RD-Sync no evade las defensas anti-bot del banco. El scraper es de solo lectura: navega y extrae transacciones sobre una sesión abierta por un humano.
 - **Launch command is trusted server config.** `RD_SYNC_BANK_BROWSER_LAUNCH_COMMAND` solo se establece en la configuración del servidor gestionada por el operador. Nunca desde entrada de usuario ni desde la interfaz de empleado.

--- a/openspec/changes/multi-bank-auto-login/tasks.md
+++ b/openspec/changes/multi-bank-auto-login/tasks.md
@@ -25,7 +25,7 @@ Tracker branch `feature/multi-bank-auto-login` (base = current/main per repo con
 | Unit | Goal | PR | Base boundary |
 |------|------|----|------|
 | 1 | BankAdapter + registry + Popular migration (no behavior change) | PR1 | tracker branch |
-| 2 | Per-bank browser/CDP isolation + loopback + backpressure + portal configs only | PR2 | PR1 branch |
+| 2 | Per-bank browser/CDP isolation + loopback + backpressure + Popular portal config only | PR2 | PR1 branch |
 | 3 | Credential model + AES-GCM envelope + admin API + audit (no auto-login) | PR3 | PR2 branch |
 | 4 | Auto-login orchestration + Redis lock/fencing + breaker + Popular auto-login | PR4 | PR3 branch |
 | 5 | Banreservas/BHD read-only adapters + portal drift fixtures (no auto-login) | PR5 | PR4 branch |
@@ -41,14 +41,22 @@ Tracker branch `feature/multi-bank-auto-login` (base = current/main per repo con
 - [x] 1.6 Tests: route by bankCode; unknown fails closed (400+audit); absent->Popular; Popular path unchanged.
 - Gate: full gates; maintainer-approved `size:exception` for PR1 foundation slice; no behavior change.
 
-## PR2: Per-bank browser/CDP isolation + loopback + backpressure + portal configs
+## PR2A: CDP loopback + Popular bank-aware launcher slice
 
-- [ ] 2.1 Modify `src/worker/scraper/browser-runtime.ts`: per-port mutex (not global), per-bank env factory (`RD_SYNC_BANK_<BANK>_CDP_URL`/profile/start-url), `assertCdpLoopback` (reject non-loopback/bad-protocol/malformed before ANY CDP use), semaphore `RD_SYNC_BANK_BROWSER_MAX_CONCURRENCY=2`, safe `throttled` outcome, redacted error summaries.
-- [ ] 2.2 Create `src/modules/observability/bank-metrics.ts`: capacity metrics (active/queueDepth/throttleEvents) per bank.
-- [ ] 2.3 Add Banreservas/BHD `BankPortalConfig` config objects (env+selector placeholders from recon) — configs only, NO scraping logic.
-- [ ] 2.4 Modify `scripts/launch-bank-browser.sh`: per-bank profile/port/start-url parameterization (loopback binding; runtime still validates).
-- [ ] 2.5 Tests: `assertCdpLoopback` rejections; isolated concurrent banks use distinct profile+port; over-capacity->throttled (503/Retry-After where sync); error redacts command.
-- Gate: full gates; <=400 lines; no scraping/auto-login logic.
+- [x] 2A.1 Modify `src/worker/scraper/browser-runtime.ts`: `assertCdpLoopback` rejects non-loopback/bad-protocol/malformed before CDP fetch/ensure paths; keep redacted safe summaries.
+- [x] 2A.2 Wire Popular to bank-aware CDP env resolution: `RD_SYNC_BANK_POPULAR_CDP_URL` takes precedence over legacy `RD_SYNC_CDP_URL` in scraper/session checker construction.
+- [x] 2A.3 Fix production auto-launch: `createEnsureBrowserForBank("popular", env)` injects `BANK_CODE=popular` without shell command concatenation, so the launcher resolves the same per-bank env as the worker polls/connects.
+- [x] 2A.4 Modify `scripts/launch-bank-browser.sh`: optional bank code resolves per-bank profile/CDP/start-url with global fallback; CDP URL is the GENUINE single source of truth for the debug port (no `DEBUG_PORT` knob — removed). When no CDP URL is configured, the launcher and worker share ONE default (`DEFAULT_CDP_URL` = `http://127.0.0.1:9222`, port enforced equal by a parity test). A GLOBAL `RD_SYNC_BANK_BROWSER_PROFILE_DIR` is bank-scoped (`/<bank>` appended) so two banks never collide; a per-bank `*_PROFILE_DIR` is verbatim (MEDIUM-1). Per-bank/global CDP URLs must be origin-only HTTP loopback URLs.
+- [x] 2A.5 Tests: loopback/origin-only rejection before fetch/connect/launch; Popular per-bank CDP precedence; auto-launch injects `BANK_CODE=popular` and polls the same `RD_SYNC_BANK_POPULAR_CDP_URL`; launcher/worker default-port parity + DEBUG_PORT removed; global profile dir bank-scoped vs per-bank verbatim; registry fails closed when two banks share a CDP port (MEDIUM-2); unknown bank routing still fails closed.
+- Gate: targeted tests + full gate if feasible; <=400 changed-line target; no backpressure, metrics, credentials, or auto-login logic.
+
+## PR2B: Browser capacity/backpressure + metrics (deferred)
+
+- [ ] 2B.1 Add browser semaphore/backpressure runtime behavior (`RD_SYNC_BANK_BROWSER_MAX_CONCURRENCY`, bounded queue, safe throttled result).
+- [ ] 2B.2 Add `src/modules/observability/bank-metrics.ts` capacity metrics and production wiring.
+- [ ] 2B.3 Add throttle/capacity tests and any 503/Retry-After sync-facing behavior.
+- [ ] 2B.4 Keep Banreservas/BHD placeholder portal configs deferred to PR5; no production-looking placeholder selectors in PR2B unless real read-only adapters land.
+- Gate: full gates; <=400 changed-line target; no credential vault or auto-login logic.
 
 ## PR3: Credential model + AES-GCM envelope + admin API + audit (NO auto-login) [HIGH RISK]
 

--- a/scripts/launch-bank-browser.sh
+++ b/scripts/launch-bank-browser.sh
@@ -2,10 +2,10 @@
 #
 # launch-bank-browser.sh
 #
-# Launches Brave/Chromium with a DEDICATED persistent profile for the bank
-# session used by RD-Sync on a Linux server.
+# Launches Brave/Chromium with a DEDICATED persistent profile for a specific
+# bank session used by RD-Sync on a Linux server.
 #
-# The browser exposes Chrome DevTools Protocol (CDP) on 127.0.0.1 ONLY so the
+# The browser exposes Chrome DevTools Protocol (CDP) on loopback ONLY so the
 # RD-Sync worker can attach read-only. CDP is NEVER bound to 0.0.0.0 — exposing
 # it to the network would let anyone drive the logged-in bank session.
 #
@@ -14,14 +14,22 @@
 # attempt to evade the bank's anti-bot defences.
 #
 # Usage:
-#   ./scripts/launch-bank-browser.sh
+#   ./scripts/launch-bank-browser.sh [BANK_CODE]
 #
 # Environment variables (all optional):
 #   RD_SYNC_BANK_BROWSER_BIN          — override browser binary path
-#   RD_SYNC_BANK_BROWSER_PROFILE_DIR  — persistent profile directory
-#   RD_SYNC_BANK_BROWSER_DEBUG_PORT   — CDP debug port (default 9222)
+#   RD_SYNC_CDP_URL                   — global CDP endpoint (loopback only)
+#   RD_SYNC_BANK_BROWSER_PROFILE_DIR  — persistent profile directory (global; bank-scoped)
 #   RD_SYNC_BANK_BROWSER_START_URL    — initial URL (default https://ib.bpd.com.do)
 #   RD_SYNC_BANK_BROWSER_LOG_FILE     — stdout/stderr log file
+#
+# Per-bank overrides use RD_SYNC_BANK_<BANK>_{CDP_URL,PROFILE_DIR,START_URL}.
+# The CDP URL is the SINGLE source of truth for the debug port and is shared
+# verbatim with the worker (resolveBankBrowserEnv). There is NO DEBUG_PORT knob:
+# the port ALWAYS comes from the resolved CDP URL so the launcher and worker can
+# never disagree. When no CDP URL is configured, both fall back to ONE shared
+# default (DEFAULT_CDP_URL below), which must equal the worker's DEFAULT_CDP_URL
+# in src/worker/scraper/browser-runtime.ts.
 #
 set -euo pipefail
 
@@ -35,9 +43,125 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 umask 077
 
-profileDir="${RD_SYNC_BANK_BROWSER_PROFILE_DIR:-$HOME/.local/share/rd-sync/bank-browser}"
-debugPort="${RD_SYNC_BANK_BROWSER_DEBUG_PORT:-9222}"
-startUrl="${RD_SYNC_BANK_BROWSER_START_URL:-https://ib.bpd.com.do}"
+# Per-bank variable resolution with global fallback.
+BANK_CODE="${1:-${BANK_CODE:-}}"
+BANK_PREFIX=""
+
+if [[ -n "$BANK_CODE" ]]; then
+  if [[ ! "$BANK_CODE" =~ ^[[:alnum:]_]+$ ]]; then
+    echo "ERROR: el código de banco solo puede contener letras, números y guion bajo." >&2
+    exit 1
+  fi
+  BANK_PREFIX="RD_SYNC_BANK_${BANK_CODE^^}_"  # uppercase for env var name
+else
+  # MEDIUM-3: running WITHOUT a bank code while a per-bank
+  # RD_SYNC_BANK_<BANK>_CDP_URL override exists means that override is silently
+  # ignored — resolution falls back to the global/default CDP URL, so the
+  # launcher may bind a different port than the worker polls for that bank.
+  # Warn (never fail) so the operator re-runs with the matching bank code. Only
+  # the variable NAME is printed; the URL value is never echoed (no leakage).
+  while IFS= read -r perBankCdpVar; do
+    [[ -z "$perBankCdpVar" ]] && continue
+    echo "ADVERTENCIA: '${perBankCdpVar}' está definida pero el lanzador se ejecutó SIN código de banco." >&2
+    echo "             Se usará la URL CDP global/por defecto y se ignorará la configuración por banco," >&2
+    echo "             por lo que el lanzador podría abrir un puerto distinto del que el worker consulta." >&2
+    echo "             Vuelva a ejecutar con el código de banco correspondiente (p. ej. ./scripts/launch-bank-browser.sh popular)." >&2
+  done < <(compgen -v 2>/dev/null | grep -E '^RD_SYNC_BANK_[A-Za-z0-9_]+_CDP_URL$' || true)
+fi
+
+resolveBankVar() {
+  local perBankKey="${BANK_PREFIX}$1"
+  local globalKey="$2"
+  local defaultVal="${3:-}"
+
+  if [[ -n "$BANK_CODE" && -n "${!perBankKey:-}" ]]; then
+    echo "${!perBankKey}"
+  elif [[ -n "${!globalKey:-}" ]]; then
+    echo "${!globalKey}"
+  else
+    echo "$defaultVal"
+  fi
+}
+
+parsedCdpPort=""
+cdpBindAddress="127.0.0.1"
+cdpProbeHost="127.0.0.1"
+
+parseLoopbackCdpUrl() {
+  local rawUrl="$1"
+  local host=""
+  local port=""
+
+  if [[ ! "$rawUrl" =~ ^http://(\[[^]]+\]|[^/@:?#/]+):([0-9]+)$ ]]; then
+    echo "ERROR: RD-Sync CDP URL debe tener formato http://loopback:puerto." >&2
+    exit 1
+  fi
+
+  host="${BASH_REMATCH[1],,}"
+  port="${BASH_REMATCH[2]}"
+
+  case "$host" in
+    "127.0.0.1"|"localhost")
+      cdpBindAddress="127.0.0.1"
+      cdpProbeHost="127.0.0.1"
+      ;;
+    "::1"|"[::1]")
+      cdpBindAddress="::1"
+      cdpProbeHost="[::1]"
+      ;;
+    *)
+      echo "ERROR: RD-Sync CDP URL debe usar loopback (127.0.0.1, localhost o ::1)." >&2
+      exit 1
+      ;;
+  esac
+
+  parsedCdpPort="$port"
+}
+
+# Bank-scoped profile dir (H1 / MEDIUM-1). Each bank MUST get its own Chromium
+# profile: a shared profile trips the Chromium singleton lock and ignores the
+# per-bank --remote-debugging-port, silently sharing one logged-in session
+# across banks and defeating isolation.
+#
+# Resolution precedence:
+#   1. Per-bank RD_SYNC_BANK_<BANK>_PROFILE_DIR — used VERBATIM (operator chose
+#      this exact path for this exact bank).
+#   2. Global RD_SYNC_BANK_BROWSER_PROFILE_DIR — bank-SCOPED by appending
+#      "/<bank>" when a bank code is set, so a single global override can never
+#      collapse two banks onto one profile dir.
+#   3. Built-in default ~/.local/share/rd-sync/bank-browser[/<bank>].
+defaultProfileDir="$HOME/.local/share/rd-sync/bank-browser"
+if [[ -n "$BANK_CODE" ]]; then
+  defaultProfileDir="${defaultProfileDir}/${BANK_CODE,,}"
+fi
+
+perBankProfileKey="${BANK_PREFIX}PROFILE_DIR"
+if [[ -n "$BANK_CODE" && -n "${!perBankProfileKey:-}" ]]; then
+  profileDir="${!perBankProfileKey}"
+elif [[ -n "${RD_SYNC_BANK_BROWSER_PROFILE_DIR:-}" ]]; then
+  profileDir="${RD_SYNC_BANK_BROWSER_PROFILE_DIR%/}"
+  if [[ -n "$BANK_CODE" ]]; then
+    profileDir="${profileDir}/${BANK_CODE,,}"
+  fi
+else
+  profileDir="$defaultProfileDir"
+fi
+
+# CDP URL is the GENUINE single source of truth for the debug port (H2). The
+# port is ALWAYS derived from the resolved CDP URL so the launcher and the
+# worker's resolveBankBrowserEnv can never disagree. There is no DEBUG_PORT knob.
+#
+# DEFAULT_CDP_URL is the ONE shared fallback used when neither a per-bank nor a
+# global CDP URL is configured. It MUST equal the worker's DEFAULT_CDP_URL in
+# src/worker/scraper/browser-runtime.ts; a parity test enforces the port match.
+# RD-Sync shared default CDP URL: http://127.0.0.1:9222
+DEFAULT_CDP_URL="http://127.0.0.1:9222"
+
+cdpUrl="$(resolveBankVar 'CDP_URL' 'RD_SYNC_CDP_URL' "$DEFAULT_CDP_URL")"
+parseLoopbackCdpUrl "$cdpUrl"
+debugPort="$parsedCdpPort"
+
+startUrl="$(resolveBankVar 'START_URL' 'RD_SYNC_BANK_BROWSER_START_URL' 'https://ib.bpd.com.do')"
 logFile="${RD_SYNC_BANK_BROWSER_LOG_FILE:-$profileDir/browser.log}"
 lockFile="$profileDir/.launch.lock"
 
@@ -82,7 +206,7 @@ detectBrowser() {
 # cdpAlive — check whether CDP is already responding on the debug port.
 # ---------------------------------------------------------------------------
 cdpAlive() {
-  curl -fsS "http://127.0.0.1:${debugPort}/json/version" >/dev/null 2>&1
+  curl -fsS "http://${cdpProbeHost}:${debugPort}/json/version" >/dev/null 2>&1
 }
 
 # ---------------------------------------------------------------------------
@@ -188,20 +312,34 @@ fi
 echo "Lanzando navegador del banco..."
 echo "  Navegador  : $browserBin"
 echo "  Perfil     : $profileDir"
-echo "  Puerto CDP : $debugPort (127.0.0.1 únicamente)"
+echo "  Puerto CDP : $debugPort (${cdpBindAddress} únicamente)"
 echo "  URL inicial: $startUrl"
 echo "  Log        : $logFile"
 echo ""
 
+# Build the launch argv ONCE so the browser exec and the recorded audit line
+# share a single source of truth (the human banner above could otherwise drift
+# from the real flags). CDP is bound to loopback only.
+launchArgs=(
+  --user-data-dir="$profileDir"
+  --remote-debugging-address="$cdpBindAddress"
+  --remote-debugging-port="$debugPort"
+  --no-first-run
+  --new-window "$startUrl"
+)
+
+# Record the exact launch argv SYNCHRONOUSLY from this (non-detached) process so
+# the line is durable even on filesystems where a detached child's async write
+# could be lost on shell teardown. This is the real argv passed to the browser.
+{
+  printf 'launch argv:'
+  printf ' %s' "${launchArgs[@]}"
+  printf '\n'
+} >>"$logFile"
+
 # Launch detached. stdout/stderr are redirected to the log file so this script
-# can exit without killing the browser. CDP is bound to 127.0.0.1 only.
-nohup "$browserBin" \
-  --user-data-dir="$profileDir" \
-  --remote-debugging-address=127.0.0.1 \
-  --remote-debugging-port="$debugPort" \
-  --no-first-run \
-  --new-window "$startUrl" \
-  >>"$logFile" 2>&1 &
+# can exit without killing the browser.
+nohup "$browserBin" "${launchArgs[@]}" >>"$logFile" 2>&1 &
 
 disown 2>/dev/null || true
 
@@ -218,5 +356,5 @@ echo "   en el próximo scrape programado o manual."
 echo ""
 echo "ADVERTENCIA: No navegue sitios personales en este perfil."
 echo "             Manténgalo exclusivo para el banco."
-echo "             CDP está limitado a 127.0.0.1 — no exponer a Internet."
+echo "             CDP está limitado a loopback — no exponer a Internet."
 echo "============================================================"

--- a/src/app/api/bank-sessions/defaults.test.ts
+++ b/src/app/api/bank-sessions/defaults.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // ---------------------------------------------------------------------------
 // resolveDefaultSessionChecker env resolution
@@ -9,13 +9,15 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 // busting (resetModules). Each test group calls the isolated factory directly.
 // ---------------------------------------------------------------------------
 
-// We test the exported factories by re-importing after env changes.
-// Use the factory functions directly rather than the module-level singletons.
+const BANK_SESSIONS_MODULE = "../../../modules/bank-sessions";
 
 describe("resolveDefaultSessionChecker — env branches", () => {
   afterEach(() => {
     delete process.env.RD_SYNC_SCRAPER;
     delete process.env.RD_SYNC_CDP_URL;
+    delete process.env.RD_SYNC_BANK_POPULAR_CDP_URL;
+    vi.doUnmock(BANK_SESSIONS_MODULE);
+    vi.resetModules();
   });
 
   it("returns browser_unavailable stub when RD_SYNC_SCRAPER is not set", async () => {
@@ -30,15 +32,48 @@ describe("resolveDefaultSessionChecker — env branches", () => {
     expect(result.safeSummary).toBe("Bank browser session is not available");
   });
 
-  it("returns a CdpSessionChecker (has check()) when RD_SYNC_SCRAPER=popular-cdp", async () => {
+  // Real behavior test (not just a seam): the per-bank Popular CDP URL must win
+  // over the global one, and that exact URL must reach createCdpSessionChecker.
+  it("constructs the CDP checker with the per-bank URL when both per-bank and global are set", async () => {
+    process.env.RD_SYNC_SCRAPER = "popular-cdp";
+    process.env.RD_SYNC_BANK_POPULAR_CDP_URL = "http://127.0.0.1:9333";
+    process.env.RD_SYNC_CDP_URL = "http://127.0.0.1:9222";
+
+    const createSpy = vi.fn(() => ({ check: vi.fn() }));
+    vi.doMock(BANK_SESSIONS_MODULE, async (importOriginal) => ({
+      ...(await importOriginal<
+        typeof import("../../../modules/bank-sessions")
+      >()),
+      createCdpSessionChecker: createSpy,
+    }));
+    vi.resetModules();
+
+    const { resolveDefaultSessionChecker } = await import("./defaults");
+    createSpy.mockClear(); // drop the module-load-time construction, if any
+    resolveDefaultSessionChecker();
+
+    expect(createSpy).toHaveBeenCalledTimes(1);
+    expect(createSpy).toHaveBeenCalledWith({ cdpUrl: "http://127.0.0.1:9333" });
+  });
+
+  it("falls back to the global CDP URL when only the global is set", async () => {
     process.env.RD_SYNC_SCRAPER = "popular-cdp";
     process.env.RD_SYNC_CDP_URL = "http://127.0.0.1:9222";
 
-    const { resolveDefaultSessionChecker } = await import("./defaults");
-    const checker = resolveDefaultSessionChecker();
+    const createSpy = vi.fn(() => ({ check: vi.fn() }));
+    vi.doMock(BANK_SESSIONS_MODULE, async (importOriginal) => ({
+      ...(await importOriginal<
+        typeof import("../../../modules/bank-sessions")
+      >()),
+      createCdpSessionChecker: createSpy,
+    }));
+    vi.resetModules();
 
-    // We only assert it has the check method — we don't actually connect
-    expect(typeof checker.check).toBe("function");
+    const { resolveDefaultSessionChecker } = await import("./defaults");
+    createSpy.mockClear();
+    resolveDefaultSessionChecker();
+
+    expect(createSpy).toHaveBeenCalledWith({ cdpUrl: "http://127.0.0.1:9222" });
   });
 });
 

--- a/src/app/api/bank-sessions/defaults.ts
+++ b/src/app/api/bank-sessions/defaults.ts
@@ -7,7 +7,7 @@
  *
  * Relevant env vars:
  *   RD_SYNC_SCRAPER            — "popular-cdp" enables the CDP-backed checker
- *   RD_SYNC_CDP_URL            — CDP endpoint (default http://127.0.0.1:9222)
+ *   RD_SYNC_BANK_POPULAR_CDP_URL — Popular CDP endpoint (fallback RD_SYNC_CDP_URL)
  *   RD_SYNC_SESSION_MONITOR    — "enabled" activates the background monitor
  *   RD_SYNC_SESSION_CHECK_INTERVAL_MS — poll interval in ms (default 300000, min 60000)
  */
@@ -19,6 +19,8 @@ import {
   type BankSessionCheckResult,
   type BankSessionMonitor,
 } from "../../../modules/bank-sessions";
+import { popularBankCode } from "../../../modules/bank-adapters/popular";
+import { resolveBankBrowserEnv } from "../../../worker/scraper/browser-runtime";
 import { resolveDefaultAlertSink } from "../../../worker/alerts/email-alert-sink";
 import { defaultAuditSink } from "../audit/defaults";
 
@@ -40,8 +42,9 @@ import { defaultAuditSink } from "../audit/defaults";
  */
 export function resolveDefaultSessionChecker(): CdpSessionChecker {
   if (process.env.RD_SYNC_SCRAPER === "popular-cdp") {
+    const bankEnv = resolveBankBrowserEnv(popularBankCode);
     return createCdpSessionChecker({
-      cdpUrl: process.env.RD_SYNC_CDP_URL,
+      cdpUrl: bankEnv.cdpUrl || undefined,
     });
   }
 

--- a/src/app/api/scrape-runs/consumer-defaults-popular-cdp.test.ts
+++ b/src/app/api/scrape-runs/consumer-defaults-popular-cdp.test.ts
@@ -12,6 +12,7 @@ describe("resolveDefaultScraper — branch selection", () => {
   beforeEach(() => {
     delete process.env.RD_SYNC_SCRAPER;
     delete process.env.RD_SYNC_CDP_URL;
+    delete process.env.RD_SYNC_BANK_POPULAR_CDP_URL;
     delete process.env.RD_SYNC_DEV_PREVIEW;
     delete process.env.RD_SYNC_BANK_BROWSER_AUTO_LAUNCH;
     delete process.env.RD_SYNC_BANK_BROWSER_LAUNCH_COMMAND;
@@ -22,6 +23,7 @@ describe("resolveDefaultScraper — branch selection", () => {
   afterEach(() => {
     delete process.env.RD_SYNC_SCRAPER;
     delete process.env.RD_SYNC_CDP_URL;
+    delete process.env.RD_SYNC_BANK_POPULAR_CDP_URL;
     delete process.env.RD_SYNC_DEV_PREVIEW;
     delete process.env.RD_SYNC_BANK_BROWSER_AUTO_LAUNCH;
     delete process.env.RD_SYNC_BANK_BROWSER_LAUNCH_COMMAND;
@@ -101,13 +103,14 @@ describe("buildPopularCdpScraperOptionsFromEnv — ensureBrowser wiring (Fix C)"
   it("wires an ensureBrowser seam when auto-launch is enabled (Fix C happy path)", () => {
     const options = buildPopularCdpScraperOptionsFromEnv({
       RD_SYNC_SCRAPER: "popular-cdp",
+      RD_SYNC_BANK_POPULAR_CDP_URL: "http://127.0.0.1:9333",
       RD_SYNC_CDP_URL: CDP_URL,
       RD_SYNC_BANK_BROWSER_AUTO_LAUNCH: "enabled",
       RD_SYNC_BANK_BROWSER_LAUNCH_COMMAND: "./scripts/launch-bank-browser.sh",
     });
 
     expect(options).toBeDefined();
-    expect(options!.cdpUrl).toBe(CDP_URL);
+    expect(options!.cdpUrl).toBe("http://127.0.0.1:9333");
     // The contract: ensureBrowser is a function the scraper will await before
     // connecting — NOT undefined. This is the behaviour the env wiring test
     // must actually prove (construction alone is not enough).
@@ -130,14 +133,14 @@ describe("buildPopularCdpScraperOptionsFromEnv — ensureBrowser wiring (Fix C)"
   it("leaves ensureBrowser undefined when auto-launch is enabled but CDP_URL is missing", () => {
     const options = buildPopularCdpScraperOptionsFromEnv({
       RD_SYNC_SCRAPER: "popular-cdp",
-      // RD_SYNC_CDP_URL intentionally unset
+      // No per-bank or global CDP URL set
       RD_SYNC_BANK_BROWSER_AUTO_LAUNCH: "enabled",
       RD_SYNC_BANK_BROWSER_LAUNCH_COMMAND: "./scripts/launch-bank-browser.sh",
     });
 
     // Options are still returned (the scraper handles a missing cdpUrl via its
-    // own default), but the ensureBrowser seam is absent because
-    // createEnsureBrowserFromEnv requires a cdpUrl.
+    // own default), but the ensureBrowser seam is absent because the bank-aware
+    // launcher seam requires a resolved cdpUrl.
     expect(options).toBeDefined();
     expect(options!.ensureBrowser).toBeUndefined();
   });
@@ -190,6 +193,7 @@ describe("resolveDefaultScraper — bankCode registry routing", () => {
   beforeEach(() => {
     delete process.env.RD_SYNC_SCRAPER;
     delete process.env.RD_SYNC_CDP_URL;
+    delete process.env.RD_SYNC_BANK_POPULAR_CDP_URL;
     delete process.env.RD_SYNC_DEV_PREVIEW;
     delete process.env.RD_SYNC_BANK_BROWSER_AUTO_LAUNCH;
   });
@@ -197,6 +201,7 @@ describe("resolveDefaultScraper — bankCode registry routing", () => {
   afterEach(() => {
     delete process.env.RD_SYNC_SCRAPER;
     delete process.env.RD_SYNC_CDP_URL;
+    delete process.env.RD_SYNC_BANK_POPULAR_CDP_URL;
     delete process.env.RD_SYNC_DEV_PREVIEW;
     delete process.env.RD_SYNC_BANK_BROWSER_AUTO_LAUNCH;
   });

--- a/src/modules/bank-adapters/registry.test.ts
+++ b/src/modules/bank-adapters/registry.test.ts
@@ -36,12 +36,57 @@ describe("createBankAdapterRegistry — factory keyed by bankCode", () => {
   });
 
   it("derives supportedBankCodes from the registered adapters (no separate whitelist to drift)", () => {
-    const registry = createBankAdapterRegistry([
-      fakeAdapter("popular"),
-      fakeAdapter("banreservas"),
-    ]);
+    const registry = createBankAdapterRegistry(
+      [fakeAdapter("popular"), fakeAdapter("banreservas")],
+      {},
+    );
 
     expect(registry.supportedBankCodes()).toEqual(["popular", "banreservas"]);
+  });
+});
+
+describe("createBankAdapterRegistry — CDP endpoint uniqueness guard (MEDIUM-2)", () => {
+  it("throws when two banks share the same explicit per-bank CDP port", () => {
+    expect(() =>
+      createBankAdapterRegistry([fakeAdapter("popular"), fakeAdapter("banreservas")], {
+        RD_SYNC_BANK_POPULAR_CDP_URL: "http://127.0.0.1:9222",
+        RD_SYNC_BANK_BANRESERVAS_CDP_URL: "http://127.0.0.1:9222",
+      }),
+    ).toThrow(/CDP endpoint collision/);
+  });
+
+  it("throws when two banks both inherit the single global RD_SYNC_CDP_URL fallback", () => {
+    expect(() =>
+      createBankAdapterRegistry([fakeAdapter("popular"), fakeAdapter("banreservas")], {
+        RD_SYNC_CDP_URL: "http://127.0.0.1:9222",
+      }),
+    ).toThrow(/CDP endpoint collision/);
+  });
+
+  it("treats loopback host aliases on the same port as a collision", () => {
+    expect(() =>
+      createBankAdapterRegistry([fakeAdapter("popular"), fakeAdapter("banreservas")], {
+        RD_SYNC_BANK_POPULAR_CDP_URL: "http://127.0.0.1:9222",
+        RD_SYNC_BANK_BANRESERVAS_CDP_URL: "http://localhost:9222",
+      }),
+    ).toThrow(/CDP endpoint collision/);
+  });
+
+  it("allows banks with distinct loopback CDP ports", () => {
+    expect(() =>
+      createBankAdapterRegistry([fakeAdapter("popular"), fakeAdapter("banreservas")], {
+        RD_SYNC_BANK_POPULAR_CDP_URL: "http://127.0.0.1:9222",
+        RD_SYNC_BANK_BANRESERVAS_CDP_URL: "http://127.0.0.1:9333",
+      }),
+    ).not.toThrow();
+  });
+
+  it("does not flag unconfigured banks (empty resolution falls back to the shared default later)", () => {
+    // No CDP env at all — both resolve to "" here and only adopt DEFAULT_CDP_URL
+    // at scraper construction. The guard must not block registration.
+    expect(() =>
+      createBankAdapterRegistry([fakeAdapter("popular"), fakeAdapter("banreservas")], {}),
+    ).not.toThrow();
   });
 });
 

--- a/src/modules/bank-adapters/registry.ts
+++ b/src/modules/bank-adapters/registry.ts
@@ -20,7 +20,8 @@ import {
   type PopularCdpScraperOptions,
 } from "../../worker/scraper/navigation/popular-cdp";
 import {
-  createEnsureBrowserFromEnv,
+  createEnsureBrowserForBank,
+  resolveBankBrowserEnv,
   type EnsureBrowserSeam,
 } from "../../worker/scraper/browser-runtime";
 import {
@@ -67,11 +68,65 @@ export interface BankAdapterRegistry {
 }
 
 /**
+ * Fail-closed guard against two registered banks resolving to the SAME loopback
+ * CDP port (MEDIUM-2). A shared CDP endpoint would let the worker attach to the
+ * wrong bank's authenticated session once a second bank is registered. Only
+ * EXPLICITLY configured endpoints are compared — a bank with no per-bank URL and
+ * no global `RD_SYNC_CDP_URL` resolves to "" here and falls back to the shared
+ * `DEFAULT_CDP_URL` at scraper construction; comparing those would wrongly flag
+ * unconfigured banks. The global `RD_SYNC_CDP_URL` fallback IS compared, because
+ * two banks both inheriting one global URL is exactly the collision to catch.
+ *
+ * Throws a server-side-only error (registry build runs at import/startup, never
+ * inside a request) so the message never reaches a browser response.
+ */
+function assertDistinctBankCdpEndpoints(
+  adapters: readonly BankAdapter[],
+  env: Record<string, string | undefined>,
+): void {
+  const portToBankCode = new Map<string, string>();
+  for (const adapter of adapters) {
+    const cdpUrl = resolveBankBrowserEnv(adapter.bankCode, env).cdpUrl;
+    if (!cdpUrl) {
+      continue;
+    }
+
+    let port: string;
+    try {
+      port = new URL(cdpUrl).port;
+    } catch {
+      // Malformed CDP URLs are rejected later by assertCdpLoopback on the
+      // connect/launch path; the uniqueness guard stays focused on collisions.
+      continue;
+    }
+
+    const owner = portToBankCode.get(port);
+    if (owner) {
+      throw new Error(
+        `Bank adapter CDP endpoint collision: "${adapter.bankCode}" and "${owner}" ` +
+          `both resolve to loopback CDP port ${port}. Each registered bank must use a ` +
+          `distinct loopback CDP URL/port (RD_SYNC_BANK_<BANK>_CDP_URL); the global ` +
+          `RD_SYNC_CDP_URL fallback is single-bank-only.`,
+      );
+    }
+    portToBankCode.set(port, adapter.bankCode);
+  }
+}
+
+/**
  * Builds a `BankAdapterRegistry` from an explicit adapter list. The supported
  * codes are derived from the registered adapters' `bankCode` values — there is
  * no separate whitelist to drift out of sync.
+ *
+ * At build time it fails closed if two registered banks resolve to the same
+ * loopback CDP port (MEDIUM-2 cross-bank session attach guard).
  */
-export function createBankAdapterRegistry(adapters: readonly BankAdapter[]): BankAdapterRegistry {
+export function createBankAdapterRegistry(
+  adapters: readonly BankAdapter[],
+  env: Record<string, string | undefined> = process.env,
+): BankAdapterRegistry {
+  assertDistinctBankCdpEndpoints(adapters, env);
+
   const byCode = new Map<string, BankAdapter>();
   for (const adapter of adapters) {
     byCode.set(adapter.bankCode, adapter);
@@ -103,9 +158,9 @@ export function createBankAdapterRegistry(adapters: readonly BankAdapter[]): Ban
  *
  * Returns `undefined` when the popular-cdp scraper is not selected, so callers
  * can fall through to the other branches. The `ensureBrowser` seam is included
- * only when `RD_SYNC_BANK_BROWSER_AUTO_LAUNCH=enabled` (and `RD_SYNC_CDP_URL`
- * is set); otherwise it is `undefined` and the scraper connects directly as
- * before (backward compatible).
+ * only when `RD_SYNC_BANK_BROWSER_AUTO_LAUNCH=enabled` and the bank-aware CDP
+ * URL resolves; otherwise it is `undefined` and the scraper connects directly
+ * as before (backward compatible).
  */
 export function buildPopularCdpScraperOptionsFromEnv(
   env: Record<string, string | undefined> = process.env,
@@ -114,9 +169,13 @@ export function buildPopularCdpScraperOptionsFromEnv(
     return undefined;
   }
 
-  const ensureBrowser: EnsureBrowserSeam | undefined = createEnsureBrowserFromEnv(env);
+  const bankEnv = resolveBankBrowserEnv(popularBankCode, env);
+  const ensureBrowser: EnsureBrowserSeam | undefined = createEnsureBrowserForBank(
+    popularBankCode,
+    env,
+  );
   return {
-    cdpUrl: env.RD_SYNC_CDP_URL,
+    cdpUrl: bankEnv.cdpUrl || undefined,
     ensureBrowser,
   };
 }

--- a/src/modules/bank-sessions/bank-sessions.test.ts
+++ b/src/modules/bank-sessions/bank-sessions.test.ts
@@ -10,6 +10,7 @@ import {
   type CdpBrowserLike,
   type SessionProbePage,
 } from "./index";
+import { DEFAULT_CDP_URL } from "../../worker/scraper/browser-runtime";
 
 // ---------------------------------------------------------------------------
 // FakeSessionProbePage — implements SessionProbePage seam
@@ -232,6 +233,43 @@ describe("createCdpSessionChecker — connect failure", () => {
     });
 
     await expect(checker.check()).resolves.toBeDefined();
+  });
+
+  it("rejects non-loopback CDP URLs before connect is attempted", async () => {
+    let connectCalled = false;
+    const checker = createCdpSessionChecker({
+      cdpUrl: "http://10.0.0.5:9222",
+      connect: async () => {
+        connectCalled = true;
+        throw new Error("should not connect");
+      },
+    });
+
+    const result = await checker.check();
+
+    expect(result.status).toBe("browser_unavailable");
+    expect(result.safeSummary).toBe("Bank browser session is not available");
+    expect(connectCalled).toBe(false);
+  });
+});
+
+describe("createCdpSessionChecker — unconfigured CDP fallback", () => {
+  it("adopts the shared DEFAULT_CDP_URL when no cdpUrl is configured (LOW-2)", async () => {
+    // Neither a per-bank nor a global CDP URL is supplied here, mirroring the
+    // env state where RD_SYNC_BANK_POPULAR_CDP_URL and RD_SYNC_CDP_URL are both
+    // unset: the checker must fall back to the worker's shared DEFAULT_CDP_URL.
+    let connectedUrl = "";
+    const checker = createCdpSessionChecker({
+      connect: async (cdpUrl: string) => {
+        connectedUrl = cdpUrl;
+        throw new Error("ECONNREFUSED");
+      },
+    });
+
+    const result = await checker.check();
+
+    expect(connectedUrl).toBe(DEFAULT_CDP_URL);
+    expect(result.status).toBe("browser_unavailable");
   });
 });
 

--- a/src/modules/bank-sessions/index.ts
+++ b/src/modules/bank-sessions/index.ts
@@ -6,6 +6,7 @@ import {
   type CdpBrowserLike,
   type CdpPageLike,
 } from "../../worker/scraper/navigation/popular-cdp";
+import { assertCdpLoopback, DEFAULT_CDP_URL } from "../../worker/scraper/browser-runtime";
 
 // ---------------------------------------------------------------------------
 // Re-export the structural types the CDP adapter already declares so callers
@@ -122,6 +123,7 @@ export interface CdpSessionChecker {
 }
 
 async function lazyPlaywrightConnect(cdpUrl: string): Promise<CdpBrowserLike> {
+  assertCdpLoopback(cdpUrl);
   const { chromium } = await import("playwright-core");
   return chromium.connectOverCDP(cdpUrl) as Promise<CdpBrowserLike>;
 }
@@ -137,7 +139,7 @@ export function createCdpSessionChecker(
   options: CdpSessionCheckerOptions = {},
 ): CdpSessionChecker {
   const {
-    cdpUrl = "http://127.0.0.1:9222",
+    cdpUrl = DEFAULT_CDP_URL,
     baseUrl = "https://ib.bpd.com.do",
     waitTimeoutMs = 15_000,
     connect = lazyPlaywrightConnect,
@@ -150,6 +152,16 @@ export function createCdpSessionChecker(
       let cdpPage: CdpPageLike | null = null;
 
       try {
+        try {
+          assertCdpLoopback(cdpUrl);
+        } catch {
+          return {
+            status: "browser_unavailable",
+            checkedAt: clock().toISOString(),
+            safeSummary: SUMMARY_UNAVAILABLE,
+          };
+        }
+
         try {
           browser = await connect(cdpUrl);
         } catch {

--- a/src/worker/scraper/browser-runtime.test.ts
+++ b/src/worker/scraper/browser-runtime.test.ts
@@ -4,6 +4,12 @@ import {
   isCdpAvailable,
   ensureCdpBrowser,
   createEnsureBrowserFromEnv,
+  createEnsureBrowserForBank,
+  assertCdpLoopback,
+  resolveBankBrowserEnv,
+  SAFE_SUMMARY_MALFORMED_CDP_URL,
+  SAFE_SUMMARY_NON_LOOPBACK_CDP,
+  SAFE_SUMMARY_UNSUPPORTED_PROTOCOL,
   type FetchLike,
   type SpawnLike,
 } from "./browser-runtime";
@@ -32,12 +38,18 @@ function makeFetchSequence(
   return { fetch, urls };
 }
 
-function makeSpawnTracker(): { spawn: SpawnLike; calls: string[] } {
+function makeSpawnTracker(): {
+  spawn: SpawnLike;
+  calls: string[];
+  envs: Array<Record<string, string> | undefined>;
+} {
   const calls: string[] = [];
-  const spawn: SpawnLike = (command) => {
+  const envs: Array<Record<string, string> | undefined> = [];
+  const spawn: SpawnLike = (command, options) => {
     calls.push(command);
+    envs.push(options?.env);
   };
-  return { spawn, calls };
+  return { spawn, calls, envs };
 }
 
 /** No-op sleep — resolves immediately so tests never wait in real time. */
@@ -83,6 +95,15 @@ describe("isCdpAvailable", () => {
     const result = await isCdpAvailable(CDP_URL, { fetch });
 
     expect(result).toBe(false);
+  });
+
+  it("rejects non-loopback URLs before any fetch is attempted", async () => {
+    const { fetch, urls } = makeFetchSequence([true]);
+
+    await expect(
+      isCdpAvailable("http://10.0.0.5:9222", { fetch }),
+    ).rejects.toThrow(SAFE_SUMMARY_NON_LOOPBACK_CDP);
+    expect(urls).toEqual([]);
   });
 
   it("returns false on timeout when fetch never resolves but respects signal.abort (Fix D)", async () => {
@@ -147,6 +168,25 @@ describe("ensureCdpBrowser — CDP unavailable, no launch command", () => {
     expect(result.ok).toBe(false);
     expect(result).toHaveProperty("safeErrorSummary", "Bank browser is not running");
     expect(calls).toEqual([]); // spawn never called
+  });
+
+  it("rejects non-loopback URLs without fetching or spawning", async () => {
+    const { fetch, urls } = makeFetchSequence([true]);
+    const { spawn, calls } = makeSpawnTracker();
+
+    const result = await ensureCdpBrowser({
+      cdpUrl: "http://10.0.0.5:9222",
+      launchCommand: "./scripts/launch-bank-browser.sh",
+      deps: { fetch, spawn, sleep: noopSleep, now: () => 0 },
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      launched: false,
+      safeErrorSummary: SAFE_SUMMARY_NON_LOOPBACK_CDP,
+    });
+    expect(urls).toEqual([]);
+    expect(calls).toEqual([]);
   });
 });
 
@@ -341,5 +381,94 @@ describe("createEnsureBrowserFromEnv", () => {
       RD_SYNC_BANK_BROWSER_AUTO_LAUNCH: "true",
     });
     expect(seam).toBeUndefined();
+  });
+});
+
+describe("assertCdpLoopback", () => {
+  it("accepts origin-only loopback http endpoints", () => {
+    for (const cdpUrl of [
+      "http://127.0.0.1:9222",
+      "http://localhost:9222",
+      "http://[::1]:9222",
+    ]) {
+      expect(() => assertCdpLoopback(cdpUrl)).not.toThrow();
+    }
+  });
+
+  it("rejects unsafe CDP URLs with fixed safe summaries", () => {
+    expect(() => assertCdpLoopback("http://10.0.0.5:9222")).toThrow(
+      SAFE_SUMMARY_NON_LOOPBACK_CDP,
+    );
+    for (const unsupportedUrl of ["ftp://127.0.0.1:9222", "ws://127.0.0.1:9222"]) {
+      expect(() => assertCdpLoopback(unsupportedUrl)).toThrow(
+        SAFE_SUMMARY_UNSUPPORTED_PROTOCOL,
+      );
+    }
+    expect(() => assertCdpLoopback("not-a-url")).toThrow(
+      SAFE_SUMMARY_MALFORMED_CDP_URL,
+    );
+    for (const invalidUrl of [
+      "http://127.0.0.1:9222/json/version",
+      "http://user@127.0.0.1:9222",
+      "http://127.0.0.1:9222?probe=1",
+      "http://127.0.0.1:9222#devtools",
+    ]) {
+      expect(() => assertCdpLoopback(invalidUrl)).toThrow(
+        SAFE_SUMMARY_MALFORMED_CDP_URL,
+      );
+    }
+  });
+});
+
+describe("resolveBankBrowserEnv", () => {
+  it("uses per-bank CDP, then falls back to non-blank global CDP", () => {
+    expect(resolveBankBrowserEnv("popular", {
+      RD_SYNC_CDP_URL: "http://127.0.0.1:9333",
+    }).cdpUrl).toBe("http://127.0.0.1:9333");
+    expect(resolveBankBrowserEnv("popular", {
+      RD_SYNC_BANK_POPULAR_CDP_URL: "http://127.0.0.1:9222",
+      RD_SYNC_CDP_URL: "http://127.0.0.1:9333",
+    }).cdpUrl).toBe("http://127.0.0.1:9222");
+    expect(resolveBankBrowserEnv("popular", {
+      RD_SYNC_BANK_POPULAR_CDP_URL: "",
+      RD_SYNC_CDP_URL: "http://127.0.0.1:9333",
+    }).cdpUrl).toBe("http://127.0.0.1:9333");
+  });
+});
+
+describe("createEnsureBrowserForBank", () => {
+  it("passes bank identity through env and polls the same per-bank CDP URL", async () => {
+    const bankCdpUrl = "http://127.0.0.1:9333";
+    const { fetch, urls } = makeFetchSequence([false, true]);
+    const { spawn, calls, envs } = makeSpawnTracker();
+    const seam = createEnsureBrowserForBank(
+      "popular",
+      {
+        RD_SYNC_BANK_POPULAR_CDP_URL: bankCdpUrl,
+        RD_SYNC_CDP_URL: CDP_URL,
+        RD_SYNC_BANK_BROWSER_AUTO_LAUNCH: "enabled",
+        RD_SYNC_BANK_BROWSER_LAUNCH_COMMAND: "./scripts/launch-bank-browser.sh",
+      },
+      { fetch, spawn, sleep: noopSleep, now: () => 0 },
+    );
+
+    const result = await seam?.();
+
+    expect(result).toEqual({ ok: true, launched: true });
+    expect(calls).toEqual(["./scripts/launch-bank-browser.sh"]);
+    expect(envs).toEqual([{ BANK_CODE: "popular" }]);
+    expect(urls).toEqual([
+      `${bankCdpUrl}/json/version`,
+      `${bankCdpUrl}/json/version`,
+    ]);
+  });
+
+  it("fails explicitly for invalid bank codes", () => {
+    expect(() =>
+      createEnsureBrowserForBank("popular;echo", {
+        RD_SYNC_BANK_POPULAR_CDP_URL: CDP_URL,
+        RD_SYNC_BANK_BROWSER_AUTO_LAUNCH: "enabled",
+      }),
+    ).toThrow("Invalid bank code for browser launcher");
   });
 });

--- a/src/worker/scraper/browser-runtime.ts
+++ b/src/worker/scraper/browser-runtime.ts
@@ -15,6 +15,69 @@ import { spawn as nodeSpawn } from "node:child_process";
 // those details stay in server-side logs only.
 // ---------------------------------------------------------------------------
 
+// Runtime guard: configured CDP endpoints must be origin-only http loopback
+// URLs before any fetch, connect, or launch path uses them. URL.hostname
+// returns the BRACKETED form "[::1]" for http://[::1]:port, so the bare "::1"
+// is unreachable here — only the bracketed IPv6 loopback belongs in this set.
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "[::1]"]);
+
+export const SAFE_SUMMARY_MALFORMED_CDP_URL = "CDP endpoint URL is malformed";
+export const SAFE_SUMMARY_NON_LOOPBACK_CDP = "CDP endpoint must be on loopback (127.0.0.1 / localhost / ::1)";
+export const SAFE_SUMMARY_UNSUPPORTED_PROTOCOL = "CDP endpoint uses an unsupported protocol (only http allowed)";
+
+const SAFE_CDP_ERROR_SUMMARIES = new Set([
+  SAFE_SUMMARY_MALFORMED_CDP_URL,
+  SAFE_SUMMARY_NON_LOOPBACK_CDP,
+  SAFE_SUMMARY_UNSUPPORTED_PROTOCOL,
+]);
+
+/**
+ * Shared default CDP endpoint — the SINGLE source of truth for the loopback
+ * debug port used when no CDP URL is configured. The scraper (popular-cdp), the
+ * session monitor (bank-sessions), and the shell launcher
+ * (scripts/launch-bank-browser.sh) MUST all agree on this value so the launcher
+ * and worker can never bind/attach mismatched ports. The shell launcher cannot
+ * import TypeScript, so its fallback literal is comment-anchored to this
+ * constant and a parity test enforces the port stays equal.
+ */
+export const DEFAULT_CDP_URL = "http://127.0.0.1:9222";
+
+export function assertCdpLoopback(rawUrl: string): void {
+  let parsed: URL;
+  const trimmedUrl = rawUrl.trim();
+  try {
+    parsed = new URL(trimmedUrl);
+  } catch {
+    throw new Error(SAFE_SUMMARY_MALFORMED_CDP_URL);
+  }
+
+  if (parsed.protocol !== "http:") {
+    throw new Error(SAFE_SUMMARY_UNSUPPORTED_PROTOCOL);
+  }
+
+  if (!LOOPBACK_HOSTS.has(parsed.hostname)) {
+    throw new Error(SAFE_SUMMARY_NON_LOOPBACK_CDP);
+  }
+
+  if (
+    !parsed.port ||
+    parsed.username ||
+    parsed.password ||
+    parsed.search ||
+    parsed.hash ||
+    trimmedUrl.slice(parsed.origin.length) !== ""
+  ) {
+    throw new Error(SAFE_SUMMARY_MALFORMED_CDP_URL);
+  }
+}
+
+export function getSafeCdpErrorSummary(error: unknown): string {
+  const message = error instanceof Error ? error.message : "";
+  return SAFE_CDP_ERROR_SUMMARIES.has(message)
+    ? message
+    : SAFE_SUMMARY_MALFORMED_CDP_URL;
+}
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -30,11 +93,13 @@ export type FetchLike = (
 ) => Promise<{ ok: boolean }>;
 
 /**
- * Spawns a detached process for the given command string. The default
- * implementation runs the command through a shell, detaches it, and unrefs
- * it so the parent (worker) is not held alive by the child browser.
+ * Spawns a detached process for the given trusted command string. Optional env
+ * vars are injected without altering the shell command text.
  */
-export type SpawnLike = (command: string) => void;
+export type SpawnLike = (
+  command: string,
+  options?: { env?: Record<string, string> },
+) => void;
 
 export interface BrowserRuntimeDeps {
   fetch?: FetchLike;
@@ -51,6 +116,8 @@ export interface EnsureCdpBrowserOptions {
   cdpUrl: string;
   /** Command to launch the browser when CDP is not already available. */
   launchCommand?: string;
+  /** Extra environment passed to the launcher without shell interpolation. */
+  launchEnv?: Record<string, string>;
   /** Max time to wait for CDP after launching. Default 30000 ms. */
   readyTimeoutMs?: number;
   /** Poll interval while waiting for CDP. Default 500 ms. */
@@ -85,11 +152,15 @@ function defaultSleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function defaultSpawn(command: string): void {
+function defaultSpawn(
+  command: string,
+  options?: { env?: Record<string, string> },
+): void {
   const child = nodeSpawn(command, {
     shell: true,
     detached: true,
     stdio: "ignore",
+    ...(options?.env ? { env: { ...process.env, ...options.env } } : {}),
   });
   child.unref();
 }
@@ -106,19 +177,23 @@ export interface IsCdpAvailableDeps {
 
 /**
  * Checks whether a CDP endpoint is alive by requesting /json/version.
- * Returns false on any network error, timeout, or non-2xx response.
+ * Throws fixed validation errors for malformed/non-loopback/non-http
+ * configured URLs; returns false only for network errors, timeouts, or non-2xx
+ * responses after the URL passes validation.
  */
 export async function isCdpAvailable(
   cdpUrl: string,
   deps?: IsCdpAvailableDeps,
 ): Promise<boolean> {
+  assertCdpLoopback(cdpUrl);
+
   const doFetch = deps?.fetch ?? globalThis.fetch;
   const timeoutMs = deps?.timeoutMs ?? DEFAULT_CHECK_TIMEOUT_MS;
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const response = await doFetch(`${cdpUrl}/json/version`, {
+    const response = await doFetch(new URL("/json/version", cdpUrl).toString(), {
       signal: controller.signal,
     });
     return response.ok;
@@ -163,6 +238,16 @@ export async function ensureCdpBrowser(
 ): Promise<EnsureCdpBrowserResult> {
   const { cdpUrl } = options;
 
+  try {
+    assertCdpLoopback(cdpUrl);
+  } catch (error) {
+    return {
+      ok: false,
+      launched: false,
+      safeErrorSummary: getSafeCdpErrorSummary(error),
+    };
+  }
+
   // Coalesce concurrent launches for the same CDP endpoint. If a launch is
   // already in flight, await and return its result instead of spawning again.
   const existing = inflightLaunches.get(cdpUrl);
@@ -183,6 +268,7 @@ async function runEnsureCdpBrowser(
   const {
     cdpUrl,
     launchCommand,
+    launchEnv,
     readyTimeoutMs = DEFAULT_READY_TIMEOUT_MS,
     pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
     deps = {},
@@ -206,7 +292,7 @@ async function runEnsureCdpBrowser(
   // Launch the browser. Spawn failures are caught and reported as a safe
   // summary — never leak the command or its output.
   try {
-    doSpawn(launchCommand);
+    doSpawn(launchCommand, launchEnv ? { env: launchEnv } : undefined);
   } catch {
     return { ok: false, launched: true, safeErrorSummary: SAFE_SUMMARY_NOT_RUNNING };
   }
@@ -221,6 +307,38 @@ async function runEnsureCdpBrowser(
   }
 
   return { ok: false, launched: true, safeErrorSummary: SAFE_SUMMARY_NOT_READY };
+}
+
+export interface BankBrowserEnv {
+  cdpUrl: string;
+}
+
+function readNonBlankEnv(
+  env: Record<string, string | undefined>,
+  key: string,
+): string | undefined {
+  const value = env[key];
+  return value === undefined || value === "" ? undefined : value;
+}
+
+const SAFE_BANK_CODE_PATTERN = /^[a-z0-9_]+$/;
+
+function normalizeBankCode(bankCode: string): string {
+  const normalized = bankCode.trim().toLowerCase();
+  if (!SAFE_BANK_CODE_PATTERN.test(normalized)) {
+    throw new Error("Invalid bank code for browser launcher");
+  }
+  return normalized;
+}
+
+export function resolveBankBrowserEnv(
+  bankCode: string,
+  env: Record<string, string | undefined> = process.env,
+): BankBrowserEnv {
+  const prefix = `RD_SYNC_BANK_${normalizeBankCode(bankCode).toUpperCase()}_`;
+  return {
+    cdpUrl: readNonBlankEnv(env, `${prefix}CDP_URL`) ?? readNonBlankEnv(env, "RD_SYNC_CDP_URL") ?? "",
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -277,5 +395,38 @@ export function createEnsureBrowserFromEnv(
       launchCommand,
       readyTimeoutMs,
       pollIntervalMs,
+    });
+}
+
+/** Builds an `ensureBrowser` seam for one bank using bank-aware CDP env vars. */
+export function createEnsureBrowserForBank(
+  bankCode: string,
+  env: Record<string, string | undefined> = process.env,
+  deps?: BrowserRuntimeDeps,
+): EnsureBrowserSeam | undefined {
+  const normalizedBankCode = normalizeBankCode(bankCode);
+  const bankEnv = resolveBankBrowserEnv(normalizedBankCode, env);
+  if (env.RD_SYNC_BANK_BROWSER_AUTO_LAUNCH !== "enabled" || !bankEnv.cdpUrl) {
+    return undefined;
+  }
+
+  const launchCommand = env.RD_SYNC_BANK_BROWSER_LAUNCH_COMMAND;
+  const readyTimeoutMs = parseOptionalMs(
+    env.RD_SYNC_BANK_BROWSER_READY_TIMEOUT_MS,
+    DEFAULT_READY_TIMEOUT_MS,
+  );
+  const pollIntervalMs = parseOptionalMs(
+    env.RD_SYNC_BANK_BROWSER_POLL_INTERVAL_MS,
+    DEFAULT_POLL_INTERVAL_MS,
+  );
+
+  return () =>
+    ensureCdpBrowser({
+      cdpUrl: bankEnv.cdpUrl,
+      launchCommand,
+      launchEnv: launchCommand ? { BANK_CODE: normalizedBankCode } : undefined,
+      readyTimeoutMs,
+      pollIntervalMs,
+      deps,
     });
 }

--- a/src/worker/scraper/navigation/popular-cdp.test.ts
+++ b/src/worker/scraper/navigation/popular-cdp.test.ts
@@ -9,6 +9,9 @@ import {
   type DocumentLike,
   type ElementLike,
 } from "./popular-cdp";
+import {
+  SAFE_SUMMARY_NON_LOOPBACK_CDP,
+} from "../browser-runtime";
 import type { PopularTransactionRow } from "../../../modules/bank-adapters/popular";
 
 // ---------------------------------------------------------------------------
@@ -240,6 +243,31 @@ describe("createPopularCdpScraper — connect failure", () => {
     expect(result.status).toBe("needs_admin_action");
     expect(result.movements).toEqual([]);
     expect(result.safeErrorSummary).toBe("Bank browser session is not available");
+  });
+
+  it("rejects non-loopback CDP URLs before ensureBrowser or connect can run", async () => {
+    let ensureBrowserCalled = false;
+    let connectCalled = false;
+    const scraper = createPopularCdpScraper({
+      cdpUrl: "http://10.0.0.5:9222",
+      ensureBrowser: async () => {
+        ensureBrowserCalled = true;
+        return { ok: true };
+      },
+      connect: async () => {
+        connectCalled = true;
+        throw new Error("should not connect");
+      },
+      collectRows: async () => ({ kind: "rows" as const, rows: FIXTURE_ROWS }),
+    });
+
+    const result = await scraper.collect();
+
+    expect(result.status).toBe("needs_admin_action");
+    expect(result.movements).toEqual([]);
+    expect(result.safeErrorSummary).toBe(SAFE_SUMMARY_NON_LOOPBACK_CDP);
+    expect(ensureBrowserCalled).toBe(false);
+    expect(connectCalled).toBe(false);
   });
 });
 

--- a/src/worker/scraper/navigation/popular-cdp.ts
+++ b/src/worker/scraper/navigation/popular-cdp.ts
@@ -2,6 +2,11 @@ import {
   parsePopularTransactionRows,
   popularScraperProfile,
 } from "../../../modules/bank-adapters/popular";
+import {
+  assertCdpLoopback,
+  DEFAULT_CDP_URL,
+  getSafeCdpErrorSummary,
+} from "../browser-runtime";
 import type { IngestionScraper } from "../../queues";
 import type { ScrapeCollectionResult } from "../../scraper";
 import {
@@ -236,8 +241,9 @@ export interface PopularCdpScraperOptions {
   ) => Promise<CollectPopularPortalRowsResult>;
 }
 
-const DEFAULT_CDP_URL = "http://127.0.0.1:9222";
-// NOTE: This constant is Banco Popular–specific. Do not share it across bank adapters.
+// NOTE: DEFAULT_BASE_URL is Banco Popular–specific. Do not share it across bank
+// adapters. The CDP default (DEFAULT_CDP_URL) is bank-agnostic and shared from
+// browser-runtime so the scraper, session monitor, and launcher never drift.
 const DEFAULT_BASE_URL = "https://ib.bpd.com.do";
 
 /**
@@ -273,6 +279,16 @@ export function createPopularCdpScraper(options: PopularCdpScraperOptions = {}):
       let cdpPage: CdpPageLike | null = null;
 
       try {
+        try {
+          assertCdpLoopback(cdpUrl);
+        } catch (error) {
+          return {
+            status: "needs_admin_action",
+            movements: [],
+            safeErrorSummary: getSafeCdpErrorSummary(error),
+          };
+        }
+
         // Ensure the CDP-enabled bank browser is running before connecting.
         // A failed check short-circuits to needs_admin_action — connect is
         // never attempted, so no transient CDP error leaks to the employee.
@@ -365,6 +381,7 @@ export function createPopularCdpScraper(options: PopularCdpScraperOptions = {}):
 // ---------------------------------------------------------------------------
 
 async function lazyPlaywrightConnect(cdpUrl: string): Promise<CdpBrowserLike> {
+  assertCdpLoopback(cdpUrl);
   const { chromium } = await import("playwright-core");
   // connectOverCDP returns a Browser — it is structurally compatible with CdpBrowserLike.
   return chromium.connectOverCDP(cdpUrl) as Promise<CdpBrowserLike>;

--- a/tests/launch-bank-browser.test.ts
+++ b/tests/launch-bank-browser.test.ts
@@ -1,0 +1,315 @@
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_CDP_URL } from "../src/worker/scraper/browser-runtime";
+
+const hasBash = spawnSync("bash", ["--version"], { encoding: "utf8" }).status === 0;
+
+// In CI, the absence of bash means the launcher contract goes completely
+// untested — a silent describe.skip would hide that gap. Fail loudly instead.
+// Locally (no CI env), skipping is acceptable for Windows-only dev runs.
+if (!hasBash && process.env.CI) {
+  throw new Error(
+    "launch-bank-browser.sh tests require bash, but bash was not found on PATH. " +
+      "CI must provide bash; refusing to silently skip launcher coverage.",
+  );
+}
+
+const describeIfBash = hasBash ? describe : describe.skip;
+const bashPwd = hasBash
+  ? spawnSync("bash", ["-lc", "pwd"], { encoding: "utf8" }).stdout.trim()
+  : "";
+const windowsDrivePrefix = bashPwd.startsWith("/mnt/") ? "/mnt/" : "/";
+
+function toBashPath(path: string): string {
+  const normalized = path.replace(/\\/g, "/");
+  return process.platform === "win32"
+    ? normalized.replace(
+        /^([A-Za-z]):/,
+        (_match, drive: string) => `${windowsDrivePrefix}${drive.toLowerCase()}`,
+      )
+    : normalized;
+}
+
+function writeExecutable(path: string, content: string): void {
+  writeFileSync(path, content, "utf8");
+  chmodSync(path, 0o755);
+}
+
+function createSandbox(): {
+  tempDir: string;
+  logFile: string;
+  env: Record<string, string>;
+  cleanup: () => void;
+} {
+  const tempDir = mkdtempSync(join(tmpdir(), "rd-sync-launcher-"));
+  const binDir = join(tempDir, "bin");
+  const profileDir = join(tempDir, "profile");
+  const logFile = join(tempDir, "browser.log");
+  mkdirSync(binDir);
+
+  writeExecutable(join(binDir, "curl"), "#!/usr/bin/env bash\nexit 1\n");
+  writeExecutable(join(binDir, "flock"), "#!/usr/bin/env bash\nexit 0\n");
+  writeExecutable(join(binDir, "stat"), "#!/usr/bin/env bash\necho 1000\n");
+  writeExecutable(join(binDir, "id"), "#!/usr/bin/env bash\necho 1000\n");
+
+  return {
+    tempDir,
+    // Real OS path so the test can read what the launched argv was written to.
+    logFile,
+    env: {
+      PATH: `${toBashPath(binDir)}:/usr/bin:/bin:${process.env.PATH ?? ""}`,
+      RD_SYNC_BANK_BROWSER_BIN: "/bin/echo",
+      RD_SYNC_BANK_BROWSER_PROFILE_DIR: toBashPath(profileDir),
+      RD_SYNC_BANK_BROWSER_LOG_FILE: toBashPath(logFile),
+    },
+    cleanup: () => rmSync(tempDir, { recursive: true, force: true }),
+  };
+}
+
+/**
+ * Reads a file that a backgrounded (`nohup ... &`) launch writes to. The browser
+ * stub (/bin/echo) records the launched argv, but the write races the parent
+ * script's exit, so we poll briefly until the expected content appears.
+ */
+async function readFileWhen(
+  path: string,
+  predicate: (content: string) => boolean,
+  attempts = 40,
+): Promise<string> {
+  let content = "";
+  for (let i = 0; i < attempts; i += 1) {
+    try {
+      content = readFileSync(path, "utf8");
+      if (predicate(content)) return content;
+    } catch {
+      // File may not exist yet — the launch is detached via nohup.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  return content;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function runLauncher(env: Record<string, string>, bankCode = "popular") {
+  const assignments = Object.entries(env)
+    .map(([key, value]) => `${key}=${shellQuote(value)}`)
+    .join(" ");
+  const command = `${assignments} ${shellQuote(
+    toBashPath(join(process.cwd(), "scripts", "launch-bank-browser.sh")),
+  )} ${shellQuote(bankCode)}`;
+
+  return spawnSync(
+    "bash",
+    ["-lc", command],
+    { encoding: "utf8" },
+  );
+}
+
+// This parity check needs no bash — it reads the script text directly — so it
+// runs on every platform (including Windows-only dev) to guarantee the launcher
+// and the worker can never default to mismatched CDP ports (HIGH-1 / LOW).
+describe("launcher / worker shared CDP default parity", () => {
+  it("launcher DEFAULT_CDP_URL full origin equals the worker's DEFAULT_CDP_URL origin", () => {
+    const scriptPath = join(process.cwd(), "scripts", "launch-bank-browser.sh");
+    const scriptText = readFileSync(scriptPath, "utf8");
+
+    const match = scriptText.match(/^DEFAULT_CDP_URL="([^"]+)"/m);
+    expect(match, "launcher must define DEFAULT_CDP_URL").not.toBeNull();
+
+    // LOW-1: the contract is that the FULL value agrees, not merely the port.
+    // Compare the whole origin (protocol + host + port) so a host drift (e.g.
+    // localhost vs 127.0.0.1) can never slip past a port-only assertion.
+    const launcherDefaultUrl = match![1];
+    const launcherOrigin = new URL(launcherDefaultUrl).origin;
+    const workerOrigin = new URL(DEFAULT_CDP_URL).origin;
+
+    expect(launcherOrigin).toBe(workerOrigin);
+  });
+
+  it("the launcher no longer exposes a DEBUG_PORT knob (port comes only from the CDP URL)", () => {
+    const scriptPath = join(process.cwd(), "scripts", "launch-bank-browser.sh");
+    const scriptText = readFileSync(scriptPath, "utf8");
+
+    // The legacy override must be fully removed so the CDP URL is the genuine
+    // single source of truth for the debug port.
+    expect(scriptText).not.toContain("RD_SYNC_BANK_BROWSER_DEBUG_PORT");
+  });
+});
+
+describeIfBash("launch-bank-browser.sh", () => {
+  it.each([
+    ["non-loopback", "http://10.0.0.5:9333", "loopback"],
+    ["ws protocol", "ws://127.0.0.1:9333", "http://loopback:puerto"],
+    ["path-bearing", "http://127.0.0.1:9333/json/version", "http://loopback:puerto"],
+  ])("rejects %s per-bank CDP URLs", (_caseName, cdpUrl, errorText) => {
+    const sandbox = createSandbox();
+    try {
+      const result = runLauncher({
+        ...sandbox.env,
+        RD_SYNC_BANK_POPULAR_CDP_URL: cdpUrl,
+        RD_SYNC_CDP_URL: "http://127.0.0.1:9222",
+      });
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(errorText);
+      // A rejected CDP URL must abort BEFORE any browser is launched: the log
+      // file (created only on the launch path) must never appear.
+      expect(existsSync(sandbox.logFile)).toBe(false);
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  it("warns when a per-bank CDP URL is set but no bank code is passed (MEDIUM-3)", () => {
+    const sandbox = createSandbox();
+    try {
+      // No bank code argument, but a per-bank CDP override is present: the
+      // override is ignored, so the launcher must warn the operator.
+      const result = runLauncher(
+        {
+          ...sandbox.env,
+          RD_SYNC_BANK_POPULAR_CDP_URL: "http://127.0.0.1:9333",
+        },
+        "",
+      );
+
+      expect(result.status).toBe(0);
+      // The warning names the ignored variable so the operator knows to re-run
+      // with the matching bank code.
+      expect(result.stderr).toContain("RD_SYNC_BANK_POPULAR_CDP_URL");
+      expect(result.stderr).toContain("SIN código de banco");
+      // No URL/credential leakage: the override's value (port 9333) is never
+      // echoed — only the variable name appears.
+      expect(result.stderr).not.toContain("9333");
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  it("lets per-bank CDP override global CDP and launches with that debug port", async () => {
+    const sandbox = createSandbox();
+    try {
+      const result = runLauncher({
+        ...sandbox.env,
+        RD_SYNC_BANK_POPULAR_CDP_URL: "http://127.0.0.1:9333",
+        RD_SYNC_CDP_URL: "http://127.0.0.1:9222",
+      });
+
+      expect(result.status).toBe(0);
+
+      // Assert the REAL launched argv (the flags the browser receives), not just
+      // the human-readable banner.
+      const launchedArgv = await readFileWhen(sandbox.logFile, (content) =>
+        content.includes("--remote-debugging-port=9333"),
+      );
+      expect(launchedArgv).toContain("--remote-debugging-port=9333");
+      expect(launchedArgv).toContain("--remote-debugging-address=127.0.0.1");
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  it("falls back to global CDP when per-bank CDP is absent", async () => {
+    const sandbox = createSandbox();
+    try {
+      const result = runLauncher({
+        ...sandbox.env,
+        RD_SYNC_CDP_URL: "http://127.0.0.1:9444",
+      });
+
+      expect(result.status).toBe(0);
+
+      const launchedArgv = await readFileWhen(sandbox.logFile, (content) =>
+        content.includes("--remote-debugging-port=9444"),
+      );
+      expect(launchedArgv).toContain("--remote-debugging-port=9444");
+      expect(launchedArgv).toContain("--remote-debugging-address=127.0.0.1");
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  it("derives a bank-scoped default profile dir when no explicit profile dir is set", () => {
+    const sandbox = createSandbox();
+    const home = join(sandbox.tempDir, "home");
+    mkdirSync(home);
+    try {
+      // Rebuild env WITHOUT the explicit profile/log overrides so the script
+      // falls through to its bank-scoped default under $HOME.
+      const env: Record<string, string> = {
+        PATH: sandbox.env.PATH,
+        RD_SYNC_BANK_BROWSER_BIN: sandbox.env.RD_SYNC_BANK_BROWSER_BIN,
+        HOME: toBashPath(home),
+        RD_SYNC_BANK_POPULAR_CDP_URL: "http://127.0.0.1:9333",
+      };
+
+      const result = runLauncher(env);
+
+      expect(result.status).toBe(0);
+      // Default profile must be bank-scoped:
+      // <home>/.local/share/rd-sync/bank-browser/popular
+      expect(result.stdout).toContain("bank-browser/popular");
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  it("bank-scopes a GLOBAL profile dir override so two banks never collide (MEDIUM-1)", () => {
+    const sandbox = createSandbox();
+    try {
+      // sandbox.env sets the GLOBAL RD_SYNC_BANK_BROWSER_PROFILE_DIR (…/profile).
+      const result = runLauncher(
+        {
+          ...sandbox.env,
+          RD_SYNC_BANK_POPULAR_CDP_URL: "http://127.0.0.1:9333",
+        },
+        "popular",
+      );
+
+      expect(result.status).toBe(0);
+      // The global override must be suffixed with the bank code.
+      expect(result.stdout).toContain("profile/popular");
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  it("uses a per-bank profile dir override verbatim — no bank-code suffix (MEDIUM-1)", () => {
+    const sandbox = createSandbox();
+    try {
+      const perBankDir = toBashPath(join(sandbox.tempDir, "perbank"));
+      const result = runLauncher(
+        {
+          PATH: sandbox.env.PATH,
+          RD_SYNC_BANK_BROWSER_BIN: sandbox.env.RD_SYNC_BANK_BROWSER_BIN,
+          RD_SYNC_BANK_BROWSER_LOG_FILE: sandbox.env.RD_SYNC_BANK_BROWSER_LOG_FILE,
+          RD_SYNC_BANK_POPULAR_PROFILE_DIR: perBankDir,
+          RD_SYNC_BANK_POPULAR_CDP_URL: "http://127.0.0.1:9333",
+        },
+        "popular",
+      );
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain("perbank");
+      // An explicit per-bank path must NOT get the bank code appended.
+      expect(result.stdout).not.toContain("perbank/popular");
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## Chain Context

```text
backend/popular-vps-session-orchestration
 └── feature/multi-bank-auto-login          ← tracker branch
      ├── ✅ PR #1 adapter registry (merged)
      └── 📍 feature/multi-bank-auto-login-pr2-browser-isolation  (this PR — PR2A)
           └── PR2B: browser backpressure + capacity metrics (next)
           └── PR3: credential vault (later, high risk)
           └── PR4: auto-login Popular (later, high risk)
           └── PR5: Banreservas/BHD read-only adapters (later)
           └── PR6: Banreservas/BHD auto-login (later)
```

Base for this PR: `feature/multi-bank-auto-login` (tracker), not `main`.

> **Size note:** This slice is a cohesive browser/CDP isolation foundation whose safety guarantees (loopback enforcement, per-bank env, launcher handoff) cannot be reviewed in isolation from each other. Most of the line count is behavior tests that must ship with the code. It exceeds the 400-line review budget and carries a maintainer-approved `size:exception`. The deferable backpressure/metrics work was split out into PR2B to keep this slice focused.

## Summary

- Enforces CDP loopback (origin-only `http://`) before every fetch/connect/launch path.
- Resolves Popular CDP via per-bank env (`RD_SYNC_BANK_POPULAR_CDP_URL`) with legacy global `RD_SYNC_CDP_URL` fallback.
- Passes bank identity to the launcher via `BANK_CODE` env injection — no shell command concatenation.
- Makes the CDP URL the single source of truth for the debug port across worker and launcher via a shared `DEFAULT_CDP_URL` constant.
- Bank-scopes the default browser profile dir to prevent Chromium singleton collisions across banks.
- Fails closed at registry build time when two banks resolve to the same loopback CDP port.

## Changes

| Area | Change |
|------|--------|
| `src/worker/scraper/browser-runtime.ts` | `assertCdpLoopback`, shared `DEFAULT_CDP_URL`, per-bank env resolution, `BANK_CODE` env injection. |
| `src/worker/scraper/navigation/popular-cdp.ts` | Loopback guard before connect; consumes shared `DEFAULT_CDP_URL`. |
| `src/modules/bank-sessions/index.ts` | Session checker enforces loopback and uses shared default. |
| `src/modules/bank-adapters/registry.ts` | Build-time uniqueness guard for per-bank CDP ports. |
| `src/app/api/bank-sessions/defaults.ts` | Per-bank CDP precedence for the default session checker. |
| `scripts/launch-bank-browser.sh` | Bank-scoped profile dir, port derived from CDP URL, non-loopback rejection, missing-bank-code warning. |
| `tests/launch-bank-browser.test.ts` | Deterministic launcher behavior tests (stubbed binary/curl/flock). |
| `.env.example`, `docs/runbooks/bank-session.md` | Accurate per-bank CDP/profile config docs. |

## Non-goals

- No browser backpressure or capacity metrics (PR2B).
- No credential storage, auto-login, or MFA handling.
- No Banreservas/BHD runtime adapters.

## Verification

- [x] `pnpm test` — 715 passed / 38 skipped
- [x] `pnpm lint` — exit 0
- [x] `pnpm typecheck` — exit 0
- [x] `git diff --check` — clean (CRLF advisories only)
- [x] Fresh 4R review (risk/reliability/readability/resilience) across multiple rounds: all prior BLOCKER/HIGH findings closed; final pass returned no BLOCKER/HIGH.

## Review history (adversarial)

Multiple fresh-context review rounds drove real fixes before this PR:
- Wired the loopback guard, per-bank env, and backpressure intent into production paths (not just helpers).
- Replaced shell-string bank-code concatenation with `BANK_CODE` env injection.
- Closed launcher↔worker port drift by removing `DEBUG_PORT` and making the CDP URL the single source of truth.
- Bank-scoped the profile dir and added a registry CDP-port uniqueness guard.

## Rollback

Revert this PR to return to the PR1 Popular-only wiring. No schema or data migration is introduced.