### PR TITLE
feat(credentials): expose credential metadata route (PR3B2A)

### DIFF
--- a/openspec/changes/multi-bank-auto-login/tasks.md
+++ b/openspec/changes/multi-bank-auto-login/tasks.md
@@ -75,12 +75,17 @@ Tracker branch `feature/multi-bank-auto-login` (base = current/main per repo con
 - [x] Create `src/modules/bank-credentials/service.ts`: Business logic for set/rotate/test with canonical audit actions (`bank_credential.set|rotate|test`); plaintext never logged or echoed.
 - [x] Tests: compact key-resolver + service coverage for base64/hex/safe errors, set/rotate/test outcomes, audit safety, and metadata delegation — 394 total changed lines in slice.
 
-**PR3B2 (admin routes, deferred):**
-- [ ] 3.3 Create `src/app/api/bank-credentials/route.ts`: POST set/rotate, POST test (dry decrypt, never echoes), GET metadata; `requireCapability('bankCredentials.manage')`; rate-limit 10/min; UI "Credenciales actualizadas".
-- [ ] 3.5b Admin API tests (TDD): 403/400/429/503; GET no ciphertext; set/rotate audit.
-- [ ] 3.6 Create `src/modules/audit/bank-actions.ts`: canonical audit action constants for bank credential/auto-login/breaker/killswitch/adapter/session domains.
+**PR3B2A (admin route metadata slice):**
+- [x] 3.3a Create `src/app/api/bank-credentials/route.ts` + `defaults.ts`: GET metadata only; `requireRole(principal, ["admin"])` (no capability system exists — uses existing RBAC pattern); safe error masking (401/403/400/404/503); never returns plaintext, ciphertext, envelopes, key material, or audit internals.
+- [x] 3.5b-a Admin API tests (TDD): focused GET tests covering authz (401/403), metadata success, no secret fields, missing metadata (404), and safe error masking (503).
+- [x] 3.6 Create `src/modules/audit/bank-actions.ts`: canonical audit action constants for bank credential/auto-login/breaker/killswitch/adapter/session domains.
 
-Gate: full gates + FRESH 4R review + Judgment Day before merge; PR3B1 <=400 lines; PR3B2 <=400 lines; NO auto-login, NO decrypt_use outside test.
+**PR3B2B (admin route mutation/test slice, deferred):**
+- [ ] 3.3b Add POST set/rotate route with `InMemoryRateLimiter` 10/min, `requireRole(principal, ["admin"])`, safe errors, credential mutation through `BankCredentialService.setOrRotate`, and Spanish success message: "Credenciales actualizadas".
+- [ ] 3.3c Add POST test route with `InMemoryRateLimiter` 10/min, `requireRole(principal, ["admin"])`, dry decrypt via `validateStoredCredentialDecryption`, and no credential echo.
+- [ ] 3.5b-b Add POST tests for authz, validation, rate limit (429), set/rotate/test success paths, service error masking (503), no plaintext/ciphertext/envelope echo, and credential service call contracts.
+
+Gate: full gates + FRESH 4R review + Judgment Day before merge; PR3B1 <=400 lines (merged); PR3B2A <=400 total changed lines; PR3B2B <=400 total changed lines; NO auto-login, NO decrypt_use outside test.
 
 ## PR4: Auto-login orchestration + Redis lock/fencing + breaker + Popular auto-login [HIGH RISK]
 

--- a/src/app/api/bank-credentials/defaults.ts
+++ b/src/app/api/bank-credentials/defaults.ts
@@ -1,0 +1,39 @@
+/**
+ * Default service singleton for bank credential admin routes.
+ *
+ * Uses the shared PrismaClient singleton from persistence/prisma-client.ts.
+ * The key resolver reads RD_SYNC_BANK_CREDENTIAL_KEY at call time.
+ * Audit sink uses the shared default from api/audit/defaults.
+ *
+ * Lazy initialization: the service is created on first access, not at module
+ * import time. This prevents PrismaClient instantiation during test setup
+ * when DATABASE_URL is not set.
+ */
+
+import { getPrismaClient } from "../../../modules/persistence/prisma-client";
+import { BankCredentialRepository } from "../../../modules/bank-credentials/repository";
+import { BankCredentialService } from "../../../modules/bank-credentials/service";
+import { resolveCredentialKey } from "../../../modules/bank-credentials/key-resolver";
+import { defaultAuditSink } from "../audit/defaults";
+
+const globalRegistry = globalThis as typeof globalThis & {
+  __rdSyncBankCredentialService?: BankCredentialService;
+};
+
+function createBankCredentialService(): BankCredentialService {
+  const prisma = getPrismaClient();
+  const repository = new BankCredentialRepository(prisma);
+  return new BankCredentialService({
+    repository,
+    keyResolver: resolveCredentialKey,
+    auditSink: defaultAuditSink,
+  });
+}
+
+/**
+ * Lazy singleton — created on first access, not at module import time.
+ * This prevents PrismaClient instantiation during test setup.
+ */
+export function getDefaultBankCredentialService(): BankCredentialService {
+  return (globalRegistry.__rdSyncBankCredentialService ??= createBankCredentialService());
+}

--- a/src/app/api/bank-credentials/route.test.ts
+++ b/src/app/api/bank-credentials/route.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { GET, createGetBankCredentialsHandler } from "./route";
+import type { BankCredentialsHandlerDeps } from "./route";
+import type { BankCredentialMetadata } from "../../../modules/bank-credentials/repository";
+
+function adminHeaders(): Record<string, string> {
+  return { "x-rd-sync-user-id": "admin-1", "x-rd-sync-role": "admin" };
+}
+
+function makeRequest(path: string, headers: Record<string, string> = {}): Request {
+  return new Request(`http://localhost:3000${path}`, { headers });
+}
+
+function makeHandler(metadata: BankCredentialMetadata | null = null) {
+  const service: BankCredentialsHandlerDeps["service"] = {
+    getMetadata: vi.fn().mockResolvedValue(metadata),
+  };
+
+  return {
+    service,
+    handler: createGetBankCredentialsHandler({ service }),
+  };
+}
+
+function clearDefaultCredentialServiceSingletons(): void {
+  delete (globalThis as {
+    __rdSyncBankCredentialService?: unknown;
+    __rdSyncPrismaClient?: unknown;
+  }).__rdSyncBankCredentialService;
+  delete (globalThis as {
+    __rdSyncBankCredentialService?: unknown;
+    __rdSyncPrismaClient?: unknown;
+  }).__rdSyncPrismaClient;
+}
+
+function serializedConsoleCalls(spy: { mock: { calls: unknown[] } }): string {
+  return JSON.stringify(spy.mock.calls);
+}
+
+async function withDatabaseUrlUnset(act: () => Promise<void>): Promise<void> {
+  const originalDatabaseUrl = process.env.DATABASE_URL;
+  delete process.env.DATABASE_URL;
+  clearDefaultCredentialServiceSingletons();
+  try {
+    await act();
+  } finally {
+    if (originalDatabaseUrl === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = originalDatabaseUrl;
+    clearDefaultCredentialServiceSingletons();
+  }
+}
+
+describe("GET /api/bank-credentials", () => {
+  beforeEach(() => {
+    process.env.RD_SYNC_TRUST_PROXY_HEADERS = "enabled";
+  });
+
+  afterEach(() => {
+    delete process.env.RD_SYNC_TRUST_PROXY_HEADERS;
+    vi.restoreAllMocks();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const { handler } = makeHandler();
+
+    const res = await handler(makeRequest("/api/bank-credentials?bankCode=popular"));
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when caller is not an admin", async () => {
+    const { handler } = makeHandler();
+
+    const res = await handler(makeRequest("/api/bank-credentials?bankCode=popular", {
+      "x-rd-sync-user-id": "viewer-1",
+      "x-rd-sync-role": "viewer",
+    }));
+
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 when bankCode is missing", async () => {
+    const { handler } = makeHandler();
+
+    const res = await handler(makeRequest("/api/bank-credentials", adminHeaders()));
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns metadata without secret fields", async () => {
+    const metadata = {
+      bankCode: "popular",
+      isActive: true,
+      keyVersion: 1,
+      lastRotatedAt: null,
+    } satisfies BankCredentialMetadata;
+    const { handler, service } = makeHandler(metadata);
+
+    const res = await handler(makeRequest("/api/bank-credentials?bankCode=popular", adminHeaders()));
+    const body = await res.json();
+    const serialized = JSON.stringify(body);
+
+    expect(res.status).toBe(200);
+    expect(service.getMetadata).toHaveBeenCalledWith("popular");
+    expect(body).toEqual(metadata);
+    expect(serialized).not.toContain("username");
+    expect(serialized).not.toContain("password");
+    expect(serialized).not.toContain("ciphertext");
+    expect(serialized).not.toContain("encrypted");
+    expect(serialized).not.toContain("keyMaterial");
+    expect(serialized).not.toContain("audit");
+  });
+
+  it("returns 404 when credentials are not configured", async () => {
+    const { handler } = makeHandler(null);
+
+    const res = await handler(makeRequest("/api/bank-credentials?bankCode=popular", adminHeaders()));
+
+    expect(res.status).toBe(404);
+  });
+
+  it("masks service errors", async () => {
+    const { handler, service } = makeHandler();
+    vi.mocked(service.getMetadata).mockRejectedValue(
+      new Error("SENSITIVE_DIAGNOSTIC_SENTINEL"),
+    );
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const res = await handler(makeRequest("/api/bank-credentials?bankCode=popular", adminHeaders()));
+    const body = await res.json();
+    const serialized = JSON.stringify(body);
+    const logs = serializedConsoleCalls(consoleSpy);
+
+    expect(res.status).toBe(503);
+    expect(body).toEqual({ error: "Unable to retrieve credential metadata" });
+    expect(serialized).not.toContain("SENSITIVE_DIAGNOSTIC_SENTINEL");
+    expect(logs).toContain("GET /api/bank-credentials");
+    expect(logs).toContain("popular");
+    expect(logs).not.toContain("SENSITIVE_DIAGNOSTIC_SENTINEL");
+    expect(logs).not.toContain("message");
+    expect(logs).not.toContain("stack");
+  });
+
+  it("does not construct default deps before authz or bankCode validation", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    await withDatabaseUrlUnset(async () => {
+      await expect(GET(makeRequest("/api/bank-credentials?bankCode=popular")))
+        .resolves.toHaveProperty("status", 401);
+      await expect(GET(makeRequest("/api/bank-credentials", adminHeaders())))
+        .resolves.toHaveProperty("status", 400);
+      expect(consoleSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  it("masks default dependency construction failures", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    await withDatabaseUrlUnset(async () => {
+      const res = await GET(makeRequest("/api/bank-credentials?bankCode=popular", adminHeaders()));
+      const body = await res.json();
+      const logs = serializedConsoleCalls(consoleSpy);
+
+      expect(res.status).toBe(503);
+      expect(body).toEqual({ error: "Unable to retrieve credential metadata" });
+      expect(logs).toContain("GET /api/bank-credentials");
+      expect(logs).toContain("popular");
+      expect(logs).not.toContain("DATABASE_URL");
+      expect(logs).not.toContain("PostgreSQL");
+      expect(logs).not.toContain("connection string");
+      expect(logs).not.toContain("message");
+      expect(logs).not.toContain("stack");
+    });
+  });
+});

--- a/src/app/api/bank-credentials/route.ts
+++ b/src/app/api/bank-credentials/route.ts
@@ -1,0 +1,111 @@
+import { resolvePrincipal, requireRole } from "../../../modules/auth";
+import type { BankCredentialService } from "../../../modules/bank-credentials/service";
+import { getDefaultBankCredentialService } from "./defaults";
+
+export interface BankCredentialsHandlerDeps {
+  service: Pick<BankCredentialService, "getMetadata">;
+}
+
+function getDefaultDeps(): BankCredentialsHandlerDeps {
+  return {
+    service: getDefaultBankCredentialService(),
+  };
+}
+
+export function createGetBankCredentialsHandler(deps?: BankCredentialsHandlerDeps) {
+  return async function getBankCredentials(request: Request): Promise<Response> {
+    const principal = resolvePrincipal(request);
+
+    try {
+      requireRole(principal, ["admin"]);
+    } catch {
+      return Response.json(
+        { error: principal ? "Forbidden" : "Authentication required" },
+        { status: principal ? 403 : 401 },
+      );
+    }
+
+    const url = new URL(request.url);
+    const bankCode = url.searchParams.get("bankCode");
+
+    if (!bankCode || !bankCode.trim()) {
+      return Response.json(
+        { error: "bankCode query parameter is required" },
+        { status: 400 },
+      );
+    }
+
+    const trimmedBankCode = bankCode.trim();
+    let d = deps;
+
+    if (!d) {
+      try {
+        d = getDefaultDeps();
+      } catch (error) {
+        logGetCredentialMetadataFailure(trimmedBankCode, error);
+        return Response.json(
+          { error: "Unable to retrieve credential metadata" },
+          { status: 503 },
+        );
+      }
+    }
+
+    try {
+      const metadata = await d.service.getMetadata(trimmedBankCode);
+
+      if (!metadata) {
+        return Response.json(
+          { error: "No credentials configured for this bank" },
+          { status: 404 },
+        );
+      }
+
+      return Response.json(metadata);
+    } catch (error) {
+      logGetCredentialMetadataFailure(trimmedBankCode, error);
+      return Response.json(
+        { error: "Unable to retrieve credential metadata" },
+        { status: 503 },
+      );
+    }
+  };
+}
+
+function logGetCredentialMetadataFailure(bankCode: string, error: unknown): void {
+  console.error("[bank-credentials] GET failed", {
+    route: "GET /api/bank-credentials",
+    bankCode,
+    error: getSafeErrorDiagnostic(error),
+  });
+}
+
+function getSafeErrorDiagnostic(error: unknown): { name?: string; code?: string } {
+  const diagnostic: { name?: string; code?: string } = {};
+
+  if (error instanceof Error && isSafeDiagnosticToken(error.name)) {
+    diagnostic.name = error.name;
+  }
+
+  const code = getErrorCode(error);
+  if (code !== undefined && isSafeDiagnosticToken(code)) {
+    diagnostic.code = code;
+  }
+
+  return diagnostic;
+}
+
+function getErrorCode(error: unknown): string | undefined {
+  if (typeof error !== "object" || error === null || !("code" in error)) return undefined;
+
+  const code = (error as { code?: unknown }).code;
+  if (typeof code === "string" || typeof code === "number") return String(code);
+
+  return undefined;
+}
+
+function isSafeDiagnosticToken(value: string): boolean {
+  return /^[A-Za-z][A-Za-z0-9_.:-]{0,63}$/.test(value)
+    && !/(secret|token|key|password|credential|database|url|uri|connection)/i.test(value);
+}
+
+export const GET = createGetBankCredentialsHandler();

--- a/src/modules/audit/bank-actions.ts
+++ b/src/modules/audit/bank-actions.ts
@@ -1,0 +1,46 @@
+/**
+ * Canonical audit action constants for bank credential, auto-login,
+ * circuit breaker, kill-switch, adapter, and session domains.
+ *
+ * All bank-related audit events MUST use these exact string values.
+ * Shorthand like bare "disabled" is prohibited — it is ambiguous between
+ * kill-switch and adapter toggle.
+ *
+ * @see specs/multi-bank-auto-login/spec.md — Canonical Audit Action Table
+ */
+
+export const BANK_CREDENTIAL_ACTIONS = {
+  SET: "bank_credential.set",
+  ROTATE: "bank_credential.rotate",
+  TEST: "bank_credential.test",
+  DECRYPT_USE: "bank_credential.decrypt_use",
+} as const;
+
+export const BANK_AUTOLOGIN_ACTIONS = {
+  ATTEMPTED: "bank_autologin.attempted",
+  SUCCEEDED: "bank_autologin.succeeded",
+  FAILED: "bank_autologin.failed",
+  SKIPPED: "bank_autologin.skipped",
+  NEEDS_ADMIN_ACTION: "bank_autologin.needs_admin_action",
+} as const;
+
+export const BANK_BREAKER_ACTIONS = {
+  OPENED: "bank_breaker.opened",
+  RESET: "bank_breaker.reset",
+} as const;
+
+export const BANK_KILLSWITCH_ACTIONS = {
+  AUTO_LOGIN_ENABLED: "bank_killswitch.auto_login_enabled",
+  AUTO_LOGIN_DISABLED: "bank_killswitch.auto_login_disabled",
+} as const;
+
+export const BANK_ADAPTER_ACTIONS = {
+  ENABLED: "bank_adapter.enabled",
+  DISABLED: "bank_adapter.disabled",
+} as const;
+
+export const BANK_SESSION_ACTIONS = {
+  EXPIRED: "bank_session.expired",
+  RESTORED: "bank_session.restored",
+  UNAVAILABLE: "bank_session.unavailable",
+} as const;

--- a/src/modules/bank-credentials/service.ts
+++ b/src/modules/bank-credentials/service.ts
@@ -1,12 +1,9 @@
 import { decryptCredentialField, encryptCredentialField, type AesGcmEnvelope, type KeyResolver } from "./crypto";
 import { BankCredentialRepository, type BankCredentialMetadata } from "./repository";
 import { createAuditEvent, type AuditSink } from "../audit";
+import { BANK_CREDENTIAL_ACTIONS } from "../audit/bank-actions";
 
-export const CREDENTIAL_AUDIT_ACTIONS = {
-  SET: "bank_credential.set",
-  ROTATE: "bank_credential.rotate",
-  TEST: "bank_credential.test",
-} as const;
+export { BANK_CREDENTIAL_ACTIONS as CREDENTIAL_AUDIT_ACTIONS } from "../audit/bank-actions";
 
 export const CURRENT_CREDENTIAL_WRITE_KEY_VERSION = 1;
 export const NO_STORED_CREDENTIAL_KEY_VERSION = 0;
@@ -41,7 +38,7 @@ export class BankCredentialService {
     const usernameEnvelope = encryptCredentialField(input.username, this.deps.keyResolver, keyVersion);
     const passwordEnvelope = encryptCredentialField(input.password, this.deps.keyResolver, keyVersion);
     await this.emitAudit({
-      action: existing ? CREDENTIAL_AUDIT_ACTIONS.ROTATE : CREDENTIAL_AUDIT_ACTIONS.SET,
+      action: existing ? BANK_CREDENTIAL_ACTIONS.ROTATE : BANK_CREDENTIAL_ACTIONS.SET,
       bankCode: input.bankCode,
       keyVersion,
       actorId,
@@ -89,7 +86,7 @@ export class BankCredentialService {
   }
 
   private async emitTestAudit(bankCode: string, keyVersion: number, actorId: string, outcome: CredentialTestResult["outcome"]): Promise<void> {
-    await this.emitAudit({ action: CREDENTIAL_AUDIT_ACTIONS.TEST, bankCode, keyVersion, actorId, outcome });
+    await this.emitAudit({ action: BANK_CREDENTIAL_ACTIONS.TEST, bankCode, keyVersion, actorId, outcome });
   }
 
   private async emitAudit(input: { action: string; bankCode: string; keyVersion: number; actorId: string; outcome?: CredentialTestResult["outcome"] }): Promise<void> {


### PR DESCRIPTION
## Chain Context

```text
backend/popular-vps-session-orchestration
 └── feature/multi-bank-auto-login          ← tracker branch
      ├── ✅ PR #1 adapter registry (merged)
      ├── ✅ PR #2 browser/CDP isolation (merged)
      ├── ✅ PR #3 browser backpressure / PR2B (merged)
      ├── ✅ PR #4 admin scrape-runs build fix (merged)
      ├── ✅ PR #5 credential vault core / PR3A (merged)
      ├── ✅ PR #6 credential service foundation / PR3B1 (merged)
      └── 📍 feature/multi-bank-auto-login-pr3b2-credential-routes (this PR — PR3B2A)
           └── PR3B2B: POST set/rotate/test credential routes (next)
           └── PR4: auto-login Popular (later, high risk)
```

Base for this PR: `feature/multi-bank-auto-login` (tracker), not `main`.

## Summary

- Adds admin-only `GET /api/bank-credentials` for credential metadata.
- Returns flat metadata only: `bankCode`, `isActive`, `keyVersion`, `lastRotatedAt`.
- Masks service/default dependency failures with safe 503 responses.
- Delays default dependency construction until after authz and input validation.
- Adds canonical bank audit action constants and wires credential service to them.

## Non-goals / Deferred

- No POST set/rotate/test routes yet (PR3B2B).
- No UI.
- No auto-login credential use.
- No worker decrypt path.
- No MFA/Imperva automation or bypass.

## Verification

- [x] `pnpm test` — 774 passed / 38 skipped
- [x] `pnpm lint` — exit 0
- [x] `pnpm typecheck` — exit 0
- [x] `pnpm build` — exit 0
- [x] `git diff --check` — exit 0; CRLF advisories only
- [x] Fresh 4R review → blockers fixed
- [x] Fresh 4R final → no blocking findings
- [x] Judgment Day dual review → Judge A APPROVE, Judge B APPROVE; no CRITICAL or real WARNING findings

## Judgment Day Result

`JUDGMENT: APPROVED ✅`

INFO follow-up:
- Add whitespace/trim-specific `bankCode` tests in PR3B2B if touching route validation again.

## Review Budget

- Diff: 386 insertions / 12 deletions = 398 changed lines.
- Under the 400-line budget.

## Rollback

Revert this PR to remove the metadata GET route and canonical audit action constants. PR3A/PR3B1 credential core remains available but no HTTP credential metadata endpoint exists.