### PR TITLE
feat(credentials): add credential mutation route

### DIFF
--- a/openspec/changes/multi-bank-auto-login/design.md
+++ b/openspec/changes/multi-bank-auto-login/design.md
@@ -171,7 +171,7 @@ State machine: `expired(scrape-time, expiredEventId) -> adapterEnabled? scraping
 
 ## Admin API/UI Surfaces
 
-`POST /api/bank-credentials` (set/rotate, `requireCapability('bankCredentials.manage')`, rate-limited), `POST .../test` (dry decrypt + ensureBrowser probe, never echoes value), `GET ...` (returns `{ bankCode, isActive, keyVersion, lastRotatedAt }` — NO ciphertext/plaintext). Kill-switch/breaker endpoints: `PATCH /api/bank-credentials/:bankCode/auto-login` (`autoLoginEnabled`), `POST .../reset-breaker`. Adapter toggle: `PATCH /api/bank-credentials/:bankCode/adapter` (`scrapingEnabled`). UI confirms "Credenciales actualizadas" / "Auto-login desactivado" / "Adaptador desactivado" (professional Spanish) without echoing values. 401/403/400/429/503 safe categorization matches `run-now/route.ts`.
+`POST /api/bank-credentials` accepts `action: "set" | "rotate" | "test"` (set/rotate mutate credentials; test dry-decrypts via `validateStoredCredentialDecryption`; never echoes values; rate-limited and admin-gated via `requireRole`). `GET ...` returns `{ bankCode, isActive, keyVersion, lastRotatedAt }` — NO ciphertext/plaintext. Kill-switch/breaker endpoints: `PATCH /api/bank-credentials/:bankCode/auto-login` (`autoLoginEnabled`), `POST .../reset-breaker`. Adapter toggle: `PATCH /api/bank-credentials/:bankCode/adapter` (`scrapingEnabled`). UI confirms "Credenciales actualizadas" / "Auto-login desactivado" / "Adaptador desactivado" (professional Spanish) without echoing values. 401/403/400/429/503 safe categorization matches `run-now/route.ts`.
 
 ## Audit Integration
 

--- a/openspec/changes/multi-bank-auto-login/tasks.md
+++ b/openspec/changes/multi-bank-auto-login/tasks.md
@@ -80,10 +80,10 @@ Tracker branch `feature/multi-bank-auto-login` (base = current/main per repo con
 - [x] 3.5b-a Admin API tests (TDD): focused GET tests covering authz (401/403), metadata success, no secret fields, missing metadata (404), and safe error masking (503).
 - [x] 3.6 Create `src/modules/audit/bank-actions.ts`: canonical audit action constants for bank credential/auto-login/breaker/killswitch/adapter/session domains.
 
-**PR3B2B (admin route mutation/test slice, deferred):**
-- [ ] 3.3b Add POST set/rotate route with `InMemoryRateLimiter` 10/min, `requireRole(principal, ["admin"])`, safe errors, credential mutation through `BankCredentialService.setOrRotate`, and Spanish success message: "Credenciales actualizadas".
-- [ ] 3.3c Add POST test route with `InMemoryRateLimiter` 10/min, `requireRole(principal, ["admin"])`, dry decrypt via `validateStoredCredentialDecryption`, and no credential echo.
-- [ ] 3.5b-b Add POST tests for authz, validation, rate limit (429), set/rotate/test success paths, service error masking (503), no plaintext/ciphertext/envelope echo, and credential service call contracts.
+**PR3B2B (admin route mutation/test slice):**
+- [x] 3.3b Add POST set/rotate route with `InMemoryRateLimiter` 10/min, `requireRole(principal, ["admin"])`, safe errors, credential mutation through `BankCredentialService.setOrRotate`, and Spanish success message: "Credenciales actualizadas".
+- [x] 3.3c Add action-based POST test path (`POST /api/bank-credentials` with `action: "test"`) with `InMemoryRateLimiter` 10/min, `requireRole(principal, ["admin"])`, dry decrypt via `validateStoredCredentialDecryption`, and no credential echo.
+- [x] 3.5b-b Add POST tests for authz, validation, rate limit (429), set/rotate/test success paths, service error masking (503), no plaintext/ciphertext/envelope echo, and credential service call contracts.
 
 Gate: full gates + FRESH 4R review + Judgment Day before merge; PR3B1 <=400 lines (merged); PR3B2A <=400 total changed lines; PR3B2B <=400 total changed lines; NO auto-login, NO decrypt_use outside test.
 

--- a/src/app/api/bank-credentials/route.test.ts
+++ b/src/app/api/bank-credentials/route.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { GET, createGetBankCredentialsHandler } from "./route";
-import type { BankCredentialsHandlerDeps } from "./route";
+import { GET, POST, createGetBankCredentialsHandler, createPostBankCredentialsHandler } from "./route";
+import type { GetBankCredentialsHandlerDeps, PostBankCredentialsHandlerDeps } from "./route";
 import type { BankCredentialMetadata } from "../../../modules/bank-credentials/repository";
+import { InMemoryRateLimiter, type RateLimiter } from "../../../modules/auth/rate-limiter";
 
 function adminHeaders(): Record<string, string> {
   return { "x-rd-sync-user-id": "admin-1", "x-rd-sync-role": "admin" };
@@ -13,9 +14,9 @@ function makeRequest(path: string, headers: Record<string, string> = {}): Reques
 }
 
 function makeHandler(metadata: BankCredentialMetadata | null = null) {
-  const service: BankCredentialsHandlerDeps["service"] = {
+  const service = {
     getMetadata: vi.fn().mockResolvedValue(metadata),
-  };
+  } satisfies GetBankCredentialsHandlerDeps["service"];
 
   return {
     service,
@@ -171,6 +172,241 @@ describe("GET /api/bank-credentials", () => {
       expect(logs).not.toContain("connection string");
       expect(logs).not.toContain("message");
       expect(logs).not.toContain("stack");
+    });
+  });
+});
+
+function passThroughRateLimiter(): RateLimiter {
+  return { check: () => ({ allowed: true }), recordFailure: () => undefined };
+}
+
+function trackingRateLimiter(): RateLimiter & { calls: string[] } {
+  const calls: string[] = [];
+  return {
+    calls,
+    check: (key: string) => { calls.push(`check:${key}`); return { allowed: true }; },
+    recordFailure: (key: string) => { calls.push(`fail:${key}`); },
+  };
+}
+
+function postBody(body: unknown, headers: Record<string, string> = adminHeaders()): Request {
+  return new Request("http://localhost:3000/api/bank-credentials", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+function makePostHandler(
+  serviceOverrides: Partial<PostBankCredentialsHandlerDeps["service"]> = {},
+  rateLimiter: RateLimiter = passThroughRateLimiter(),
+) {
+  const service: PostBankCredentialsHandlerDeps["service"] = {
+    setOrRotate: vi.fn().mockResolvedValue({ bankCode: "popular", keyVersion: 1, action: "set" }),
+    validateStoredCredentialDecryption: vi.fn().mockResolvedValue({ bankCode: "popular", outcome: "decrypted" }),
+    ...serviceOverrides,
+  };
+
+  return { service, handler: createPostBankCredentialsHandler({ service, rateLimiter }) };
+}
+
+describe("POST /api/bank-credentials", () => {
+  beforeEach(() => {
+    process.env.RD_SYNC_TRUST_PROXY_HEADERS = "enabled";
+  });
+
+  afterEach(() => {
+    delete process.env.RD_SYNC_TRUST_PROXY_HEADERS;
+    vi.restoreAllMocks();
+  });
+
+  it.each([{ headers: {} as Record<string, string>, status: 401 }, { headers: { "x-rd-sync-user-id": "viewer-1", "x-rd-sync-role": "viewer" }, status: 403 }])(
+    "rejects POST caller without admin access ($status)", async ({ headers, status }) => {
+      const { handler } = makePostHandler();
+      const res = await handler(postBody({ bankCode: "popular", action: "set", username: "u", password: "p" }, headers));
+      expect(res.status).toBe(status);
+    });
+
+  it("rate-limits POST attempts per actor and resets after the window", async () => {
+    let now = 1_000;
+    const limiter = new InMemoryRateLimiter({ maxAttempts: 10, windowMs: 60_000, clock: () => now });
+    const { handler } = makePostHandler({}, limiter);
+
+    for (let i = 0; i < 10; i += 1) {
+      await expect(handler(postBody({ bankCode: "popular", action: "test" }))).resolves.toHaveProperty("status", 200);
+    }
+    const blocked = await handler(postBody({ bankCode: "popular", action: "test" }));
+    const otherActor = await handler(postBody({ bankCode: "popular", action: "test" }, { "x-rd-sync-user-id": "admin-2", "x-rd-sync-role": "admin" }));
+
+    now += 60_000;
+    const reset = await handler(postBody({ bankCode: "popular", action: "test" }));
+
+    expect(blocked.status).toBe(429);
+    expect(blocked.headers.get("Retry-After")).toBe("60");
+    expect(otherActor.status).toBe(200);
+    expect(reset.status).toBe(200);
+  });
+
+  it("rate-limits concurrent POST attempts before service resolves", async () => {
+    const limiter = new InMemoryRateLimiter({ maxAttempts: 10, windowMs: 60_000, clock: () => 1_000 });
+    let release!: (value: { bankCode: string; outcome: "decrypted" }) => void;
+    const gate = new Promise<{ bankCode: string; outcome: "decrypted" }>((resolve) => { release = resolve; });
+    const { handler, service } = makePostHandler({
+      validateStoredCredentialDecryption: vi.fn(() => gate),
+    }, limiter);
+
+    const attempts = Array.from({ length: 11 }, () => handler(postBody({ bankCode: "popular", action: "test" })));
+    const blocked = await attempts[10];
+    release({ bankCode: "popular", outcome: "decrypted" });
+
+    expect(blocked.status).toBe(429);
+    expect((await Promise.all(attempts.slice(0, 10))).map((res) => res.status)).toEqual(Array(10).fill(200));
+    expect(service.validateStoredCredentialDecryption).toHaveBeenCalledTimes(10);
+  });
+
+  it("returns 400 when body is not valid JSON", async () => {
+    const { handler } = makePostHandler();
+    const res = await handler(new Request("http://localhost:3000/api/bank-credentials", {
+      method: "POST",
+      headers: { "content-type": "application/json", ...adminHeaders() },
+      body: "not-json",
+    }));
+    expect(res.status).toBe(400);
+  });
+
+  it.each([null, [], "primitive", 7, true])(
+    "returns 400 and records an attempt for invalid JSON shape %#",
+    async (body) => {
+      const limiter = trackingRateLimiter();
+      const { handler, service } = makePostHandler({}, limiter);
+
+      const res = await handler(postBody(body));
+
+      expect(res.status).toBe(400);
+      expect(service.setOrRotate).not.toHaveBeenCalled();
+      expect(limiter.calls).toEqual(["check:post:admin-1", "fail:post:admin-1"]);
+    },
+  );
+
+  it.each([
+    { action: "set", username: "u", password: "p" },
+    { bankCode: "popular", username: "u", password: "p" },
+    { bankCode: "popular", action: "delete" },
+    { bankCode: "popular", action: "set", password: "p" },
+    { bankCode: "popular", action: "rotate", username: "u" },
+    { username: {}, password: "p" },
+    { username: "u", password: [] },
+    { username: 123, password: "p" },
+    { username: "u", password: false },
+    { username: "   ", password: "p" },
+    { username: "u", password: "   " },
+  ])("rejects invalid POST body %#", async (body) => {
+    const { handler, service } = makePostHandler();
+    const payload = "bankCode" in body || "action" in body
+      ? body
+      : { bankCode: "popular", action: "set", ...body };
+    const res = await handler(postBody(payload));
+
+    expect(res.status).toBe(400);
+    expect(service.setOrRotate).not.toHaveBeenCalled();
+  });
+
+  it.each(["set", "rotate"] as const)("returns success for %s action", async (action) => {
+    const { handler, service } = makePostHandler({
+      setOrRotate: vi.fn().mockResolvedValue({ bankCode: "popular", keyVersion: 1, action }),
+    });
+
+    const res = await handler(postBody({ bankCode: "popular", action, username: "user", password: "pass" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(service.setOrRotate).toHaveBeenCalledWith({ bankCode: "popular", username: "user", password: "pass" }, "admin-1");
+    expect(body).toEqual({ message: "Credenciales actualizadas", bankCode: "popular", action, keyVersion: 1 });
+  });
+
+  it("returns success for test action", async () => {
+    const { handler, service } = makePostHandler();
+
+    const res = await handler(postBody({ bankCode: "popular", action: "test" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(service.validateStoredCredentialDecryption).toHaveBeenCalledWith("popular", "admin-1");
+    expect(body).toEqual({ bankCode: "popular", outcome: "decrypted" });
+  });
+
+  it("does not echo credential material in responses", async () => {
+    const { handler } = makePostHandler();
+    const res1 = await handler(postBody({ bankCode: "popular", action: "set", username: "secret-user", password: "secret-pass" }));
+    const s1 = JSON.stringify(await res1.json());
+    expect(s1).not.toContain("secret-user");
+    expect(s1).not.toContain("secret-pass");
+    expect(s1).not.toContain("username");
+    expect(s1).not.toContain("password");
+    expect(s1).not.toContain("ciphertext");
+    expect(s1).not.toContain("envelope");
+
+    const res2 = await handler(postBody({ bankCode: "popular", action: "test" }));
+    const s2 = JSON.stringify(await res2.json());
+    expect(s2).not.toContain("username");
+    expect(s2).not.toContain("password");
+    expect(s2).not.toContain("ciphertext");
+    expect(s2).not.toContain("envelope");
+    expect(s2).not.toContain("keyMaterial");
+  });
+
+  it("masks service errors", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const { handler: setHandler } = makePostHandler({
+      setOrRotate: vi.fn().mockRejectedValue(new Error("DB connection lost")),
+    });
+    const res1 = await setHandler(postBody({ bankCode: "popular", action: "set", username: "u", password: "p" }));
+    const body1 = await res1.json();
+    expect(res1.status).toBe(503);
+    expect(body1.error).toBe("Unable to process credential request");
+    expect(JSON.stringify(body1)).not.toContain("DB connection lost");
+
+    const { handler: testHandler } = makePostHandler({
+      validateStoredCredentialDecryption: vi.fn().mockRejectedValue(new Error("SENSITIVE")),
+    });
+    const res2 = await testHandler(postBody({ bankCode: "popular", action: "test" }));
+    const body2 = await res2.json();
+    expect(res2.status).toBe(503);
+    expect(JSON.stringify(body2)).not.toContain("SENSITIVE");
+  });
+
+  it("does not construct default deps before authz", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    await withDatabaseUrlUnset(async () => {
+      const req = new Request("http://localhost:3000/api/bank-credentials", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ bankCode: "popular", action: "test" }),
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(401);
+      expect(consoleSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  it.each([
+    { action: "set", username: "u", password: "p" },
+    { action: "test" },
+  ])("masks default dependency failures for valid $action POST", async (body) => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    await withDatabaseUrlUnset(async () => {
+      const res = await POST(postBody({ bankCode: "popular", ...body }));
+      const response = JSON.stringify(await res.json());
+      const logs = serializedConsoleCalls(consoleSpy);
+
+      expect(res.status).toBe(503);
+      expect(response).toBe(JSON.stringify({ error: "Service unavailable" }));
+      for (const unsafe of ["DATABASE_URL", "PostgreSQL", "connection string", "message", "stack"]) {
+        expect(response).not.toContain(unsafe);
+        expect(logs).not.toContain(unsafe);
+      }
     });
   });
 });

--- a/src/app/api/bank-credentials/route.ts
+++ b/src/app/api/bank-credentials/route.ts
@@ -1,18 +1,19 @@
 import { resolvePrincipal, requireRole } from "../../../modules/auth";
+import type { RateLimiter } from "../../../modules/auth/rate-limiter";
+import { InMemoryRateLimiter } from "../../../modules/auth/rate-limiter";
 import type { BankCredentialService } from "../../../modules/bank-credentials/service";
 import { getDefaultBankCredentialService } from "./defaults";
 
-export interface BankCredentialsHandlerDeps {
+export interface GetBankCredentialsHandlerDeps {
   service: Pick<BankCredentialService, "getMetadata">;
 }
 
-function getDefaultDeps(): BankCredentialsHandlerDeps {
-  return {
-    service: getDefaultBankCredentialService(),
-  };
+export interface PostBankCredentialsHandlerDeps {
+  service: Pick<BankCredentialService, "setOrRotate" | "validateStoredCredentialDecryption">;
+  rateLimiter?: RateLimiter;
 }
 
-export function createGetBankCredentialsHandler(deps?: BankCredentialsHandlerDeps) {
+export function createGetBankCredentialsHandler(deps?: GetBankCredentialsHandlerDeps) {
   return async function getBankCredentials(request: Request): Promise<Response> {
     const principal = resolvePrincipal(request);
 
@@ -36,11 +37,11 @@ export function createGetBankCredentialsHandler(deps?: BankCredentialsHandlerDep
     }
 
     const trimmedBankCode = bankCode.trim();
-    let d = deps;
+    let resolvedDeps = deps;
 
-    if (!d) {
+    if (!resolvedDeps) {
       try {
-        d = getDefaultDeps();
+        resolvedDeps = { service: getDefaultBankCredentialService() };
       } catch (error) {
         logGetCredentialMetadataFailure(trimmedBankCode, error);
         return Response.json(
@@ -51,7 +52,7 @@ export function createGetBankCredentialsHandler(deps?: BankCredentialsHandlerDep
     }
 
     try {
-      const metadata = await d.service.getMetadata(trimmedBankCode);
+      const metadata = await resolvedDeps.service.getMetadata(trimmedBankCode);
 
       if (!metadata) {
         return Response.json(
@@ -109,3 +110,122 @@ function isSafeDiagnosticToken(value: string): boolean {
 }
 
 export const GET = createGetBankCredentialsHandler();
+
+type PostAction = "set" | "rotate" | "test";
+
+const POST_RATE_LIMIT_MAX_ATTEMPTS = 10;
+const POST_RATE_LIMIT_WINDOW_MS = 60_000;
+
+const defaultPostRateLimiter = new InMemoryRateLimiter({ maxAttempts: POST_RATE_LIMIT_MAX_ATTEMPTS, windowMs: POST_RATE_LIMIT_WINDOW_MS });
+
+export function createPostBankCredentialsHandler(deps?: PostBankCredentialsHandlerDeps) {
+  return async function postBankCredentials(request: Request): Promise<Response> {
+    const principal = resolvePrincipal(request);
+
+    try {
+      requireRole(principal, ["admin"]);
+    } catch {
+      return Response.json({ error: principal ? "Forbidden" : "Authentication required" }, { status: principal ? 403 : 401 });
+    }
+
+    const rateLimiter = deps?.rateLimiter ?? defaultPostRateLimiter;
+    const rateKey = `post:${principal!.id}`;
+    const rateResult = rateLimiter.check(rateKey);
+
+    if (!rateResult.allowed) {
+      const headers = rateResult.retryAfterSeconds ? { "Retry-After": String(rateResult.retryAfterSeconds) } : undefined;
+      return Response.json({ error: "Rate limit exceeded" }, { status: 429, headers });
+    }
+
+    recordPostAttempt(rateLimiter, rateKey);
+
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+
+    if (!isPostBody(body)) {
+      return Response.json({ error: "Invalid request body" }, { status: 400 });
+    }
+
+    const bankCode = typeof body.bankCode === "string" ? body.bankCode.trim() : "";
+    const action = typeof body.action === "string" ? body.action.trim() : "";
+
+    if (!bankCode) {
+      return Response.json({ error: "bankCode is required" }, { status: 400 });
+    }
+
+    if (!action || !isPostAction(action)) {
+      return Response.json({ error: "action is required (set, rotate, or test)" }, { status: 400 });
+    }
+
+    const username = body.username;
+    const password = body.password;
+    let credentialInput: { username: string; password: string } | undefined;
+
+    if (action === "set" || action === "rotate") {
+      if (!isNonBlankString(username) || !isNonBlankString(password)) {
+        return Response.json({ error: "username and password are required for set/rotate" }, { status: 400 });
+      }
+      credentialInput = { username, password };
+    }
+
+    let resolvedDeps = deps;
+    if (!resolvedDeps) {
+      try {
+        resolvedDeps = { service: getDefaultBankCredentialService() };
+      } catch (error) {
+        logPostFailure(bankCode, action, error);
+        return Response.json({ error: "Service unavailable" }, { status: 503 });
+      }
+    }
+
+    try {
+      if (credentialInput) {
+        const result = await resolvedDeps.service.setOrRotate({ bankCode, ...credentialInput }, principal!.id);
+        return Response.json({
+          message: "Credenciales actualizadas",
+          bankCode: result.bankCode,
+          action: result.action,
+          keyVersion: result.keyVersion,
+        });
+      }
+
+      // action === "test"
+      const result = await resolvedDeps.service.validateStoredCredentialDecryption(bankCode, principal!.id);
+      return Response.json(result);
+    } catch (error) {
+      logPostFailure(bankCode, action, error);
+      return Response.json({ error: "Unable to process credential request" }, { status: 503 });
+    }
+  };
+}
+
+function isPostAction(value: string): value is PostAction {
+  return value === "set" || value === "rotate" || value === "test";
+}
+
+function isPostBody(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNonBlankString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function recordPostAttempt(rateLimiter: RateLimiter, rateKey: string): void {
+  rateLimiter.recordFailure(rateKey);
+}
+
+function logPostFailure(bankCode: string, action: string, error: unknown): void {
+  console.error("[bank-credentials] POST failed", {
+    route: "POST /api/bank-credentials",
+    bankCode,
+    action,
+    error: getSafeErrorDiagnostic(error),
+  });
+}
+
+export const POST = createPostBankCredentialsHandler();


### PR DESCRIPTION
## Summary
- Adds admin-only POST /api/bank-credentials with action-based set, rotate, and test flows.
- Rate-limits POST credential attempts and records attempts before async work to block concurrent bypasses.
- Updates SDD/OpenSpec bridge tasks and design to match the action-based contract.

## Verification
- [x] Judgment Day: approved by both blind judges; no CRITICAL or real WARNING findings.
- [x] pnpm test — 803 passed / 38 skipped.
- [x] pnpm lint.
- [x] pnpm typecheck.
- [x] pnpm build.
- [x] git diff --check.

## Notes
- No credential material is echoed in responses.
- Dry decrypt test path never attempts bank login.
- This repo currently has no PR template, open approved issues, or type:* labels; this PR continues the multi-bank-auto-login tracker branch.