### PR TITLE
feat(credentials): add credential service foundation (PR3B1)

### DIFF
--- a/openspec/changes/multi-bank-auto-login/tasks.md
+++ b/openspec/changes/multi-bank-auto-login/tasks.md
@@ -66,12 +66,21 @@ Tracker branch `feature/multi-bank-auto-login` (base = current/main per repo con
 - [x] 3.2 Create `src/modules/bank-credentials/crypto.ts`: AES-256-GCM `encryptCredentialField`/`decryptCredentialField`, full envelope per field, fresh 12-byte IV each, `keyResolver` injectable (not env-coupled); `AesGcmEnvelope` type exported.
 - [x] 3.5a Crypto tests (TDD): compact suite preserving round-trip (normal/empty/unicode/long), IV uniqueness, wrong-key, tampered-tag/ciphertext, unknown keyVersion, malformed envelope including strict canonical base64 rejection, explicit `ciphertext` envelope field, ciphertext no-plaintext-leak, default/explicit keyVersion, and envelope shape/iv/tag lengths.
 
-### PR3B: Admin API + audit + repo (deferred to next slice)
+### PR3B: Admin API + audit + repo
 
-- [ ] 3.3 Create `src/app/api/bank-credentials/route.ts`: POST set/rotate (overwrite+audit), POST test (dry decrypt+probe, never echoes), GET `{bankCode,isActive,keyVersion,lastRotatedAt}`; `requireCapability('bankCredentials.manage')`; rate-limit 10/min; UI "Credenciales actualizadas".
-- [ ] 3.4 Modify `src/modules/audit/index.ts`: add `username/credential/plaintext/envelope` to `sensitiveKeys`; `bank_credential.set|rotate|test` canonical action constants; structural redaction (no value).
-- [ ] 3.5b Admin API + repo tests (TDD): 403/400/429/503; GET no ciphertext; set/rotate audit (bankCode+keyVersion, never value).
-- Gate: full gates + FRESH 4R review + Judgment Day before merge; <=400 lines; NO auto-login, NO decrypt_use outside test.
+**PR3B1 (foundation, complete):**
+- [x] 3.4 Modify `src/modules/audit/index.ts`: add `username/credential/plaintext/envelope` to `sensitiveKeys`.
+- [x] Create `src/modules/bank-credentials/key-resolver.ts`: AES-256 key resolver from `RD_SYNC_BANK_CREDENTIAL_KEY` env (base64/hex, 32 bytes, safe errors, no key material logging).
+- [x] Create `src/modules/bank-credentials/repository.ts`: Prisma access for `BankCredential` (find/upsert/metadata-only; no ciphertext in metadata reads).
+- [x] Create `src/modules/bank-credentials/service.ts`: Business logic for set/rotate/test with canonical audit actions (`bank_credential.set|rotate|test`); plaintext never logged or echoed.
+- [x] Tests: compact key-resolver + service coverage for base64/hex/safe errors, set/rotate/test outcomes, audit safety, and metadata delegation — 394 total changed lines in slice.
+
+**PR3B2 (admin routes, deferred):**
+- [ ] 3.3 Create `src/app/api/bank-credentials/route.ts`: POST set/rotate, POST test (dry decrypt, never echoes), GET metadata; `requireCapability('bankCredentials.manage')`; rate-limit 10/min; UI "Credenciales actualizadas".
+- [ ] 3.5b Admin API tests (TDD): 403/400/429/503; GET no ciphertext; set/rotate audit.
+- [ ] 3.6 Create `src/modules/audit/bank-actions.ts`: canonical audit action constants for bank credential/auto-login/breaker/killswitch/adapter/session domains.
+
+Gate: full gates + FRESH 4R review + Judgment Day before merge; PR3B1 <=400 lines; PR3B2 <=400 lines; NO auto-login, NO decrypt_use outside test.
 
 ## PR4: Auto-login orchestration + Redis lock/fencing + breaker + Popular auto-login [HIGH RISK]
 

--- a/src/modules/audit/audit.test.ts
+++ b/src/modules/audit/audit.test.ts
@@ -6,16 +6,26 @@ describe("audit events", () => {
   it("redacts credentials, session tokens, and raw banking evidence", () => {
     const metadata = redactAuditMetadata({
       filter: { amount: "1000.00" },
+      credential: "secret",
+      envelope: "ciphertext",
       password: "secret",
+      plaintext: "clear",
       sessionToken: "token",
+      username: "operator",
       rawHtml: "<table>bank</table>",
+      nested: { metadata: { username: "nested-user", credentialEnvelope: "nested-secret" } },
     });
 
     expect(metadata).toEqual({
       filter: { amount: "1000.00" },
+      credential: "[REDACTED]",
+      envelope: "[REDACTED]",
       password: "[REDACTED]",
+      plaintext: "[REDACTED]",
       sessionToken: "[REDACTED]",
+      username: "[REDACTED]",
       rawHtml: "[REDACTED]",
+      nested: { metadata: { username: "[REDACTED]", credentialEnvelope: "[REDACTED]" } },
     });
   });
 

--- a/src/modules/audit/index.ts
+++ b/src/modules/audit/index.ts
@@ -16,13 +16,17 @@ export interface AuditEvent extends Required<Omit<AuditEventInput, "metadata" | 
 
 const sensitiveKeys = new Set([
   "cookie",
+  "credential",
+  "envelope",
   "password",
+  "plaintext",
   "rawhtml",
   "screenshot",
   "secret",
   "sessioncookie",
   "sessiontoken",
   "token",
+  "username",
 ]);
 
 export function createAuditEvent(input: AuditEventInput): AuditEvent {

--- a/src/modules/bank-credentials/key-resolver.test.ts
+++ b/src/modules/bank-credentials/key-resolver.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveCredentialKey } from "./key-resolver";
+
+const ENV_KEY = "RD_SYNC_BANK_CREDENTIAL_KEY";
+const key32 = Buffer.alloc(32, 0x42);
+
+describe("resolveCredentialKey", () => {
+  const originalEnv = process.env[ENV_KEY];
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env[ENV_KEY];
+    else process.env[ENV_KEY] = originalEnv;
+  });
+
+  it.each([
+    ["base64", key32.toString("base64"), key32],
+    ["hex", Buffer.alloc(32, 0xab).toString("hex"), Buffer.alloc(32, 0xab)],
+  ])("resolves a %s key", (_label, value, expected) => {
+    process.env[ENV_KEY] = value;
+    expect(resolveCredentialKey()).toEqual(expected);
+  });
+
+  it.each([undefined, "   "])("throws when env var is missing or empty", (value) => {
+    if (value === undefined) delete process.env[ENV_KEY];
+    else process.env[ENV_KEY] = value;
+    expect(() => resolveCredentialKey()).toThrow(/RD_SYNC_BANK_CREDENTIAL_KEY is not set/);
+  });
+
+  it("throws for unsupported key versions", () => {
+    process.env[ENV_KEY] = key32.toString("base64");
+    expect(() => resolveCredentialKey(2)).toThrow(/Unsupported key version: 2/);
+  });
+
+  it.each([
+    ["not-a-valid-key-format!!", /not valid base64 or hex/],
+    [Buffer.alloc(16, 0x42).toString("base64"), /decoded to 16 bytes/],
+  ])("throws safe errors for invalid keys", (value, message) => {
+    process.env[ENV_KEY] = value;
+    expect(() => resolveCredentialKey()).toThrow(message);
+    try {
+      resolveCredentialKey();
+    } catch (error) {
+      expect((error as Error).message).not.toContain(value);
+    }
+  });
+});

--- a/src/modules/bank-credentials/key-resolver.ts
+++ b/src/modules/bank-credentials/key-resolver.ts
@@ -1,0 +1,42 @@
+const AES_KEY_LENGTH_BYTES = 32;
+
+export function resolveCredentialKey(version: number = 1): Buffer {
+  if (version !== 1) {
+    throw new Error(`Unsupported key version: ${version}. Only version 1 is currently supported.`);
+  }
+
+  const raw = process.env.RD_SYNC_BANK_CREDENTIAL_KEY;
+  if (!raw || raw.trim() === "") {
+    throw new Error(
+      "RD_SYNC_BANK_CREDENTIAL_KEY is not set. " +
+        "Set a 32-byte key encoded as base64 or hex in the environment.",
+    );
+  }
+
+  const key = decodeKey(raw.trim());
+  if (key.length !== AES_KEY_LENGTH_BYTES) {
+    throw new Error(
+      `RD_SYNC_BANK_CREDENTIAL_KEY decoded to ${key.length} bytes, expected ${AES_KEY_LENGTH_BYTES}.`,
+    );
+  }
+
+  return key;
+}
+
+function decodeKey(value: string): Buffer {
+  if (/^[0-9a-fA-F]{64}$/.test(value)) {
+    return Buffer.from(value, "hex");
+  }
+
+  if (/^[A-Za-z0-9+/]+=*$/.test(value)) {
+    const buf = Buffer.from(value, "base64");
+    if (buf.toString("base64") === value) {
+      return buf;
+    }
+  }
+
+  throw new Error(
+    "RD_SYNC_BANK_CREDENTIAL_KEY is not valid base64 or hex. " +
+      "Expected a base64-encoded 32-byte key or a 64-char hex string.",
+  );
+}

--- a/src/modules/bank-credentials/repository.ts
+++ b/src/modules/bank-credentials/repository.ts
@@ -1,0 +1,56 @@
+import type { BankCredential, PrismaClient } from "../../generated/prisma/client";
+
+export type BankCredentialRecord = BankCredential;
+
+export interface UpsertCredentialInput {
+  bankCode: string;
+  encryptedUsernameEnvelope: string;
+  encryptedPasswordEnvelope: string;
+  keyVersion: number;
+}
+
+export interface BankCredentialMetadata {
+  bankCode: string;
+  isActive: boolean;
+  keyVersion: number;
+  lastRotatedAt: Date | null;
+}
+
+export class BankCredentialRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async findByBankCode(bankCode: string): Promise<BankCredentialRecord | null> {
+    return this.prisma.bankCredential.findUnique({ where: { bankCode } });
+  }
+
+  async upsert(input: UpsertCredentialInput): Promise<BankCredentialRecord> {
+    const now = new Date();
+    return this.prisma.bankCredential.upsert({
+      where: { bankCode: input.bankCode },
+      create: {
+        bankCode: input.bankCode,
+        encryptedUsernameEnvelope: input.encryptedUsernameEnvelope,
+        encryptedPasswordEnvelope: input.encryptedPasswordEnvelope,
+        keyVersion: input.keyVersion,
+        isActive: true,
+        createdAt: now,
+        updatedAt: now,
+      },
+      update: {
+        encryptedUsernameEnvelope: input.encryptedUsernameEnvelope,
+        encryptedPasswordEnvelope: input.encryptedPasswordEnvelope,
+        keyVersion: input.keyVersion,
+        isActive: true,
+        lastRotatedAt: now,
+        updatedAt: now,
+      },
+    });
+  }
+
+  async getMetadata(bankCode: string): Promise<BankCredentialMetadata | null> {
+    return this.prisma.bankCredential.findUnique({
+      where: { bankCode },
+      select: { bankCode: true, isActive: true, keyVersion: true, lastRotatedAt: true },
+    });
+  }
+}

