### PR TITLE
feat(credentials): add bank credential vault core (PR3A)

### DIFF
--- a/openspec/changes/multi-bank-auto-login/design.md
+++ b/openspec/changes/multi-bank-auto-login/design.md
@@ -92,7 +92,7 @@ export interface BankAdapterRegistry {
 }
 
 // AES-256-GCM envelope - ONE per field, fresh 12-byte IV per encrypt
-export interface AesGcmEnvelope { keyVersion: number; iv: string; ct: string; tag: string; } // all base64
+export interface AesGcmEnvelope { keyVersion: number; iv: string; ciphertext: string; tag: string; } // all base64
 export function encryptCredentialField(plain: string, keyResolver: (v:number)=>Buffer): AesGcmEnvelope;
 export function decryptCredentialField(env: AesGcmEnvelope, keyResolver: (v:number)=>Buffer): string;
 

--- a/openspec/changes/multi-bank-auto-login/specs/multi-bank-auto-login/spec.md
+++ b/openspec/changes/multi-bank-auto-login/specs/multi-bank-auto-login/spec.md
@@ -102,7 +102,7 @@ Single concatenated delta artifact (Engram-only store). Encodes NEW and MODIFIED
 
 | Requirement | Strength | Behavior |
 |---|---|---|
-| Full Envelope Per Field | MUST | `BankCredential` stores `encryptedUsernameEnvelope` and `encryptedPasswordEnvelope` — each a self-contained AES-256-GCM envelope `{ keyVersion, iv, ct, tag }` with its OWN fresh 12-byte random IV. NO shared `iv`/`authTag` columns. |
+| Full Envelope Per Field | MUST | `BankCredential` stores `encryptedUsernameEnvelope` and `encryptedPasswordEnvelope` — each a self-contained AES-256-GCM envelope `{ keyVersion, iv, ciphertext, tag }` with its OWN fresh 12-byte random IV. NO shared `iv`/`authTag` columns. |
 | Reversible Encryption at Rest | MUST | AES-256-GCM; master key from `RD_SYNC_BANK_CREDENTIAL_KEY` env (32 bytes), NEVER in DB |
 | No scrypt Reuse | MUST | Existing scrypt (one-way) is NOT used; reversible symmetric encryption only |
 | Bind by bankCode | MUST | `BankCredential.bankCode` is unique and FK to `Bank.code`; one credential set per bank code; no per-user attribution |

