### PR TITLE
fix(admin): prevent build-time DB access on scrape-runs page

### DIFF
--- a/src/app/admin/scrape-runs/page.test.tsx
+++ b/src/app/admin/scrape-runs/page.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   default as AdminScrapeRunsPage,
   AdminScrapeRunsDashboard,
+  loadScrapeRuns,
   summarizeScrapeRuns,
   type AdminScrapeRun,
 } from "./page";
@@ -31,6 +32,11 @@ vi.mock("next/headers", () => ({
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ refresh: vi.fn() }),
   usePathname: () => "/admin/scrape-runs",
+}));
+
+const mockListScrapeRunsForPage = vi.fn().mockResolvedValue([]);
+vi.mock("../../api/scrape-runs/defaults", () => ({
+  listScrapeRunsForPage: (...args: unknown[]) => mockListScrapeRunsForPage(...args),
 }));
 
 const runs: AdminScrapeRun[] = [
@@ -189,5 +195,72 @@ describe("AdminScrapeRunsDashboard", () => {
     const runNowButton = html.match(/<button[^>]*>Ejecutar ahora<\/button>/)?.[0];
     expect(runNowButton).toBeDefined();
     expect(runNowButton).toContain('disabled=""');
+  });
+});
+
+describe("loadScrapeRuns (safe server-side fallback)", () => {
+  it("returns empty array when listScrapeRunsForPage throws (DB unavailable)", async () => {
+    mockListScrapeRunsForPage.mockRejectedValueOnce(new Error("connect ECONNREFUSED"));
+
+    const result = await loadScrapeRuns();
+
+    expect(result).toEqual([]);
+  });
+
+  it("does not leak internal error details to the returned value", async () => {
+    mockListScrapeRunsForPage.mockRejectedValueOnce(
+      new Error("prisma: Error: P1001: Can't reach database server at localhost:5432"),
+    );
+
+    const result = await loadScrapeRuns();
+
+    // Empty array — no error objects, no stack traces, no DB connection strings.
+    expect(result).toEqual([]);
+    expect(JSON.stringify(result)).not.toContain("P1001");
+    expect(JSON.stringify(result)).not.toContain("localhost:5432");
+  });
+
+  it("records a safe server-side diagnostic when listing fails", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockListScrapeRunsForPage.mockRejectedValueOnce(
+      new Error("P1001: Can't reach database server at localhost:5432"),
+    );
+
+    try {
+      const result = await loadScrapeRuns();
+
+      // Failure is observable in server logs...
+      expect(consoleError).toHaveBeenCalledTimes(1);
+      const [message, context] = consoleError.mock.calls[0];
+      expect(message).toContain("[admin/scrape-runs]");
+      // ...but the operator-facing result still carries no runs.
+      expect(result).toEqual([]);
+      // The structured context exposes only sanitized error metadata.
+      expect(context).toEqual({
+        error: {
+          name: "Error",
+          message: "P1001: Can't reach database server at localhost:5432",
+        },
+      });
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it("delegates to listScrapeRunsForPage and returns its result on success", async () => {
+    const fakeRuns = [{ id: "ok-1", bankId: "popular", status: "succeeded" }];
+    mockListScrapeRunsForPage.mockResolvedValueOnce(fakeRuns);
+
+    const result = await loadScrapeRuns();
+
+    expect(result).toBe(fakeRuns);
+    expect(mockListScrapeRunsForPage).toHaveBeenCalledWith({});
+  });
+});
+
+describe("page segment config", () => {
+  it("exports dynamic = force-dynamic to prevent build-time prerendering", async () => {
+    const mod = await import("./page");
+    expect(mod.dynamic).toBe("force-dynamic");
   });
 });

--- a/src/app/admin/scrape-runs/page.tsx
+++ b/src/app/admin/scrape-runs/page.tsx
@@ -23,8 +23,17 @@ import { RunActionAffordances } from "../../../components/admin/run-action-affor
 import { TriggerScrapeButton } from "../../../components/admin/trigger-scrape-button";
 import type { ScrapeRunStatus } from "../../../worker/queues";
 import { listScrapeRunsForPage } from "../../api/scrape-runs/defaults";
+import type { DashboardScrapeRun } from "../../../modules/scrape-runs";
 import { BANKING_TIMEZONE } from "../../../lib/banking-day";
 import { bankDisplayName, scrapeRunStatusLabel } from "../../../lib/banks";
+
+/**
+ * Prevent Next.js from statically prerendering this page at build time.
+ * listScrapeRunsForPage hits Prisma / a live database, which is unavailable
+ * during `next build`.  Request-time rendering (SSR) is both correct and
+ * sufficient for this admin-only dashboard.
+ */
+export const dynamic = "force-dynamic";
 
 export interface AdminScrapeRun {
   id: string;
@@ -42,9 +51,38 @@ interface AdminScrapeRunsDashboardProps {
   runs: readonly AdminScrapeRun[];
 }
 
+/**
+ * Fetch scrape runs with a safe server-side fallback.
+ *
+ * Transient database errors (connection refused, timeouts, pool exhaustion)
+ * should not crash the admin dashboard at request time.  Instead, the page
+ * renders an empty state and the operator sees "no runs recorded yet" — a
+ * safe, honest default that never leaks internal error details to the
+ * browser.
+ */
+export async function loadScrapeRuns(): Promise<readonly DashboardScrapeRun[]> {
+  try {
+    return await listScrapeRunsForPage({});
+  } catch (error) {
+    // Never surface DB/Prisma details to the browser — render an empty state
+    // instead. Still record a safe, generic server-side diagnostic so the
+    // outage is observable in logs without leaking connection strings, query
+    // internals, or stack traces back to the UI.
+    console.error("[admin/scrape-runs] failed to load scrape runs", {
+      error:
+        error instanceof Error
+          ? { name: error.name, message: error.message }
+          : "unknown error",
+    });
+    return [];
+  }
+}
+
 export default async function AdminScrapeRunsPage() {
-  const principal = await getCurrentPrincipal();
-  const runs = await listScrapeRunsForPage({});
+  const [principal, runs] = await Promise.all([
+    getCurrentPrincipal(),
+    loadScrapeRuns(),
+  ]);
 
   return <AdminScrapeRunsDashboard principal={principal} runs={runs} />;
 }


### PR DESCRIPTION
## Context

Follow-up fix in the `multi-bank-auto-login` feature chain. A fresh resilience review of PR2B ran `pnpm build` and found an existing build blocker unrelated to backpressure: `/admin/scrape-runs` was statically prerendered at build time and hit Prisma, failing with `ECONNREFUSED` when no database is available during `next build`.

Base for this PR: `feature/multi-bank-auto-login` (tracker), not `main`.

## Summary

- Marks `/admin/scrape-runs` as `dynamic = "force-dynamic"` so it renders at request time instead of being prerendered at build.
- Wraps scrape-run loading in a safe fallback that returns an empty state on transient DB failure.
- Records a sanitized server-side diagnostic (error name/message only) without leaking DB/Prisma details, connection strings, or stack traces to the browser.

## Changes

| File | Change |
|------|--------|
| `src/app/admin/scrape-runs/page.tsx` | Adds `force-dynamic`, `loadScrapeRuns()` safe fallback with sanitized server-side logging, parallel principal/runs fetch. |
| `src/app/admin/scrape-runs/page.test.tsx` | Tests fallback empty state, non-leakage, server-side logging shape, and the dynamic segment config. |

## Verification

- [x] `pnpm build` — exit 0; `/admin/scrape-runs` now renders as dynamic (f)
- [x] `pnpm test` — 728 passed / 38 skipped
- [x] `pnpm lint` — exit 0
- [x] `pnpm typecheck` — exit 0
- [x] `git diff --check` — exit 0
- [x] Fresh risk + reliability review, then surgical fix for review findings (added server-side logging + test; excluded generated `next-env.d.ts`)

## Non-goals

- No visible DB-down warning banner in the UI (empty state only). Surfacing an explicit database-unavailable notice is a separate feature.
- No changes to backpressure, credentials, or auto-login.

## Rollback

Revert this PR to restore the previous static-prerender behavior of `/admin/scrape-runs` (which fails `next build` without a DB).