--- a/src/modules/bank-credentials/service.test.ts
+++ b/src/modules/bank-credentials/service.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+import { encryptCredentialField } from "./crypto";
+import { BankCredentialService, CREDENTIAL_AUDIT_ACTIONS, CURRENT_CREDENTIAL_WRITE_KEY_VERSION } from "./service";
+import { BankCredentialRepository, type BankCredentialRecord } from "./repository";
+
+const TEST_KEY = Buffer.alloc(32, 0x42);
+const testKeyResolver = (version = CURRENT_CREDENTIAL_WRITE_KEY_VERSION) => {
+  if (version !== CURRENT_CREDENTIAL_WRITE_KEY_VERSION) throw new Error(`Unsupported key version: ${version}`);
+  return TEST_KEY;
+};
+function record(options: { valid?: boolean; keyVersion?: number; isActive?: boolean } = {}): BankCredentialRecord {
+  const { valid = true, keyVersion = CURRENT_CREDENTIAL_WRITE_KEY_VERSION, isActive = true } = options;
+  const envelope = (value: string) => JSON.stringify(encryptCredentialField(value, () => TEST_KEY, keyVersion));
+  return {
+    id: "cred-1", bankCode: "popular",
+    encryptedUsernameEnvelope: valid ? envelope("user") : "{}",
+    encryptedPasswordEnvelope: valid ? envelope("pass") : "{}",
+    keyVersion, isActive, lastRotatedAt: null, createdAt: new Date(), updatedAt: new Date(),
+  };
+}
+function setup(existing?: BankCredentialRecord | null) {
+  const events: Array<{ action: string; metadata: unknown }> = [];
+  const repository = {
+    findByBankCode: vi.fn().mockResolvedValue(existing ?? null),
+    upsert: vi.fn().mockImplementation(async (input: Record<string, unknown>) => ({ ...record(), ...input })),
+    getMetadata: vi.fn().mockResolvedValue({ bankCode: "popular", isActive: true, keyVersion: 1, lastRotatedAt: null }),
+  } as unknown as BankCredentialRepository;
+  const auditSink = {
+    record: vi.fn().mockImplementation(async (event: { action: string; metadata: unknown }) => events.push(event)),
+  };
+  return { events, repository, svc: new BankCredentialService({ repository, keyResolver: testKeyResolver, auditSink }) };
+}
+describe("BankCredentialService", () => {
+  it("sets new credentials with set audit and no plaintext metadata", async () => {
+    const { events, repository, svc } = setup(null);
+    const result = await svc.setOrRotate({ bankCode: "popular", username: "u1", password: "p1" }, "admin-1");
+    expect(result.action).toBe("set");
+    expect(repository.upsert).toHaveBeenCalledOnce();
+    expect(events[0].action).toBe(CREDENTIAL_AUDIT_ACTIONS.SET);
+    expect(JSON.stringify(events[0].metadata)).not.toContain("u1");
+  });
+
+  it("rotates existing credentials with rotate audit", async () => {
+    const { events, repository, svc } = setup(record({ keyVersion: 99, isActive: false }));
+    expect((await svc.setOrRotate({ bankCode: "popular", username: "new", password: "new" }, "a")).action).toBe("rotate");
+    expect(repository.upsert).toHaveBeenCalledWith(expect.objectContaining({ keyVersion: CURRENT_CREDENTIAL_WRITE_KEY_VERSION }));
+    expect(events[0].action).toBe(CREDENTIAL_AUDIT_ACTIONS.ROTATE);
+  });
+
+  it.each([
+    { label: "active record decrypts", existing: record(), outcome: "decrypted" },
+    { label: "missing record is not configured", existing: null, outcome: "not_configured" },
+    { label: "inactive record is not decrypted", existing: record({ isActive: false }), outcome: "inactive" },
+    { label: "malformed envelope fails safely", existing: record({ valid: false }), outcome: "decryption_failed" },
+    { label: "unsupported stored key is reported", existing: record({ keyVersion: 99 }), outcome: "unsupported_key_version" },
+  ] as const)("validateStoredCredentialDecryption returns $outcome for $label", async ({ existing, outcome }) => {
+    const { events, svc } = setup(existing);
+    await expect(svc.validateStoredCredentialDecryption("popular", "admin-1")).resolves.toMatchObject({ outcome });
+    expect(events[0].action).toBe(CREDENTIAL_AUDIT_ACTIONS.TEST);
+  });
+
+  it.each([
+    ["set", null, (svc: BankCredentialService) => svc.setOrRotate({ bankCode: "x", username: "u", password: "p" }, "a")],
+    ["test", record(), (svc: BankCredentialService) => svc.validateStoredCredentialDecryption("x", "a")],
+  ] as const)("fails closed if %s audit recording fails", async (_label, existing, act) => {
+    const { repository } = setup(existing);
+    const svc = new BankCredentialService({ repository, keyResolver: testKeyResolver, auditSink: { record: vi.fn().mockRejectedValue(new Error("down")) } });
+    await expect(act(svc)).rejects.toThrow("down");
+    expect(repository.upsert).not.toHaveBeenCalled();
+  });
+
+  it("requires an audit sink dependency", () => {
+    const { repository } = setup(null);
+    expect(() => new BankCredentialService({ repository, keyResolver: testKeyResolver } as never)).toThrow(/audit sink/);
+  });
+
+  it("getMetadata delegates to metadata-only repository access", async () => {
+    const { svc } = setup(null);
+    await expect(svc.getMetadata("popular")).resolves.toMatchObject({ bankCode: "popular" });
+  });
+
+  it("BankCredentialRepository keeps metadata reads ciphertext-free and reactivates upserts", async () => {
+    const findUnique = vi.fn().mockResolvedValue(null);
+    const upsert = vi.fn().mockResolvedValue(null);
+    const repository = new BankCredentialRepository({ bankCredential: { findUnique, upsert } } as never);
+    await repository.getMetadata("popular");
+    await repository.upsert({ bankCode: "popular", encryptedUsernameEnvelope: "u", encryptedPasswordEnvelope: "p", keyVersion: 1 });
+    const select = findUnique.mock.calls[0][0].select;
+    expect(select).toEqual({ bankCode: true, isActive: true, keyVersion: true, lastRotatedAt: true });
+    expect(JSON.stringify(select)).not.toContain("encrypted");
+    expect(upsert.mock.calls[0][0].update).toMatchObject({ isActive: true });
+  });
+});

