### PR TITLE
test(bank-adapters): add sanitized transaction fixtures

### DIFF
--- a/openspec/changes/multi-bank-auto-login/tasks.md
+++ b/openspec/changes/multi-bank-auto-login/tasks.md
@@ -102,6 +102,18 @@ Gate: full gates + FRESH 4R review + Judgment Day before merge; PR3B1 <=400 line
 
 ## PR5: Banreservas/BHD read-only adapters + portal drift fixtures (NO auto-login)
 
+### PR5A: Sanitized transaction fixtures (COMPLETE)
+
+- [x] 5A.1 Create `src/modules/bank-adapters/fixtures/types.ts`: raw transaction row types for BHD Personal, Banreservas Personas, Banreservas Empresas.
+- [x] 5A.2 Create `src/modules/bank-adapters/fixtures/bhd-personal.ts`: 2 sanitized BHD Personal transactions (credit + debit, RD$ amounts, DD/MM/YYYY, confirmation numbers).
+- [x] 5A.3 Create `src/modules/bank-adapters/fixtures/banreservas-personas.ts`: 2 sanitized Banreservas Personas transactions (credit + debit, pipe-separated reference, DD/MM/YYYY).
+- [x] 5A.4 Create `src/modules/bank-adapters/fixtures/banreservas-empresas.ts`: 2 sanitized Banreservas Empresas transactions (credit + debit, DD/MM/YY, DOP balance prefix).
+- [x] 5A.5 Create `src/modules/bank-adapters/fixtures/helpers.ts`: PII detection + text normalization helpers.
+- [x] 5A.6 Create `src/modules/bank-adapters/fixtures/__tests__/bank-transaction-fixtures.test.ts`: 36 tests — fixture loadability, field completeness, date formats, amount formats, credit/debit coverage, PII sanitization, RNC/IBAN/account number detection, no secrets.
+- Gate: pnpm test (36 pass) + pnpm typecheck + pnpm lint clean; 398 changed lines (under 400 budget).
+
+### PR5B: Read-only adapters + parsers (NEXT)
+
 - [ ] 5.1 Create `src/modules/bank-adapters/banreservas.ts` + `bhd.ts`: read-only `createScraper`+`createSessionChecker`+pure parsers; `createAutoLoginStrategy` stub (not enabled); portal configs from recon (open Q).
 - [ ] 5.2 Register banreservas/bhd in registry; add to `SUPPORTED_RUN_NOW_BANK_CODES` for read-only run-now (auto-login still gated off).
 - [ ] 5.3 Expand `src/worker/scraper/auto-login.portal-drift.test.ts`: Banreservas+BHD pre-submit incompatible-flow fixtures (assert NO fill/submit) + post-submit unknown-flow fixtures.

