### PR TITLE
feat(bank-browser): add Popular browser backpressure (PR2B)

### DIFF
--- a/openspec/changes/multi-bank-auto-login/tasks.md
+++ b/openspec/changes/multi-bank-auto-login/tasks.md
@@ -52,10 +52,10 @@ Tracker branch `feature/multi-bank-auto-login` (base = current/main per repo con
 
 ## PR2B: Browser capacity/backpressure + metrics (deferred)
 
-- [ ] 2B.1 Add browser semaphore/backpressure runtime behavior (`RD_SYNC_BANK_BROWSER_MAX_CONCURRENCY`, bounded queue, safe throttled result).
-- [ ] 2B.2 Add `src/modules/observability/bank-metrics.ts` capacity metrics and production wiring.
-- [ ] 2B.3 Add throttle/capacity tests and any 503/Retry-After sync-facing behavior.
-- [ ] 2B.4 Keep Banreservas/BHD placeholder portal configs deferred to PR5; no production-looking placeholder selectors in PR2B unless real read-only adapters land.
+- [x] 2B.1 Add and wire browser semaphore/backpressure into the production Popular CDP scraper path (`RD_SYNC_BANK_BROWSER_MAX_CONCURRENCY`, bounded queue, acquire timeout, safe throttled result, release in `finally`).
+- [ ] 2B.2 Capacity metrics exporter/alert wiring deferred; removed standalone test-only metrics scaffolding from PR2B rather than marking production metrics complete.
+- [x] 2B.3 Add deterministic throttle/capacity tests for scraper backpressure. No HTTP 503/Retry-After surface is implemented in this worker-only slice.
+- [x] 2B.4 Keep Banreservas/BHD placeholder portal configs deferred to PR5; no production-looking placeholder selectors in PR2B unless real read-only adapters land.
 - Gate: full gates; <=400 changed-line target; no credential vault or auto-login logic.
 
 ## PR3: Credential model + AES-GCM envelope + admin API + audit (NO auto-login) [HIGH RISK]

--- a/src/modules/bank-adapters/registry.test.ts
+++ b/src/modules/bank-adapters/registry.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { IngestionScraper } from "../../worker/queues";
 import {
+  buildPopularCdpScraperOptionsFromEnv,
   bankAdapterRegistry,
   createBankAdapterRegistry,
   type BankAdapter,
@@ -114,5 +115,15 @@ describe("bankAdapterRegistry — default instance (Popular registered in PR1)",
 
     const scraper = adapter!.createScraper();
     expect(typeof scraper.collect).toBe("function");
+  });
+});
+
+describe("buildPopularCdpScraperOptionsFromEnv — production backpressure wiring", () => {
+  it("wires the browser semaphore into the Popular CDP scraper options", () => {
+    const options = buildPopularCdpScraperOptionsFromEnv({
+      RD_SYNC_SCRAPER: "popular-cdp",
+    });
+
+    expect(typeof options?.acquireBrowserSlot).toBe("function");
   });
 });

--- a/src/modules/bank-adapters/registry.ts
+++ b/src/modules/bank-adapters/registry.ts
@@ -21,6 +21,7 @@ import {
 } from "../../worker/scraper/navigation/popular-cdp";
 import {
   createEnsureBrowserForBank,
+  createAcquireBrowserSlotFromEnv,
   resolveBankBrowserEnv,
   type EnsureBrowserSeam,
 } from "../../worker/scraper/browser-runtime";
@@ -177,6 +178,7 @@ export function buildPopularCdpScraperOptionsFromEnv(
   return {
     cdpUrl: bankEnv.cdpUrl || undefined,
     ensureBrowser,
+    acquireBrowserSlot: createAcquireBrowserSlotFromEnv(env),
   };
 }
 