--- a/src/modules/bank-credentials/service.ts
+++ b/src/modules/bank-credentials/service.ts
@@ -1,0 +1,124 @@
+import { decryptCredentialField, encryptCredentialField, type AesGcmEnvelope, type KeyResolver } from "./crypto";
+import { BankCredentialRepository, type BankCredentialMetadata } from "./repository";
+import { createAuditEvent, type AuditSink } from "../audit";
+
+export const CREDENTIAL_AUDIT_ACTIONS = {
+  SET: "bank_credential.set",
+  ROTATE: "bank_credential.rotate",
+  TEST: "bank_credential.test",
+} as const;
+
+export const CURRENT_CREDENTIAL_WRITE_KEY_VERSION = 1;
+export const NO_STORED_CREDENTIAL_KEY_VERSION = 0;
+
+export interface CredentialSetInput {
+  bankCode: string;
+  username: string;
+  password: string;
+}
+
+export interface CredentialTestResult {
+  bankCode: string;
+  outcome: "decrypted" | "not_configured" | "inactive" | "unsupported_key_version" | "key_unavailable" | "decryption_failed";
+}
+
+export interface CredentialServiceDeps {
+  repository: BankCredentialRepository;
+  keyResolver: KeyResolver;
+  auditSink: Pick<AuditSink, "record">;
+}
+
+export class BankCredentialService {
+  constructor(private readonly deps: CredentialServiceDeps) {
+    if (!deps.auditSink) throw new Error("Credential audit sink is required");
+  }
+
+  async setOrRotate(input: CredentialSetInput, actorId: string): Promise<{ bankCode: string; keyVersion: number; action: "set" | "rotate" }> {
+    const existing = await this.deps.repository.findByBankCode(input.bankCode);
+    const keyVersion = CURRENT_CREDENTIAL_WRITE_KEY_VERSION;
+    const action = existing ? "rotate" : "set";
+
+    const usernameEnvelope = encryptCredentialField(input.username, this.deps.keyResolver, keyVersion);
+    const passwordEnvelope = encryptCredentialField(input.password, this.deps.keyResolver, keyVersion);
+    await this.emitAudit({
+      action: existing ? CREDENTIAL_AUDIT_ACTIONS.ROTATE : CREDENTIAL_AUDIT_ACTIONS.SET,
+      bankCode: input.bankCode,
+      keyVersion,
+      actorId,
+    });
+
+    await this.deps.repository.upsert({
+      bankCode: input.bankCode,
+      encryptedUsernameEnvelope: JSON.stringify(usernameEnvelope),
+      encryptedPasswordEnvelope: JSON.stringify(passwordEnvelope),
+      keyVersion,
+    });
+
+    return { bankCode: input.bankCode, keyVersion, action };
+  }
+
+  async validateStoredCredentialDecryption(bankCode: string, actorId: string): Promise<CredentialTestResult> {
+    const record = await this.deps.repository.findByBankCode(bankCode);
+
+    if (!record) {
+      await this.emitTestAudit(bankCode, NO_STORED_CREDENTIAL_KEY_VERSION, actorId, "not_configured");
+      return { bankCode, outcome: "not_configured" };
+    }
+
+    if (!record.isActive) {
+      await this.emitTestAudit(bankCode, record.keyVersion, actorId, "inactive");
+      return { bankCode, outcome: "inactive" };
+    }
+
+    try {
+      decryptCredentialField(parseEnvelope(record.encryptedUsernameEnvelope), this.deps.keyResolver);
+      decryptCredentialField(parseEnvelope(record.encryptedPasswordEnvelope), this.deps.keyResolver);
+
+      await this.emitTestAudit(bankCode, record.keyVersion, actorId, "decrypted");
+
+      return { bankCode, outcome: "decrypted" };
+    } catch (error) {
+      const outcome = classifyDecryptFailure(error);
+      await this.emitTestAudit(bankCode, record.keyVersion, actorId, outcome);
+      return { bankCode, outcome };
+    }
+  }
+
+  async getMetadata(bankCode: string): Promise<BankCredentialMetadata | null> {
+    return this.deps.repository.getMetadata(bankCode);
+  }
+
+  private async emitTestAudit(bankCode: string, keyVersion: number, actorId: string, outcome: CredentialTestResult["outcome"]): Promise<void> {
+    await this.emitAudit({ action: CREDENTIAL_AUDIT_ACTIONS.TEST, bankCode, keyVersion, actorId, outcome });
+  }
+
+  private async emitAudit(input: { action: string; bankCode: string; keyVersion: number; actorId: string; outcome?: CredentialTestResult["outcome"] }): Promise<void> {
+    await this.deps.auditSink.record(
+      createAuditEvent({
+        actorId: input.actorId,
+        actorRole: "admin",
+        action: input.action,
+        target: "bank_credential",
+        targetId: null,
+        metadata: input.outcome === undefined ? { bankCode: input.bankCode, keyVersion: input.keyVersion } : { bankCode: input.bankCode, keyVersion: input.keyVersion, outcome: input.outcome },
+      }),
+    );
+  }
+}
+
+function classifyDecryptFailure(error: unknown): CredentialTestResult["outcome"] {
+  const message = error instanceof Error ? error.message : "";
+  if (message.includes("Unsupported key version")) return "unsupported_key_version";
+  if (message.includes("RD_SYNC_BANK_CREDENTIAL_KEY") || message.includes("Invalid AES key length")) {
+    return "key_unavailable";
+  }
+  return "decryption_failed";
+}
+
+function parseEnvelope(json: string): AesGcmEnvelope {
+  const parsed = JSON.parse(json) as Partial<AesGcmEnvelope> | null;
+  if (!parsed || typeof parsed.keyVersion !== "number" || typeof parsed.iv !== "string" || typeof parsed.ciphertext !== "string" || typeof parsed.tag !== "string") {
+    throw new Error("Malformed credential envelope");
+  }
+  return parsed as AesGcmEnvelope;
+}