--- a/src/modules/bank-adapters/fixtures/__tests__/bank-transaction-fixtures.test.ts
+++ b/src/modules/bank-adapters/fixtures/__tests__/bank-transaction-fixtures.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, it } from "vitest";
+import { bhdPersonalTransactions, BHD_PERSONAL_BANK_CODE, BHD_PERSONAL_PORTAL_VARIANT } from "../bhd-personal";
+import { banreservasPersonasTransactions, BANRESERVAS_PERSONAS_BANK_CODE, BANRESERVAS_PERSONAS_PORTAL_VARIANT } from "../banreservas-personas";
+import { banreservasEmpresasTransactions, BANRESERVAS_EMPRESAS_BANK_CODE, BANRESERVAS_EMPRESAS_PORTAL_VARIANT } from "../banreservas-empresas";
+import { containsSensitiveData, normalizeFixtureText } from "../helpers";
+
+// ---------------------------------------------------------------------------
+// Per-bank fixture contracts
+// ---------------------------------------------------------------------------
+
+describe("BHD Personal transaction fixtures", () => {
+  it("has transactions with all required fields", () => {
+    expect(bhdPersonalTransactions.length).toBeGreaterThanOrEqual(1);
+    for (const tx of bhdPersonalTransactions) {
+      expect(typeof tx.date).toBe("string");
+      expect(tx.date.length).toBeGreaterThan(0);
+      expect(typeof tx.confirmationNumber).toBe("string");
+      expect(tx.confirmationNumber.length).toBeGreaterThan(0);
+      expect(typeof tx.description).toBe("string");
+      expect(tx.description.length).toBeGreaterThan(0);
+      expect(typeof tx.receipt).toBe("string");
+      expect(typeof tx.debit).toBe("string");
+      expect(typeof tx.credit).toBe("string");
+      expect(typeof tx.balance).toBe("string");
+    }
+  });
+
+  it("uses DD/MM/YYYY date format", () => {
+    for (const tx of bhdPersonalTransactions) {
+      expect(tx.date).toMatch(/^\d{2}\/\d{2}\/\d{4}$/);
+    }
+  });
+
+  it("includes both credit and debit transactions", () => {
+    expect(bhdPersonalTransactions.some((tx) => tx.credit !== "")).toBe(true);
+    expect(bhdPersonalTransactions.some((tx) => tx.debit !== "")).toBe(true);
+  });
+
+  it("amounts and balance use RD$ prefix with comma-separated thousands", () => {
+    for (const tx of bhdPersonalTransactions) {
+      if (tx.debit !== "") expect(tx.debit).toMatch(/^RD\$ [\d,]+\.\d{2}$/);
+      if (tx.credit !== "") expect(tx.credit).toMatch(/^RD\$ [\d,]+\.\d{2}$/);
+      expect(tx.balance).toMatch(/^RD\$ [\d,]+\.\d{2}$/);
+    }
+  });
+
+  it("contains no PII or sensitive data", () => {
+    expect(containsSensitiveData(JSON.stringify(bhdPersonalTransactions))).toBe(false);
+  });
+});
+
+describe("Banreservas Personas transaction fixtures", () => {
+  it("has transactions with all required fields", () => {
+    expect(banreservasPersonasTransactions.length).toBeGreaterThanOrEqual(1);
+    for (const tx of banreservasPersonasTransactions) {
+      expect(typeof tx.date).toBe("string");
+      expect(tx.date.length).toBeGreaterThan(0);
+      expect(typeof tx.description).toBe("string");
+      expect(typeof tx.reference).toBe("string");
+      expect(tx.reference.length).toBeGreaterThan(0);
+      expect(typeof tx.debit).toBe("string");
+      expect(typeof tx.credit).toBe("string");
+      expect(typeof tx.balance).toBe("string");
+    }
+  });
+
+  it("uses DD/MM/YYYY date format", () => {
+    for (const tx of banreservasPersonasTransactions) {
+      expect(tx.date).toMatch(/^\d{2}\/\d{2}\/\d{4}$/);
+    }
+  });
+
+  it("includes both credit and debit transactions", () => {
+    expect(banreservasPersonasTransactions.some((tx) => tx.credit !== "")).toBe(true);
+    expect(banreservasPersonasTransactions.some((tx) => tx.debit !== "")).toBe(true);
+  });
+
+  it("amounts and balance use comma-separated thousands with 2 decimals (no currency prefix)", () => {
+    for (const tx of banreservasPersonasTransactions) {
+      if (tx.debit !== "") expect(tx.debit).toMatch(/^-?[\d,]+\.\d{2}$/);
+      if (tx.credit !== "") expect(tx.credit).toMatch(/^-?[\d,]+\.\d{2}$/);
+      expect(tx.balance).toMatch(/^[\d,]+\.\d{2}$/);
+    }
+  });
+
+  it("reference field contains transaction IDs with '# Nro. transacción' prefix", () => {
+    for (const tx of banreservasPersonasTransactions) {
+      expect(tx.reference).toMatch(/^# Nro\. transacción/);
+      expect(tx.reference).toMatch(/\d{5,}/);
+    }
+  });
+
+  it("contains no PII or sensitive data", () => {
+    expect(containsSensitiveData(JSON.stringify(banreservasPersonasTransactions))).toBe(false);
+  });
+});
+
+describe("Banreservas Empresas transaction fixtures", () => {
+  it("has transactions with all required fields", () => {
+    expect(banreservasEmpresasTransactions.length).toBeGreaterThanOrEqual(1);
+    for (const tx of banreservasEmpresasTransactions) {
+      expect(typeof tx.date).toBe("string");
+      expect(tx.date.length).toBeGreaterThan(0);
+      expect(typeof tx.transactionNumber).toBe("string");
+      expect(tx.transactionNumber.length).toBeGreaterThan(0);
+      expect(typeof tx.description).toBe("string");
+      expect(typeof tx.debit).toBe("string");
+      expect(typeof tx.credit).toBe("string");
+      expect(typeof tx.balance).toBe("string");
+    }
+  });
+
+  it("uses DD/MM/YY date format (2-digit year)", () => {
+    for (const tx of banreservasEmpresasTransactions) {
+      expect(tx.date).toMatch(/^\d{2}\/\d{2}\/\d{2}$/);
+    }
+  });
+
+  it("includes both positive credit and positive debit amounts", () => {
+    const hasPositiveCredit = banreservasEmpresasTransactions.some(
+      (tx) => tx.credit !== "" && parseFloat(tx.credit.replace(/,/g, "")) > 0
+    );
+    const hasPositiveDebit = banreservasEmpresasTransactions.some(
+      (tx) => tx.debit !== "" && parseFloat(tx.debit.replace(/,/g, "")) > 0
+    );
+    expect(hasPositiveCredit).toBe(true);
+    expect(hasPositiveDebit).toBe(true);
+  });
+
+  it("amounts have no currency prefix in debit/credit columns", () => {
+    for (const tx of banreservasEmpresasTransactions) {
+      if (tx.debit !== "") expect(tx.debit).toMatch(/^\d[\d,]*\.\d{2}$/);
+      if (tx.credit !== "") expect(tx.credit).toMatch(/^\d[\d,]*\.\d{2}$/);
+    }
+  });
+
+  it("balance uses DOP prefix with comma-separated thousands", () => {
+    for (const tx of banreservasEmpresasTransactions) {
+      expect(tx.balance).toMatch(/^DOP [\d,]+\.\d{2}$/);
+    }
+  });
+
+  it("contains no PII or sensitive data", () => {
+    expect(containsSensitiveData(JSON.stringify(banreservasEmpresasTransactions))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture metadata — portal variant disambiguation
+// ---------------------------------------------------------------------------
+
+describe("Fixture metadata — bank code + portal variant", () => {
+  it.each([
+    ["BHD Personal", BHD_PERSONAL_BANK_CODE, BHD_PERSONAL_PORTAL_VARIANT, "bhd", "personal"],
+    ["Banreservas Personas", BANRESERVAS_PERSONAS_BANK_CODE, BANRESERVAS_PERSONAS_PORTAL_VARIANT, "banreservas", "personas"],
+    ["Banreservas Empresas", BANRESERVAS_EMPRESAS_BANK_CODE, BANRESERVAS_EMPRESAS_PORTAL_VARIANT, "banreservas", "empresas"],
+  ])("%s exports correct bank code and portal variant", (_label, bankCode, portalVariant, expectedBank, expectedVariant) => {
+    expect(bankCode).toBe(expectedBank);
+    expect(portalVariant).toBe(expectedVariant);
+  });
+
+  it("Banreservas Personas and Empresas share bank code but differ by portal variant", () => {
+    expect(BANRESERVAS_PERSONAS_BANK_CODE).toBe(BANRESERVAS_EMPRESAS_BANK_CODE);
+    expect(BANRESERVAS_PERSONAS_PORTAL_VARIANT).not.toBe(BANRESERVAS_EMPRESAS_PORTAL_VARIANT);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeFixtureText helper
+// ---------------------------------------------------------------------------
+
+describe("normalizeFixtureText", () => {
+  it("trims and collapses whitespace", () => {
+    expect(normalizeFixtureText("  hello   world  ")).toBe("hello world");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(normalizeFixtureText("")).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-fixture sanitization invariants
+// ---------------------------------------------------------------------------
+
+describe("Sanitization invariant — all fixtures", () => {
+  const combined = JSON.stringify([
+    bhdPersonalTransactions,
+    banreservasPersonasTransactions,
+    banreservasEmpresasTransactions,
+  ]);
+  const combinedLower = combined.toLowerCase();
+
+  it("contains no IBANs, RNC, or real account numbers", () => {
+    expect(combined).not.toMatch(/\bDO\s*[A-Z]{2}\s*\d{2}\s*\d{4}/i);
+    expect(combined).not.toMatch(/\b0[1-9]\d{8,}\b/);
+    expect(combined).not.toMatch(/\b[1-9]\d{2}-\d{7}\b/);
+  });
+
+  it("contains no cookie, token, session, password, or credential patterns", () => {
+    for (const term of ["cookie", "session", "token", "password", "credential"]) {
+      expect(combinedLower).not.toContain(term);
+    }
+  });
+
+  it("contains no email addresses", () => {
+    expect(combined).not.toMatch(/[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression: containsSensitiveData determinism + detection coverage
+// ---------------------------------------------------------------------------
+
+describe("containsSensitiveData", () => {
+  it("is deterministic across repeated calls (sensitive input)", () => {
+    const sensitive = "Password: abc123";
+    for (let i = 0; i < 11; i++) {
+      expect(containsSensitiveData(sensitive)).toBe(true);
+    }
+  });
+
+  it("is deterministic across repeated calls (safe input)", () => {
+    const safe = JSON.stringify(bhdPersonalTransactions);
+    for (let i = 0; i < 11; i++) {
+      expect(containsSensitiveData(safe)).toBe(false);
+    }
+  });
+
+  it.each([
+    ["cédula-like IDs", "Cédula: 000-0000000-0"],
+    ["RNC-like tax IDs", "RNC: 101-0000000"],
+    ["phone numbers", "Tel: 000-000-0000"],
+    ["Visa PAN", "4000-0000-0000-0001"],
+    ["Mastercard PAN", "5100 0000 0000 0001"],
+    ["JWT Bearer token", "Bearer eyJ0ZXN0.eyJ0ZXN0.eyJ0ZXN0"],
+    ["session cookie assignment", "session_id=fake-session-abc123"],
+  ])("detects %s", (_label, input) => {
+    expect(containsSensitiveData(input)).toBe(true);
+  });
+
+  it("does not false-positive on fixture descriptions", () => {
+    const fixtureText = JSON.stringify([
+      bhdPersonalTransactions,
+      banreservasPersonasTransactions,
+      banreservasEmpresasTransactions,
+    ]);
+    expect(containsSensitiveData(fixtureText)).toBe(false);
+  });
+});

--- a/src/modules/bank-adapters/fixtures/banreservas-empresas.ts
+++ b/src/modules/bank-adapters/fixtures/banreservas-empresas.ts
@@ -1,0 +1,24 @@
+import type { BanreservasEmpresasTransaction } from "./types";
+
+export const BANRESERVAS_EMPRESAS_BANK_CODE = "banreservas" as const;
+export const BANRESERVAS_EMPRESAS_PORTAL_VARIANT = "empresas" as const;
+
+/** DevExpress grid: Fecha | Nro. Transacción | Concepto | Débitos | Créditos | Balance (DD/MM/YY) */
+export const banreservasEmpresasTransactions: readonly BanreservasEmpresasTransaction[] = [
+  {
+    date: "29/06/26",
+    transactionNumber: "942632990001",
+    description: "DEPOSITO EN EFECTIVO",
+    debit: "0.00",
+    credit: "25,000.00",
+    balance: "DOP 29,472.55",
+  },
+  {
+    date: "28/06/26",
+    transactionNumber: "942632990002",
+    description: "COBRO IMP DGII 0.15%_TRANS TUB",
+    debit: "193.15",
+    credit: "0.00",
+    balance: "DOP 4,472.55",
+  },
+] as const;

--- a/src/modules/bank-adapters/fixtures/banreservas-personas.ts
+++ b/src/modules/bank-adapters/fixtures/banreservas-personas.ts
@@ -1,0 +1,24 @@
+import type { BanreservasPersonasTransaction } from "./types";
+
+export const BANRESERVAS_PERSONAS_BANK_CODE = "banreservas" as const;
+export const BANRESERVAS_PERSONAS_PORTAL_VARIANT = "personas" as const;
+
+/** div.rivera_row: date | description | reference | debit | credit | balance */
+export const banreservasPersonasTransactions: readonly BanreservasPersonasTransaction[] = [
+  {
+    date: "29/06/2026",
+    description: "TRANSFERENCIA RECIBIDA",
+    reference: "# Nro. transacción : 408900123456 | Número de referencia : 408900123",
+    debit: "",
+    credit: "44,000.00",
+    balance: "53,639.79",
+  },
+  {
+    date: "28/06/2026",
+    description: "TRANSFERENCIA A COMERCIO DEMO",
+    reference: "# Nro. transacción : 408900234567 | Número de referencia : 408900234",
+    debit: "-5,000.00",
+    credit: "",
+    balance: "9,639.79",
+  },
+] as const;

--- a/src/modules/bank-adapters/fixtures/bhd-personal.ts
+++ b/src/modules/bank-adapters/fixtures/bhd-personal.ts
@@ -1,0 +1,26 @@
+import type { BhdPersonalTransaction } from "./types";
+
+export const BHD_PERSONAL_BANK_CODE = "bhd" as const;
+export const BHD_PERSONAL_PORTAL_VARIANT = "personal" as const;
+
+/** PrimeNG p-datatable: Fecha | Nº confirmación | Descripción | Comprobante | Débitos | Créditos | Balance */
+export const bhdPersonalTransactions: readonly BhdPersonalTransaction[] = [
+  {
+    date: "27/06/2026",
+    confirmationNumber: "2638001",
+    description: "DEPOSITO EN EFECTIVO",
+    receipt: "0000000000",
+    debit: "",
+    credit: "RD$ 15,000.00",
+    balance: "RD$ 22,167.94",
+  },
+  {
+    date: "27/06/2026",
+    confirmationNumber: "2638002",
+    description: "Fondo reservado Visa Db: 20260627",
+    receipt: "0000000000",
+    debit: "RD$ 679.51",
+    credit: "",
+    balance: "RD$ 7,167.94",
+  },
+] as const;

--- a/src/modules/bank-adapters/fixtures/helpers.ts
+++ b/src/modules/bank-adapters/fixtures/helpers.ts
@@ -1,0 +1,33 @@
+/**
+ * PII / secret patterns that must NEVER appear in fixture data.
+ * Excludes transaction-level numbers (confirmation, reference, receipt,
+ * transaction IDs) — those are expected in bank transaction data.
+ *
+ * IMPORTANT: No `/g` flag — `.test()` with global regexes is stateful and
+ * nondeterministic across repeated calls on the same input.
+ */
+const SENSITIVE_PATTERNS = [
+  /\bDO\s*[A-Z]{2}\s*\d{2}\s*\d{4}\s*\d{4}\s*\d{4}\s*\d{4}\s*\d{4}\b/i, // IBANs
+  /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/, // emails
+  /\b(password|passwd|pwd|token|cookie|secret|authorization)\s*[:=]\s*\S+/i, // credentials
+  /\b[A-Z][a-z]+ [A-Z][a-z]+ [A-Z][a-z]+\b/, // names (3+ capitalized words)
+  /\b\d{3}-\d{7}-\d\b/, // cédula (XXX-XXXXXXX-X) — also covers RNC with check digit
+  /\b[1-9]\d{2}-\d{7}\b/, // RNC (tax ID: NXX-XXXXXXX, no check digit)
+  /\b\d{3}[-.]\d{3}[-.]\d{4}\b/, // phone (XXX-XXX-XXXX) — requires separator to avoid matching bare 10-digit numbers
+  /\b4\d{3}[-\s]?\d{4}[-\s]?\d{4}[-\s]?\d{4}\b/, // Visa PAN
+  /\b5[1-5]\d{2}[-\s]?\d{4}[-\s]?\d{4}[-\s]?\d{4}\b/, // Mastercard PAN
+  /\b3[47]\d{2}[-\s]?\d{6}[-\s]?\d{5}\b/, // Amex PAN
+  /\beyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/, // JWT
+  /\bBearer\s+[A-Za-z0-9._-]+/i, // Bearer token
+  /\bsession_id\s*=\s*\S+/i, // session cookie assignment
+] as const;
+
+/** Returns true if the input contains PII or secrets (IBANs, emails, credentials, names, etc.). */
+export function containsSensitiveData(input: string): boolean {
+  return SENSITIVE_PATTERNS.some((pattern) => pattern.test(input));
+}
+
+/** Normalize whitespace — trim and collapse internal whitespace. */
+export function normalizeFixtureText(value: string): string {
+  return value.trim().replace(/\s+/g, " ");
+}

--- a/src/modules/bank-adapters/fixtures/types.ts
+++ b/src/modules/bank-adapters/fixtures/types.ts
@@ -1,0 +1,29 @@
+/** Raw transaction row types for bank portal fixtures (PR5B parsers consume these). */
+
+export interface BhdPersonalTransaction {
+  date: string; // DD/MM/YYYY
+  confirmationNumber: string;
+  description: string;
+  receipt: string;
+  debit: string; // "RD$ 679.51" or ""
+  credit: string; // "RD$ 1,450.00" or ""
+  balance: string; // "RD$ 7,167.94"
+}
+
+export interface BanreservasPersonasTransaction {
+  date: string; // DD/MM/YYYY
+  description: string;
+  reference: string; // pipe-separated IDs
+  debit: string; // "-5,000.00" or ""
+  credit: string; // "44,000.00" or ""
+  balance: string; // "9,639.79"
+}
+
+export interface BanreservasEmpresasTransaction {
+  date: string; // DD/MM/YY (2-digit year)
+  transactionNumber: string;
+  description: string;
+  debit: string; // "193.15" — no currency prefix
+  credit: string; // "0.00" — no currency prefix
+  balance: string; // "DOP 4,472.55"
+}


### PR DESCRIPTION
## Summary
- Adds sanitized transaction fixtures for BHD Personal, Banreservas Personas, and Banreservas Empresas.
- Adds deterministic fixture sanitization helpers and tests for PII/secret guardrails.
- Marks PR5A fixture tasks complete and keeps the PR5A diff at 398 changed lines.

## PR stack
- Base branch: feature/multi-bank-auto-login-pr5-bank-mapping (recon-only branch).
- This PR intentionally contains only PR5A fixtures on top of the committed recon work.

## Verification
- [x] Fixture tests: 36/36 pass.
- [x] Bank adapter tests: pass.
- [x] Full suite reported pass during apply/review.
- [x] pnpm lint.
- [x] pnpm typecheck.
- [x] Fresh Risk/ Reliability / Readability reviews completed; final findings resolved or non-blocking.

## Notes
- No real credentials, cookies, tokens, session IDs, full account numbers, or customer data.
- Login remains admin-assisted CDP attach; no security-question/CAPTCHA automation.
- PR5B adapters/parsers are intentionally out of scope.