--- a/src/worker/scraper/browser-runtime.test.ts
+++ b/src/worker/scraper/browser-runtime.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   isCdpAvailable,
@@ -7,6 +7,7 @@ import {
   createEnsureBrowserForBank,
   assertCdpLoopback,
   resolveBankBrowserEnv,
+  BrowserSemaphore,
   SAFE_SUMMARY_MALFORMED_CDP_URL,
   SAFE_SUMMARY_NON_LOOPBACK_CDP,
   SAFE_SUMMARY_UNSUPPORTED_PROTOCOL,
@@ -54,6 +55,10 @@ function makeSpawnTracker(): {
 
 /** No-op sleep — resolves immediately so tests never wait in real time. */
 const noopSleep = async (): Promise<void> => {};
+
+async function flushPendingMicrotasks(): Promise<void> {
+  await Promise.resolve();
+}
 
 /** Fake clock that advances by `step` on each call. */
 function makeFakeClock(start: number, step: number): () => number {
@@ -470,5 +475,132 @@ describe("createEnsureBrowserForBank", () => {
         RD_SYNC_BANK_BROWSER_AUTO_LAUNCH: "enabled",
       }),
     ).toThrow("Invalid bank code for browser launcher");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// BrowserSemaphore — bounded concurrency backpressure
+// ---------------------------------------------------------------------------
+
+describe("BrowserSemaphore", () => {
+  it("acquires, queues, exposes capacity, and releases the next waiter", async () => {
+    const sem = new BrowserSemaphore(1, 2);
+    const r1 = await sem.acquire();
+    expect(r1.kind).toBe("acquired");
+    expect(sem.capacity()).toEqual({ active: 1, queueDepth: 0, max: 1 });
+
+    let secondResolved = false;
+    const r2Promise = sem.acquire().then((r) => {
+      secondResolved = true;
+      return r;
+    });
+
+    await flushPendingMicrotasks();
+    expect(secondResolved).toBe(false);
+    expect(sem.capacity()).toEqual({ active: 1, queueDepth: 1, max: 1 });
+
+    if (r1.kind === "acquired") await r1.release();
+
+    const r2 = await r2Promise;
+    expect(secondResolved).toBe(true);
+    expect(r2.kind).toBe("acquired");
+    if (r2.kind === "acquired") await r2.release();
+    expect(sem.capacity()).toEqual({ active: 0, queueDepth: 0, max: 1 });
+  });
+
+  it("throttles when the bounded queue is full and increments throttleCount", async () => {
+    const sem = new BrowserSemaphore(1, 1);
+    expect(sem.throttleCount).toBe(0);
+
+    const r1 = await sem.acquire();
+    const r2Promise = sem.acquire();
+    await flushPendingMicrotasks();
+
+    const throttled = await sem.acquire();
+    expect(throttled.kind).toBe("throttled");
+    expect(sem.throttleCount).toBe(1);
+
+    const throttled2 = await sem.acquire();
+    expect(throttled2.kind).toBe("throttled");
+    expect(sem.throttleCount).toBe(2);
+
+    if (r1.kind === "acquired") await r1.release();
+    const r2 = await r2Promise;
+    if (r2.kind === "acquired") await r2.release();
+  });
+
+  it("release is idempotent and max=0 immediately throttles", async () => {
+    const sem = new BrowserSemaphore(1);
+    const r1 = await sem.acquire();
+    expect(r1.kind).toBe("acquired");
+
+    if (r1.kind === "acquired") {
+      await r1.release();
+      // Second release should not throw or double-decrement
+      await r1.release();
+    }
+
+    expect(sem.capacity()).toEqual({ active: 0, queueDepth: 0, max: 1 });
+
+    const disabled = new BrowserSemaphore(0);
+    const result = await disabled.acquire();
+    expect(result.kind).toBe("throttled");
+    expect(disabled.throttleCount).toBe(1);
+  });
+
+  it("reads max concurrency from env and falls back for missing or invalid values", () => {
+    expect(BrowserSemaphore.fromEnv({
+      RD_SYNC_BANK_BROWSER_MAX_CONCURRENCY: "3",
+    }).capacity().max).toBe(3);
+    expect(BrowserSemaphore.fromEnv({}).capacity().max).toBe(2);
+    expect(BrowserSemaphore.fromEnv({
+      RD_SYNC_BANK_BROWSER_MAX_CONCURRENCY: "not-a-number",
+    }).capacity().max).toBe(2);
+  });
+
+  it("wakes the first queued waiter on release (FIFO ordering)", async () => {
+    const sem = new BrowserSemaphore(1, 5);
+    const r1 = await sem.acquire();
+
+    const r2Promise = sem.acquire();
+    const r3Promise = sem.acquire();
+    await flushPendingMicrotasks();
+
+    if (r1.kind === "acquired") await r1.release();
+    const r2 = await r2Promise;
+    expect(r2.kind).toBe("acquired");
+
+    let r3Resolved = false;
+    r3Promise.then(() => { r3Resolved = true; });
+    await flushPendingMicrotasks();
+    expect(r3Resolved).toBe(false);
+
+    // Release r2 — r3 wakes.
+    if (r2.kind === "acquired") await r2.release();
+    const r3 = await r3Promise;
+    expect(r3.kind).toBe("acquired");
+    if (r3.kind === "acquired") await r3.release();
+  });
+
+  it("times out queued acquire attempts without waiting forever", async () => {
+    vi.useFakeTimers();
+    try {
+      const sem = new BrowserSemaphore(1, 1);
+      const r1 = await sem.acquire();
+      expect(r1.kind).toBe("acquired");
+
+      const queued = sem.acquire({ timeoutMs: 25 });
+      expect(sem.capacity()).toEqual({ active: 1, queueDepth: 1, max: 1 });
+
+      await vi.advanceTimersByTimeAsync(25);
+      await expect(queued).resolves.toEqual({ kind: "throttled" });
+      expect(sem.capacity()).toEqual({ active: 1, queueDepth: 0, max: 1 });
+      expect(sem.throttleCount).toBe(1);
+
+      if (r1.kind === "acquired") await r1.release();
+      expect(sem.capacity()).toEqual({ active: 0, queueDepth: 0, max: 1 });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/worker/scraper/browser-runtime.ts
+++ b/src/worker/scraper/browser-runtime.ts
@@ -143,6 +143,181 @@ const SAFE_SUMMARY_NOT_READY = "Bank browser did not become ready in time";
 const DEFAULT_CHECK_TIMEOUT_MS = 2_000;
 const DEFAULT_READY_TIMEOUT_MS = 30_000;
 const DEFAULT_POLL_INTERVAL_MS = 500;
+const DEFAULT_BROWSER_ACQUIRE_TIMEOUT_MS = 30_000;
+
+/** Default maximum concurrent browser sessions across all banks. */
+export const DEFAULT_BROWSER_MAX_CONCURRENCY = 2;
+/** Maximum callers allowed to wait before returning `throttled`. */
+const DEFAULT_QUEUE_LIMIT = 10;
+export const SAFE_SUMMARY_BROWSER_CAPACITY_THROTTLED = "Bank browser capacity is temporarily exhausted";
+export interface BrowserCapacity {
+  active: number;
+  queueDepth: number;
+  max: number;
+}
+export type BrowserAcquireResult =
+  | { kind: "acquired"; release(): Promise<void> }
+  | { kind: "throttled" };
+export type AcquireBrowserSlot = () => Promise<BrowserAcquireResult>;
+interface BrowserQueueWaiter {
+  resolve: (value: BrowserAcquireResult) => void;
+  settled: boolean;
+  timer?: ReturnType<typeof setTimeout>;
+}
+/** Bounded concurrency semaphore for CDP browser launches/sessions. */
+export class BrowserSemaphore {
+  private activeCount = 0;
+  private readonly queue: BrowserQueueWaiter[] = [];
+  private _throttleCount = 0;
+  private released = new WeakSet<{ kind: "acquired"; release(): Promise<void> }>();
+
+  constructor(
+    private readonly max: number,
+    private readonly queueLimit: number = DEFAULT_QUEUE_LIMIT,
+  ) {}
+
+  /** Factory: reads browser concurrency/queue settings from env. */
+  static fromEnv(env: Record<string, string | undefined> = process.env): BrowserSemaphore {
+    return new BrowserSemaphore(
+      parseOptionalPositiveInt(
+        env.RD_SYNC_BANK_BROWSER_MAX_CONCURRENCY,
+        DEFAULT_BROWSER_MAX_CONCURRENCY,
+      ),
+      parseOptionalNonNegativeInt(env.RD_SYNC_BANK_BROWSER_QUEUE_LIMIT, DEFAULT_QUEUE_LIMIT),
+    );
+  }
+
+  async acquire(options: { timeoutMs?: number } = {}): Promise<BrowserAcquireResult> {
+    // max=0 means no slots are ever available — immediate throttle.
+    if (this.max <= 0) {
+      this._throttleCount++;
+      return { kind: "throttled" };
+    }
+
+    if (this.activeCount < this.max) {
+      this.activeCount++;
+      const handle: BrowserAcquireResult = {
+        kind: "acquired",
+        release: async () => {
+          this.releaseSlot(handle);
+        },
+      };
+      return handle;
+    }
+
+    // At capacity — try to enqueue.
+    if (this.queue.length >= this.queueLimit) {
+      this._throttleCount++;
+      return { kind: "throttled" };
+    }
+
+    return new Promise<BrowserAcquireResult>((resolve) => {
+      const waiter: BrowserQueueWaiter = { resolve, settled: false };
+      const timeoutMs = options.timeoutMs;
+      if (timeoutMs !== undefined && timeoutMs > 0) {
+        waiter.timer = setTimeout(() => {
+          if (waiter.settled) return;
+          waiter.settled = true;
+          const index = this.queue.indexOf(waiter);
+          if (index >= 0) {
+            this.queue.splice(index, 1);
+          }
+          this._throttleCount++;
+          resolve({ kind: "throttled" });
+        }, timeoutMs);
+      }
+      this.queue.push(waiter);
+    });
+  }
+
+  private releaseSlot(handle: BrowserAcquireResult): void {
+    // Idempotent: already released.
+    if (this.released.has(handle as { kind: "acquired"; release(): Promise<void> })) {
+      return;
+    }
+    this.released.add(handle as { kind: "acquired"; release(): Promise<void> });
+
+    // Wake the next queued waiter, or decrement active count.
+    let next = this.queue.shift();
+    while (next?.settled) {
+      next = this.queue.shift();
+    }
+
+    if (next) {
+      // Transfer the slot directly — activeCount stays the same.
+      next.settled = true;
+      if (next.timer) clearTimeout(next.timer);
+      const newHandle: BrowserAcquireResult = {
+        kind: "acquired",
+        release: async () => {
+          this.releaseSlot(newHandle);
+        },
+      };
+      next.resolve(newHandle);
+    } else {
+      this.activeCount = Math.max(0, this.activeCount - 1);
+    }
+  }
+
+  /** Current capacity snapshot. */
+  capacity(): BrowserCapacity {
+    return {
+      active: this.activeCount,
+      queueDepth: this.queue.length,
+      max: this.max,
+    };
+  }
+
+  /** Total number of throttled acquire attempts. */
+  get throttleCount(): number {
+    return this._throttleCount;
+  }
+}
+
+const globalBrowserRuntime = globalThis as typeof globalThis & {
+  __rdSyncBrowserSemaphore?: { key: string; semaphore: BrowserSemaphore };
+};
+
+export function createAcquireBrowserSlotFromEnv(
+  env: Record<string, string | undefined> = process.env,
+): AcquireBrowserSlot {
+  const semaphore = getSharedBrowserSemaphore(env);
+  const timeoutMs = parseOptionalPositiveInt(
+    env.RD_SYNC_BANK_BROWSER_ACQUIRE_TIMEOUT_MS,
+    DEFAULT_BROWSER_ACQUIRE_TIMEOUT_MS,
+  );
+  return () => semaphore.acquire({ timeoutMs });
+}
+
+function getSharedBrowserSemaphore(env: Record<string, string | undefined>): BrowserSemaphore {
+  const max = parseOptionalPositiveInt(
+    env.RD_SYNC_BANK_BROWSER_MAX_CONCURRENCY,
+    DEFAULT_BROWSER_MAX_CONCURRENCY,
+  );
+  const queueLimit = parseOptionalNonNegativeInt(env.RD_SYNC_BANK_BROWSER_QUEUE_LIMIT, DEFAULT_QUEUE_LIMIT);
+  const key = `${max}:${queueLimit}`;
+
+  if (globalBrowserRuntime.__rdSyncBrowserSemaphore?.key !== key) {
+    globalBrowserRuntime.__rdSyncBrowserSemaphore = {
+      key,
+      semaphore: new BrowserSemaphore(max, queueLimit),
+    };
+  }
+
+  return globalBrowserRuntime.__rdSyncBrowserSemaphore.semaphore;
+}
+
+function parseOptionalPositiveInt(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
+}
+
+function parseOptionalNonNegativeInt(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? Math.floor(parsed) : fallback;
+}
 
 // ---------------------------------------------------------------------------
 // Default dependency implementations

--- a/src/worker/scraper/navigation/popular-cdp.test.ts
+++ b/src/worker/scraper/navigation/popular-cdp.test.ts
@@ -11,6 +11,7 @@ import {
 } from "./popular-cdp";
 import {
   SAFE_SUMMARY_NON_LOOPBACK_CDP,
+  SAFE_SUMMARY_BROWSER_CAPACITY_THROTTLED,
 } from "../browser-runtime";
 import type { PopularTransactionRow } from "../../../modules/bank-adapters/popular";
 
@@ -338,6 +339,52 @@ describe("createPopularCdpScraper — ensureBrowser seam", () => {
 
     // No ensureBrowser → behaves exactly as before
     expect(result.status).toBe("collected");
+  });
+});
+
+describe("createPopularCdpScraper — browser backpressure seam", () => {
+  it("throttles before launch/connect and releases acquired slots on failure", async () => {
+    const blockedCalls: string[] = [];
+    const throttledScraper = createPopularCdpScraper({
+      cdpUrl: "http://127.0.0.1:9222",
+      acquireBrowserSlot: async () => ({ kind: "throttled" }),
+      ensureBrowser: async () => {
+        blockedCalls.push("ensureBrowser");
+        return { ok: true };
+      },
+      connect: async () => {
+        blockedCalls.push("connect");
+        throw new Error("should not connect");
+      },
+      collectRows: async () => ({ kind: "rows" as const, rows: FIXTURE_ROWS }),
+    });
+
+    const throttledResult = await throttledScraper.collect();
+
+    expect(throttledResult).toEqual({
+      status: "needs_admin_action",
+      movements: [],
+      safeErrorSummary: SAFE_SUMMARY_BROWSER_CAPACITY_THROTTLED,
+    });
+    expect(blockedCalls).toEqual([]);
+
+    let releaseCount = 0;
+    const failingScraper = createPopularCdpScraper({
+      cdpUrl: "http://127.0.0.1:9222",
+      acquireBrowserSlot: async () => ({
+        kind: "acquired",
+        release: async () => { releaseCount++; },
+      }),
+      connect: async () => {
+        throw new Error("Connection refused");
+      },
+      collectRows: async () => ({ kind: "rows" as const, rows: FIXTURE_ROWS }),
+    });
+
+    const result = await failingScraper.collect();
+
+    expect(result.status).toBe("needs_admin_action");
+    expect(releaseCount).toBe(1);
   });
 });
 

--- a/src/worker/scraper/navigation/popular-cdp.ts
+++ b/src/worker/scraper/navigation/popular-cdp.ts
@@ -6,6 +6,8 @@ import {
   assertCdpLoopback,
   DEFAULT_CDP_URL,
   getSafeCdpErrorSummary,
+  SAFE_SUMMARY_BROWSER_CAPACITY_THROTTLED,
+  type AcquireBrowserSlot,
 } from "../browser-runtime";
 import type { IngestionScraper } from "../../queues";
 import type { ScrapeCollectionResult } from "../../scraper";
@@ -214,6 +216,8 @@ export interface PopularCdpScraperOptions {
    * When omitted (default), the scraper connects directly as before.
    */
   ensureBrowser?: () => Promise<EnsureBrowserResult>;
+  /** Optional production backpressure seam. */
+  acquireBrowserSlot?: AcquireBrowserSlot;
   /**
    * Injectable CDP connect function.
    * Defaults to a LAZY DYNAMIC IMPORT of playwright-core chromium.connectOverCDP
@@ -271,12 +275,14 @@ export function createPopularCdpScraper(options: PopularCdpScraperOptions = {}):
     connect = lazyPlaywrightConnect,
     collectRows = collectPopularPortalRows,
     ensureBrowser,
+    acquireBrowserSlot,
   } = options;
 
   return {
     async collect(): Promise<ScrapeCollectionResult> {
       let browser: CdpBrowserLike | null = null;
       let cdpPage: CdpPageLike | null = null;
+      let browserSlot: { release(): Promise<void> } | null = null;
 
       try {
         try {
@@ -287,6 +293,18 @@ export function createPopularCdpScraper(options: PopularCdpScraperOptions = {}):
             movements: [],
             safeErrorSummary: getSafeCdpErrorSummary(error),
           };
+        }
+
+        if (acquireBrowserSlot) {
+          const acquireResult = await acquireBrowserSlot();
+          if (acquireResult.kind === "throttled") {
+            return {
+              status: "needs_admin_action",
+              movements: [],
+              safeErrorSummary: SAFE_SUMMARY_BROWSER_CAPACITY_THROTTLED,
+            };
+          }
+          browserSlot = acquireResult;
         }
 
         // Ensure the CDP-enabled bank browser is running before connecting.
@@ -367,6 +385,9 @@ export function createPopularCdpScraper(options: PopularCdpScraperOptions = {}):
           } catch {
             // Ignore browser handle close errors
           }
+        }
+        if (browserSlot !== null) {
+          await browserSlot.release();
         }
       }
     },


### PR DESCRIPTION
## Chain Context

```text
backend/popular-vps-session-orchestration
 └── feature/multi-bank-auto-login          ← tracker branch
      ├── ✅ PR #1 adapter registry (merged)
      ├── ✅ PR #2 browser/CDP isolation (merged)
      └── 📍 feature/multi-bank-auto-login-pr2b-backpressure-metrics  (this PR — PR2B)
           └── PR3: credential vault (later, high risk)
           └── PR4: auto-login Popular (later, high risk)
           └── PR5: Banreservas/BHD read-only adapters (later)
           └── PR6: Banreservas/BHD auto-login (later)
```

Base for this PR: `feature/multi-bank-auto-login` (tracker), not `main`.

## Summary

- Adds a production-wired browser semaphore for the Popular CDP scraper.
- Bounds concurrent browser/CDP work using `RD_SYNC_BANK_BROWSER_MAX_CONCURRENCY`.
- Adds bounded queueing + acquire timeout so excess load returns a safe throttled outcome instead of piling up indefinitely.
- Releases acquired capacity in `finally` for success and failure paths.

## Changes

| Area | Change |
|------|--------|
| `src/worker/scraper/browser-runtime.ts` | Adds `BrowserSemaphore`, bounded queueing, acquire timeout, safe throttled result, and env factory. |
| `src/modules/bank-adapters/registry.ts` | Wires the shared browser semaphore into Popular CDP scraper options. |
| `src/worker/scraper/navigation/popular-cdp.ts` | Acquires a browser slot before browser/CDP work and releases it in `finally`. |
| Tests | Adds deterministic semaphore and Popular scraper backpressure coverage. |
| `openspec/changes/multi-bank-auto-login/tasks.md` | Marks completed PR2B backpressure tasks and truthfully defers metrics exporter/alert wiring. |

## Non-goals / Deferred

- No credential vault.
- No auto-login credential submission.
- No MFA/Imperva bypass.
- No Banreservas/BHD scraping or auto-login logic.
- No HTTP `503` / `Retry-After` surface in this worker-only slice.
- Capacity metrics exporter/alert wiring remains deferred; prior test-only metrics scaffolding was intentionally removed rather than falsely marking production metrics complete.

## Review Budget

- Diff: 393 insertions / 5 deletions = 398 changed lines.
- Within the 400-line budget. Do not add more scope to this PR.

## Verification

- [x] `pnpm test` — 723 passed / 38 skipped
- [x] `pnpm lint` — exit 0
- [x] `pnpm typecheck` — exit 0
- [x] `git diff --check` — exit 0; CRLF advisories only
- [x] Fresh 4R review after implementation
- [x] Surgical fix round for initial blockers
- [x] Fresh 4R re-review after blocker fixes: PR2B backpressure blockers closed; remaining notes are LOW/SUGGESTION only

## Known Separate Finding

A resilience reviewer ran `pnpm build` and found an existing build-time DB/prerender issue in `/admin/scrape-runs` (`Prisma ECONNREFUSED`). That failure is outside this PR's diff and is not mixed into this backpressure slice. It should be handled as a separate follow-up because this PR must remain focused and under the 400-line review budget.

## Rollback

Revert this PR to return to PR2A behavior: per-bank browser/CDP isolation remains, but Popular CDP scraper no longer applies browser backpressure.