### PR DESCRIPTION
## Chain Context

```text
backend/popular-vps-session-orchestration
 └── feature/multi-bank-auto-login          ← tracker branch
      ├── ✅ PR #1 adapter registry (merged)
      ├── ✅ PR #2 browser/CDP isolation (merged)
      ├── ✅ PR #3 browser backpressure / PR2B (merged)
      ├── ✅ PR #4 admin scrape-runs build fix (merged)
      ├── ✅ PR #5 credential vault core / PR3A (merged)
      └── 📍 feature/multi-bank-auto-login-pr3b-credential-admin-api (this PR — PR3B1)
           └── PR3B2: admin credential HTTP routes (next)
           └── PR4: auto-login Popular (later, high risk)
           └── PR5: Banreservas/BHD read-only adapters (later)
           └── PR6: Banreservas/BHD auto-login (later)
```

Base for this PR: `feature/multi-bank-auto-login` (tracker), not `main`.

## Summary

- Adds the credential service foundation without HTTP routes.
- Resolves `RD_SYNC_BANK_CREDENTIAL_KEY` as canonical base64 or hex with safe errors.
- Adds a Prisma-backed internal repository plus metadata-only reads that exclude encrypted envelopes.
- Adds set/rotate and dry-decrypt validation service methods with fail-closed audit.
- Extends audit redaction for credential, envelope, plaintext, and username metadata keys.