--- a/openspec/changes/multi-bank-auto-login/tasks.md
+++ b/openspec/changes/multi-bank-auto-login/tasks.md
@@ -60,11 +60,17 @@ Tracker branch `feature/multi-bank-auto-login` (base = current/main per repo con
 
 ## PR3: Credential model + AES-GCM envelope + admin API + audit (NO auto-login) [HIGH RISK]
 
-- [ ] 3.1 `prisma/schema.prisma`: add `BankCredential` (two full envelopes `encryptedUsernameEnvelope`/`encryptedPasswordEnvelope`, `keyVersion`, `isActive`, `lastRotatedAt`; `bankCode` unique FK->`Bank.code`); migration.
-- [ ] 3.2 Create `src/modules/bank-credentials/`: AES-256-GCM `encryptCredentialField`/`decryptCredentialField`, full envelope per field, fresh 12-byte IV each, `keyResolver` from `RD_SYNC_BANK_CREDENTIAL_KEY`; repo binding by `bankCode`.
+### PR3A: Credential vault core (schema + crypto + tests)
+
+- [x] 3.1 `prisma/schema.prisma`: add `BankCredential` (two full envelopes `encryptedUsernameEnvelope`/`encryptedPasswordEnvelope`, `keyVersion`, `isActive`, `lastRotatedAt`; `bankCode` unique FK->`Bank.code`) plus committed Prisma migration `20260629000000_add_bank_credentials`. Prisma schema validation is in the gate; generated output remains outside this PR slice.
+- [x] 3.2 Create `src/modules/bank-credentials/crypto.ts`: AES-256-GCM `encryptCredentialField`/`decryptCredentialField`, full envelope per field, fresh 12-byte IV each, `keyResolver` injectable (not env-coupled); `AesGcmEnvelope` type exported.
+- [x] 3.5a Crypto tests (TDD): compact suite preserving round-trip (normal/empty/unicode/long), IV uniqueness, wrong-key, tampered-tag/ciphertext, unknown keyVersion, malformed envelope including strict canonical base64 rejection, explicit `ciphertext` envelope field, ciphertext no-plaintext-leak, default/explicit keyVersion, and envelope shape/iv/tag lengths.
+
+### PR3B: Admin API + audit + repo (deferred to next slice)
+
 - [ ] 3.3 Create `src/app/api/bank-credentials/route.ts`: POST set/rotate (overwrite+audit), POST test (dry decrypt+probe, never echoes), GET `{bankCode,isActive,keyVersion,lastRotatedAt}`; `requireCapability('bankCredentials.manage')`; rate-limit 10/min; UI "Credenciales actualizadas".
 - [ ] 3.4 Modify `src/modules/audit/index.ts`: add `username/credential/plaintext/envelope` to `sensitiveKeys`; `bank_credential.set|rotate|test` canonical action constants; structural redaction (no value).
-- [ ] 3.5 Tests (TDD): round-trip; IV uniqueness across encrypts; wrong-key/tampered-tag/unknown-keyVersion/malformed-envelope fail; no-plaintext-leak in stored ct; 403/400/429/503; GET no ciphertext; set/rotate audit (bankCode+keyVersion, never value).
+- [ ] 3.5b Admin API + repo tests (TDD): 403/400/429/503; GET no ciphertext; set/rotate audit (bankCode+keyVersion, never value).
 - Gate: full gates + FRESH 4R review + Judgment Day before merge; <=400 lines; NO auto-login, NO decrypt_use outside test.
 
 ## PR4: Auto-login orchestration + Redis lock/fencing + breaker + Popular auto-login [HIGH RISK]

--- a/prisma/migrations/20260629000000_add_bank_credentials/migration.sql
+++ b/prisma/migrations/20260629000000_add_bank_credentials/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE "BankCredential" (
+    "id" TEXT NOT NULL,
+    "bankCode" TEXT NOT NULL,
+    "encryptedUsernameEnvelope" TEXT NOT NULL,
+    "encryptedPasswordEnvelope" TEXT NOT NULL,
+    "keyVersion" INTEGER NOT NULL DEFAULT 1,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "lastRotatedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "BankCredential_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "BankCredential_bankCode_key" ON "BankCredential"("bankCode");
+
+-- AddForeignKey
+ALTER TABLE "BankCredential" ADD CONSTRAINT "BankCredential_bankCode_fkey" FOREIGN KEY ("bankCode") REFERENCES "Bank"("code") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -92,9 +92,10 @@ model Bank {
   code         String        @unique
   name         String
   isActive     Boolean       @default(true)
-  accounts     BankAccount[]
-  scrapeRuns   ScrapeRun[]
-  transactions Transaction[]
+  accounts          BankAccount[]
+  scrapeRuns        ScrapeRun[]
+  transactions      Transaction[]
+  bankCredential    BankCredential?
   createdAt    DateTime      @default(now())
   updatedAt    DateTime      @updatedAt
 }
@@ -179,4 +180,21 @@ model AuditEvent {
   @@index([actorId, createdAt])
   @@index([action, createdAt])
   @@index([target, targetId])
+}
+
+// PR3: Encrypted reversible credential store for bank auto-login.
+// Each bankCode has exactly one credential set (two AES-256-GCM envelopes).
+// The master key lives in RD_SYNC_BANK_CREDENTIAL_KEY (env/KMS), NEVER in DB.
+// plaintext is decrypted ONLY in worker memory at scrape time.
+model BankCredential {
+  id                        String   @id @default(cuid())
+  bankCode                  String   @unique
+  bank                      Bank     @relation(fields: [bankCode], references: [code], onDelete: Cascade)
+  encryptedUsernameEnvelope String
+  encryptedPasswordEnvelope String
+  keyVersion                Int      @default(1)
+  isActive                  Boolean  @default(true)
+  lastRotatedAt             DateTime?
+  createdAt                 DateTime @default(now())
+  updatedAt                 DateTime @updatedAt
 }

--- a/src/modules/bank-credentials/crypto.test.ts
+++ b/src/modules/bank-credentials/crypto.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest";
+import {
+  encryptCredentialField,
+  decryptCredentialField,
+  type AesGcmEnvelope,
+} from "./crypto";
+
+const TEST_KEY = Buffer.alloc(32, 0x42);
+const testKeyResolver = (): Buffer => TEST_KEY;
+const wrongKeyResolver = (): Buffer => Buffer.alloc(32, 0xff);
+
+describe("AES-256-GCM credential envelope", () => {
+  describe("round-trip", () => {
+    it.each([
+      "super-secret-password-123",
+      "",
+      "Contraseña de prueba ñ áéíóú 你好",
+      "A".repeat(10_000),
+    ])("decrypts encrypted plaintext %#", (plaintext) => {
+      const recovered = decryptCredentialField(
+        encryptCredentialField(plaintext, testKeyResolver),
+        testKeyResolver,
+      );
+      expect(recovered).toBe(plaintext);
+    });
+  });
+
+  describe("IV uniqueness", () => {
+    it("produces different IVs across multiple encryptions of the same plaintext", () => {
+      const ivs = new Set(
+        Array.from({ length: 20 }, () =>
+          encryptCredentialField("same-password", testKeyResolver).iv,
+        ),
+      );
+      expect(ivs.size).toBe(20);
+    });
+  });
+
+  describe("wrong key", () => {
+    it("throws on decryption with a different key", () => {
+      const envelope = encryptCredentialField("secret", testKeyResolver);
+      expect(() => decryptCredentialField(envelope, wrongKeyResolver)).toThrow();
+    });
+  });
+
+  describe("tampering", () => {
+    it.each(["tag", "ciphertext"] as const)("throws when %s is modified", (field) => {
+      const envelope = encryptCredentialField("secret", testKeyResolver);
+      const tampered: AesGcmEnvelope = {
+        ...envelope,
+        [field]: flipFirstByte(envelope[field]),
+      };
+      expect(() => decryptCredentialField(tampered, testKeyResolver)).toThrow();
+    });
+  });
+
+  describe("unknown keyVersion", () => {
+    it("throws when the envelope keyVersion is not supported by the resolver", () => {
+      const envelope = {
+        ...encryptCredentialField("secret", testKeyResolver, 1),
+        keyVersion: 99,
+      };
+
+      expect(() =>
+        decryptCredentialField(envelope, (v) => {
+          if (v === 1) return TEST_KEY;
+          throw new Error(`unknown key version: ${v}`);
+        }),
+      ).toThrow();
+    });
+  });
+
+  describe("malformed envelope", () => {
+    it.each([
+      ["iv", "!!!not-base64!!!"],
+      ["ciphertext", "not!base64"],
+      ["tag", "not!base64"],
+      ["iv", Buffer.alloc(4, 0xaa).toString("base64")],
+    ] as const)("throws on malformed %s", (field, value) => {
+      const envelope = encryptCredentialField("secret", testKeyResolver);
+      const tampered: AesGcmEnvelope = { ...envelope, [field]: value };
+      expect(() => decryptCredentialField(tampered, testKeyResolver)).toThrow();
+    });
+
+    it.each(["iv", "ciphertext", "tag"] as const)(
+      "throws when otherwise valid %s base64 has appended invalid characters",
+      (field) => {
+        const envelope = encryptCredentialField("secret", testKeyResolver);
+        const tampered: AesGcmEnvelope = {
+          ...envelope,
+          [field]: `${envelope[field]}!`,
+        };
+
+        expect(() => decryptCredentialField(tampered, testKeyResolver)).toThrow(
+          /invalid base64/,
+        );
+      },
+    );
+  });
+
+  describe("no plaintext leakage", () => {
+    it("ciphertext does not contain the plaintext bytes", () => {
+      const plaintext = "my-super-secret-password";
+      const envelope = encryptCredentialField(plaintext, testKeyResolver);
+      expect(Buffer.from(envelope.ciphertext, "base64").toString("hex")).not.toContain(
+        Buffer.from(plaintext, "utf-8").toString("hex"),
+      );
+    });
+  });
+
+  describe("keyVersion", () => {
+    it("defaults to version 1 and preserves explicit versions", () => {
+      expect(encryptCredentialField("secret", testKeyResolver).keyVersion).toBe(1);
+
+      const explicit = encryptCredentialField("secret", testKeyResolver, 5);
+      expect(explicit.keyVersion).toBe(5);
+      expect(decryptCredentialField(explicit, testKeyResolver)).toBe("secret");
+    });
+  });
+
+  describe("envelope shape", () => {
+    it("stores base64 fields with expected iv/tag lengths", () => {
+      const envelope = encryptCredentialField("test", testKeyResolver);
+      expect(typeof envelope.keyVersion).toBe("number");
+      expect(typeof envelope.iv).toBe("string");
+      expect(typeof envelope.ciphertext).toBe("string");
+      expect(typeof envelope.tag).toBe("string");
+      expect(() => Buffer.from(envelope.iv, "base64")).not.toThrow();
+      expect(() => Buffer.from(envelope.ciphertext, "base64")).not.toThrow();
+      expect(() => Buffer.from(envelope.tag, "base64")).not.toThrow();
+      expect(Buffer.from(envelope.iv, "base64").length).toBe(12);
+      expect(Buffer.from(envelope.tag, "base64").length).toBe(16);
+    });
+  });
+});
+
+function flipFirstByte(b64: string): string {
+  const buf = Buffer.from(b64, "base64");
+  if (buf.length === 0) return b64;
+  buf[0] ^= 0x01;
+  return buf.toString("base64");
+}

--- a/src/modules/bank-credentials/crypto.ts
+++ b/src/modules/bank-credentials/crypto.ts
@@ -1,0 +1,111 @@
+/** AES-256-GCM reversible encryption for bank credential fields. */
+
+import { randomBytes, createCipheriv, createDecipheriv } from "node:crypto";
+
+export interface AesGcmEnvelope {
+  keyVersion: number;
+  iv: string;
+  ciphertext: string;
+  tag: string;
+}
+
+/**
+ * Resolves the 32-byte AES-256 master key for a given version.
+ * The resolver must throw on unknown versions; this prevents silent decrypt
+ * attempts with stale keys.
+ */
+export type KeyResolver = (version: number) => Buffer;
+
+const IV_LENGTH_BYTES = 12; // 96 bits — GCM recommended
+const TAG_LENGTH_BYTES = 16; // 128 bits — GCM standard
+const AES_KEY_LENGTH_BYTES = 32; // 256 bits
+const DEFAULT_KEY_VERSION = 1;
+const CANONICAL_BASE64_PATTERN = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+
+/**
+ * Encrypt a plaintext string into an AES-256-GCM envelope.
+ * Fresh 96-bit IVs are mandatory for every AES-GCM encryption.
+ */
+export function encryptCredentialField(
+  plaintext: string,
+  keyResolver: KeyResolver,
+  keyVersion: number = DEFAULT_KEY_VERSION,
+): AesGcmEnvelope {
+  const key = keyResolver(keyVersion);
+  assertAesKeyLength(key);
+
+  const iv = randomBytes(IV_LENGTH_BYTES);
+  const cipher = createCipheriv("aes-256-gcm", key, iv);
+
+  const ciphertext = cipher.update(plaintext, "utf8");
+  cipher.final();
+
+  const tag = cipher.getAuthTag();
+
+  return {
+    keyVersion,
+    iv: iv.toString("base64"),
+    ciphertext: ciphertext.toString("base64"),
+    tag: tag.toString("base64"),
+  };
+}
+
+/**
+ * Decrypt an AES-256-GCM envelope back to the original plaintext string.
+ * Error messages never include plaintext or raw envelope values.
+ */
+export function decryptCredentialField(
+  envelope: AesGcmEnvelope,
+  keyResolver: KeyResolver,
+): string {
+  const key = keyResolver(envelope.keyVersion);
+  assertAesKeyLength(key);
+
+  const iv = base64ToBuffer(envelope.iv, "iv");
+  const ciphertext = base64ToBuffer(envelope.ciphertext, "ciphertext");
+  const tag = base64ToBuffer(envelope.tag, "auth tag");
+
+  if (iv.length !== IV_LENGTH_BYTES) {
+    throw new Error(
+      `Invalid IV length: expected ${IV_LENGTH_BYTES} bytes, got ${iv.length}`,
+    );
+  }
+
+  if (tag.length !== TAG_LENGTH_BYTES) {
+    throw new Error(
+      `Invalid auth tag length: expected ${TAG_LENGTH_BYTES} bytes, got ${tag.length}`,
+    );
+  }
+
+  const decipher = createDecipheriv("aes-256-gcm", key, iv);
+  decipher.setAuthTag(tag);
+
+  try {
+    const plaintext = decipher.update(ciphertext, undefined, "utf8");
+    decipher.final();
+    return plaintext;
+  } catch {
+    throw new Error("Credential decryption failed — invalid key or tampered data");
+  }
+}
+
+function assertAesKeyLength(key: Buffer): void {
+  if (key.length !== AES_KEY_LENGTH_BYTES) {
+    throw new Error(
+      `Invalid AES key length: expected ${AES_KEY_LENGTH_BYTES} bytes, got ${key.length}`,
+    );
+  }
+}
+
+function base64ToBuffer(b64: string, fieldName: string): Buffer {
+  if (!CANONICAL_BASE64_PATTERN.test(b64)) {
+    throw new Error(`Malformed ${fieldName} — invalid base64`);
+  }
+
+  const decoded = Buffer.from(b64, "base64");
+  if (decoded.toString("base64") !== b64) {
+    throw new Error(`Malformed ${fieldName} — invalid base64`);
+  }
+
+  return decoded;
+}


### PR DESCRIPTION
## Chain Context

```text
backend/popular-vps-session-orchestration
 └── feature/multi-bank-auto-login          ← tracker branch
      ├── ✅ PR #1 adapter registry (merged)
      ├── ✅ PR #2 browser/CDP isolation (merged)
      ├── ✅ PR #3 browser backpressure / PR2B (merged)
      ├── ✅ PR #4 admin scrape-runs build fix (merged)
      └── 📍 feature/multi-bank-auto-login-pr3a-credential-vault-core (this PR — PR3A)
           └── PR3B: admin credential API + audit (next)
           └── PR4: auto-login Popular (later, high risk)
           └── PR5: Banreservas/BHD read-only adapters (later)
           └── PR6: Banreservas/BHD auto-login (later)
```

Base for this PR: `feature/multi-bank-auto-login` (tracker), not `main`.

## Summary

- Adds the `BankCredential` Prisma model and committed migration.
- Adds AES-256-GCM credential field encryption/decryption with explicit persisted envelope fields.
- Enforces 32-byte keys, fresh 12-byte IVs, 16-byte auth tags, strict canonical base64, keyVersion support, and safe error messages.
- Adds focused crypto tests for round-trip, tampering, malformed envelopes, wrong/unknown keys, IV uniqueness, and no plaintext leakage.

## Changes

| Area | Change |
|------|--------|
| `prisma/schema.prisma` | Adds `BankCredential` linked uniquely to `Bank.code`, with username/password envelopes, keyVersion, active flag, and rotation timestamp. |
| `prisma/migrations/20260629000000_add_bank_credentials/migration.sql` | Adds the credential table, unique `bankCode`, and FK to `Bank(code)` with cascade delete. |
| `src/modules/bank-credentials/crypto.ts` | Adds AES-256-GCM envelope encrypt/decrypt helpers with injectable key resolver. |
| `src/modules/bank-credentials/crypto.test.ts` | Adds 19 security-focused crypto tests. |
| OpenSpec bridge | Splits PR3 into PR3A/PR3B and renames envelope field `ct` to explicit `ciphertext`. |

## Non-goals / Deferred

- No admin credential API yet.
- No credential UI.
- No audit integration yet.
- No env/KMS resolver wiring yet.
- No worker decrypt or auto-login credential use.
- No MFA/Imperva automation or bypass.

## Verification

- [x] `pnpm exec prisma validate` — exit 0
- [x] `pnpm test src/modules/bank-credentials/crypto.test.ts` — 19 passed
- [x] `pnpm test` — 747 passed / 38 skipped
- [x] `pnpm lint` — exit 0
- [x] `pnpm typecheck` — exit 0
- [x] `pnpm build` — exit 0
- [x] `git diff --check` — exit 0; CRLF advisories only
- [x] Fresh 4R review → findings fixed
- [x] Fresh 4R re-review → no findings
- [x] Judgment Day dual review → Judge A APPROVE, Judge B APPROVE; no CRITICAL or real WARNING findings

## Judgment Day Result

`JUDGMENT: APPROVED ✅`

INFO-only follow-ups for PR3B:
- Document/wire `RD_SYNC_BANK_CREDENTIAL_KEY` when production env resolver is introduced.
- Consider AES-GCM AAD binding and/or envelope format version if future migration needs it.

## Review Budget

- Diff: 305 insertions / 8 deletions = 313 changed lines.
- Under the 400-line budget.

## Rollback

Revert this PR to remove the `BankCredential` table migration and crypto module. No admin API, UI, worker decrypt, or auto-login behavior depends on this slice yet.