## Changes

| Area | Change |
|------|--------|
| `src/modules/bank-credentials/key-resolver.ts` | Env key resolver for 32-byte AES keys, canonical base64/hex only, no key material in errors. |
| `src/modules/bank-credentials/repository.ts` | Prisma-backed internal credential repository and metadata-only selector. |
| `src/modules/bank-credentials/service.ts` | Credential set/rotate + stored credential dry-decrypt validation; audit sink required and fail-closed. |
| `src/modules/audit/index.ts` | Adds credential/envelope/plaintext/username to sensitive key redaction. |
| Tests | Adds key resolver, service, repository metadata, and audit redaction coverage. |
| OpenSpec bridge | Splits PR3B1 foundation from PR3B2 HTTP routes. |

## Non-goals / Deferred

- No admin HTTP route handlers yet (`PR3B2`).
- No UI.
- No auto-login credential submission.
- No worker credential use.
- No MFA/Imperva automation or bypass.

## Verification

- [x] `pnpm test` — 766 passed / 38 skipped
- [x] `pnpm lint` — exit 0
- [x] `pnpm typecheck` — exit 0
- [x] `pnpm build` — exit 0
- [x] `git diff --check` — exit 0; CRLF advisories only
- [x] Fresh 4R review → blockers fixed
- [x] Fresh 4R final → no findings
- [x] Judgment Day dual review → Judge A APPROVE, Judge B APPROVE; no CRITICAL findings

## Judgment Day Result

`JUDGMENT: APPROVED ✅`

INFO/follow-up for PR3B2:
- Judge A flagged audit-before-mutation as a potential false-positive audit if DB write fails after audit succeeds. This is accepted in PR3B1 as the safer fail-closed tradeoff: no credential mutation can happen without a prior durable audit attempt. PR3B2/routes can refine this with explicit attempt/persisted semantics or transactional/outbox audit if needed.

## Review Budget

- Diff: 389 insertions / 5 deletions = 394 changed lines.
- Under the 400-line budget.

## Rollback

Revert this PR to remove the credential service/repository/env resolver and audit redaction expansion. PR3A schema + crypto core remain available but unused by admin routes.