### PR TITLE
feat(bank-adapters): add BHD skeleton adapter

### DIFF
--- a/openspec/changes/multi-bank-auto-login/tasks.md
+++ b/openspec/changes/multi-bank-auto-login/tasks.md
@@ -112,11 +112,31 @@ Gate: full gates + FRESH 4R review + Judgment Day before merge; PR3B1 <=400 line
 - [x] 5A.6 Create `src/modules/bank-adapters/fixtures/__tests__/bank-transaction-fixtures.test.ts`: 36 tests — fixture loadability, field completeness, date formats, amount formats, credit/debit coverage, PII sanitization, RNC/IBAN/account number detection, no secrets.
 - Gate: pnpm test (36 pass) + pnpm typecheck + pnpm lint clean; 398 changed lines (under 400 budget).
 
-### PR5B: Read-only adapters + parsers (NEXT)
+### PR5B1: BHD Personal read-only adapter skeleton (COMPLETE — slice 1)
 
-- [ ] 5.1 Create `src/modules/bank-adapters/banreservas.ts` + `bhd.ts`: read-only `createScraper`+`createSessionChecker`+pure parsers; `createAutoLoginStrategy` stub (not enabled); portal configs from recon (open Q).
-- [ ] 5.2 Register banreservas/bhd in registry; add to `SUPPORTED_RUN_NOW_BANK_CODES` for read-only run-now (auto-login still gated off).
-- [ ] 5.3 Expand `src/worker/scraper/auto-login.portal-drift.test.ts`: Banreservas+BHD pre-submit incompatible-flow fixtures (assert NO fill/submit) + post-submit unknown-flow fixtures.
+- [x] 5.1a Create `src/modules/bank-adapters/bhd.ts`: BHD Personal skeleton with scraper profile/selectors, portal config from recon, `createScraper`/`createSessionChecker` stubs, `createAutoLoginStrategy` stub (not enabled). Profile fields preserve core recon handoff facts for PR5C/D/E (accountFingerprint, loginStrategy, routes, navigation selectors, transaction table selectors, column mapping, amount formats). Stub session checker returns `expired` (fail-safe) until real CDP checker exists in PR5C/D/E.
+- [x] 5.1a-tests Tests: `bhd.test.ts` — identity (bankCode=bhd, portalVariant=personal), auto-login throws, stub scraper returns `needs_admin_action` with exact `safeErrorSummary`, stub session checker returns `expired` with exact `safeSummary`, full profile field assertions (selectors, column mapping, formats, pagination), portal config assertions (baseUrl, CDP env, login allowlist).
+- Gate: full gates; <=400 changed lines; NO auto-login enablement; NO registration in registry.
+
+### PR5B2: Banreservas Personas/Empresas read-only adapter skeletons (DEFERRED — slice 2)
+
+**IDENTITY NOTE — Banreservas Personas vs Empresas:** Both variants share
+`bankCode: "banreservas"` but are TWO completely different tech stacks (Angular
+SPA vs ASP.NET WebForms frameset). The current bankCode-keyed registry maps one
+bankCode → one adapter. Personas and Empresas cannot both be registered directly
+without either: (a) a single Banreservas entry with portalVariant routing, or
+(b) evolving the registry to support portalVariant-keyed resolution. Neither
+registration happens in PR5B2 — skeletons only. Registration is deferred to
+PR5.2 or later when the registry routing strategy is decided.
+
+- [ ] 5.1b Create `src/modules/bank-adapters/banreservas.ts`: Banreservas Personas + Empresas skeletons with scraper profiles/selectors, portal configs from recon, `createScraper`/`createSessionChecker` stubs, `createAutoLoginStrategy` stubs (not enabled). Profile fields preserve core recon handoff facts for PR5C/D/E.
+- [ ] 5.1b-tests Tests: `banreservas.test.ts` — shared bankCode, portalVariant differentiation, date format/pagination/inputStrategy divergence, stub scrapers return `needs_admin_action` with exact `safeErrorSummary`, stub session checkers return `expired` with exact `safeSummary`, full profile field assertions, portal config assertions.
+- Gate: full gates; <=400 changed lines; NO auto-login enablement.
+
+### PR5B shared deferred tasks (after PR5B2)
+
+- [ ] 5.2 Register banreservas/bhd in registry; add to `SUPPORTED_RUN_NOW_BANK_CODES` for read-only run-now (deferred to keep PR5B slices skeleton-only).
+- [ ] 5.3 Expand `src/worker/scraper/auto-login.portal-drift.test.ts`: Banreservas+BHD pre-submit incompatible-flow fixtures (assert NO fill/submit) + post-submit unknown-flow fixtures. **BLOCKED**: file belongs to PR4 (auto-login infrastructure); deferred.
 - [ ] 5.4 Tests: route by banreservas/bhd bankCode; read-only scrape parity; unknown fails closed ("Este banco aún no está disponible para actualización automática"); portal-drift incompatible pre-submit blocks fill; per-bank adapter kill switch.
 - Gate: full gates; <=400 lines; NO auto-login enablement.
 

--- a/src/modules/bank-adapters/bhd.test.ts
+++ b/src/modules/bank-adapters/bhd.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  bhdPersonalAdapter, bhdPersonalScraperProfile,
+  bhdPersonalPortalConfig, bhdBankCode,
+} from "./bhd";
+
+describe("BHD Personal adapter identity + skeleton contract", () => {
+  it("bankCode=bhd, portalVariant=personal, auto-login not implemented", () => {
+    expect(bhdBankCode).toBe("bhd");
+    expect(bhdPersonalAdapter.bankCode).toBe("bhd");
+    expect(bhdPersonalAdapter.portalVariant).toBe("personal");
+    expect(() => bhdPersonalAdapter.createAutoLoginStrategy()).toThrow(/not implemented/i);
+  });
+
+  it("stub scraper returns needs_admin_action with exact safeErrorSummary", async () => {
+    const r = await bhdPersonalAdapter.createScraper().collect();
+    expect(r.status).toBe("needs_admin_action");
+    expect(r.movements).toEqual([]);
+    expect(r.safeErrorSummary).toBe("BHD Personal adapter is a skeleton");
+  });
+
+  it("stub session checker returns expired (fail-safe) with exact safeSummary", async () => {
+    const r = await bhdPersonalAdapter.createSessionChecker().check();
+    expect(r.status).toBe("expired");
+    expect(r.safeSummary).toBe("Bank session expired or requires verification");
+  });
+});
+
+describe("BHD Personal profile — recon-derived fields", () => {
+  it("identity, login, accountFingerprint, loginStrategy, routes", () => {
+    expect(bhdPersonalScraperProfile.bankId).toBe("bhd");
+    expect(bhdPersonalScraperProfile.portalVariant).toBe("personal");
+    expect(bhdPersonalScraperProfile.loginUrl).toBe("https://ibp.bhd.com.do/#/login");
+    expect(bhdPersonalScraperProfile.accountFingerprint).toBe("bhd-XXXXXXXXXX");
+    expect(bhdPersonalScraperProfile.loginStrategy).toBe("admin-assisted-first-login+remember-browser+cdp-attach");
+    expect(bhdPersonalScraperProfile.routes).toEqual({
+      dashboard: "#/bhd/dashboard", productDetail: "#/bhd/product-detail",
+    });
+  });
+
+  it("login selectors, CAPTCHA area, date inputs, transaction table + row + column mapping", () => {
+    expect(bhdPersonalScraperProfile.selectors).toMatchObject({
+      usernameInput: "input#userName", passwordInput: "input#password",
+      captchaArea: "div.field.col-10.mb-2", submitButton: "button[type='submit'].bhd-btn-primary",
+      accountCard: "app-account-card", viewMovementsButton: "button.bhd-btn-primary",
+      periodDropdown: "div.p-select-dropdown", searchInput: "input[placeholder='Buscar']",
+      fromDateInput: "input.p-datepicker-input[placeholder='Fecha inicio']",
+      toDateInput: "input.p-datepicker-input[placeholder='Fecha final']",
+      transactionTable: "table.p-datatable-table", transactionRow: "tr.body-responsive",
+    });
+    expect(bhdPersonalScraperProfile.columnMapping).toEqual({
+      date: 0, confirmation: 1, description: 2, receipt: 3, debit: 4, credit: 5, balance: 6,
+    });
+    expect(bhdPersonalScraperProfile.formats).toEqual({ date: "DD/MM/YYYY", amount: "RD$ 1,234.56" });
+    expect(bhdPersonalScraperProfile.paginationStrategy).toBe("scroll-stabilize");
+  });
+});
+
+describe("BHD portal config", () => {
+  it("bankCode, baseUrl, CDP env, login allowlist", () => {
+    expect(bhdPersonalPortalConfig.bankCode).toBe("bhd");
+    expect(bhdPersonalPortalConfig.baseUrl).toBe("https://ibp.bhd.com.do");
+    expect(bhdPersonalPortalConfig.loginPathAllowlist).toContain("/#/login");
+    expect(bhdPersonalPortalConfig.cdpUrlEnv).toBe("RD_SYNC_BANK_BHD_CDP_URL");
+  });
+});

--- a/src/modules/bank-adapters/bhd.ts
+++ b/src/modules/bank-adapters/bhd.ts
@@ -1,0 +1,91 @@
+/** BHD Personal — read-only adapter skeleton (PR5B). Angular/PrimeNG SPA, scroll-stabilize. */
+/* PR5B NOTE: BHD is NOT registered in the bankCode-keyed registry yet. Registration
+   lands in PR5.2 or later; this file exports the skeleton for testing only. */
+
+import type { IngestionScraper } from "../../worker/queues";
+import type { CdpSessionChecker } from "../../modules/bank-sessions";
+import type { BankAdapter, BankAutoLoginStrategy } from "./registry";
+
+export const bhdBankCode = "bhd" as const;
+export const bhdPersonalPortalVariant = "personal" as const;
+
+export const bhdPersonalScraperProfile = {
+  bankId: bhdBankCode,
+  portalVariant: bhdPersonalPortalVariant,
+  loginUrl: "https://ibp.bhd.com.do/#/login",
+  accountFingerprint: "bhd-XXXXXXXXXX",
+  loginStrategy: "admin-assisted-first-login+remember-browser+cdp-attach",
+  routes: { dashboard: "#/bhd/dashboard", productDetail: "#/bhd/product-detail" },
+  selectors: {
+    usernameInput: "input#userName",
+    passwordInput: "input#password",
+    captchaArea: "div.field.col-10.mb-2",
+    submitButton: "button[type='submit'].bhd-btn-primary",
+    accountCard: "app-account-card",
+    viewMovementsButton: "button.bhd-btn-primary",
+    periodDropdown: "div.p-select-dropdown",
+    fromDateInput: "input.p-datepicker-input[placeholder='Fecha inicio']",
+    toDateInput: "input.p-datepicker-input[placeholder='Fecha final']",
+    searchInput: "input[placeholder='Buscar']",
+    transactionTable: "table.p-datatable-table",
+    transactionRow: "tr.body-responsive",
+  },
+  columnMapping: { date: 0, confirmation: 1, description: 2, receipt: 3, debit: 4, credit: 5, balance: 6 },
+  formats: { date: "DD/MM/YYYY", amount: "RD$ 1,234.56" },
+  paginationStrategy: "scroll-stabilize" as const,
+} as const;
+
+export const bhdPersonalPortalConfig = {
+  bankCode: bhdBankCode,
+  baseUrl: "https://ibp.bhd.com.do",
+  loginPathAllowlist: ["/#/login"] as readonly string[],
+  cdpUrlEnv: "RD_SYNC_BANK_BHD_CDP_URL",
+  profileDirEnv: "RD_SYNC_BANK_BHD_PROFILE_DIR",
+  startUrlEnv: "RD_SYNC_BANK_BHD_START_URL",
+  usernameSelector: bhdPersonalScraperProfile.selectors.usernameInput,
+  passwordSelector: bhdPersonalScraperProfile.selectors.passwordInput,
+  submitSelector: bhdPersonalScraperProfile.selectors.submitButton,
+  incompatibleFlowSelector: undefined,
+} as const;
+
+export function createBhdAutoLoginStrategy(): BankAutoLoginStrategy {
+  throw new Error("BHD auto-login strategy is not implemented yet (PR6)");
+}
+
+export function createBhdPersonalAdapter(options: {
+  createScraper: () => IngestionScraper;
+  createSessionChecker: () => CdpSessionChecker;
+}): BankAdapter & {
+  readonly portalVariant: string;
+  createSessionChecker(): CdpSessionChecker;
+} {
+  return {
+    bankCode: bhdBankCode,
+    portalVariant: bhdPersonalPortalVariant,
+    createScraper: options.createScraper,
+    createSessionChecker: options.createSessionChecker,
+    createAutoLoginStrategy: createBhdAutoLoginStrategy,
+  };
+}
+
+const bhdStubScraper: IngestionScraper = {
+  collect: async () => ({
+    status: "needs_admin_action" as const,
+    movements: [],
+    safeErrorSummary: "BHD Personal adapter is a skeleton",
+  }),
+};
+
+/** Fail-safe stub: returns expired until real CDP session checker exists in PR5C/D/E. */
+const bhdStubSessionChecker: CdpSessionChecker = {
+  check: async () => ({
+    status: "expired",
+    checkedAt: new Date().toISOString(),
+    safeSummary: "Bank session expired or requires verification",
+  }),
+};
+
+export const bhdPersonalAdapter = createBhdPersonalAdapter({
+  createScraper: () => bhdStubScraper,
+  createSessionChecker: () => bhdStubSessionChecker,
+});


### PR DESCRIPTION
## Summary
- Adds the BHD Personal read-only adapter skeleton with recon-derived scraper profile metadata.
- Adds fail-safe scraper/session checker stubs and tests for visible stub contracts.
- Splits PR5B into PR5B1 (BHD now) and PR5B2 (Banreservas next) to stay under the 400-line review budget.

## PR stack
- Base branch: feature/multi-bank-auto-login-pr5-bank-mapping.
- This PR intentionally contains only PR5B1 BHD Personal skeleton work on top of recon + PR5A fixtures.

## Verification
- [x] pnpm exec vitest run src/modules/bank-adapters/bhd.test.ts — 6/6 pass.
- [x] pnpm exec vitest run src/modules/bank-adapters/ — 64/64 pass.
- [x] pnpm typecheck.
- [x] pnpm lint.
- [x] git diff --check.
- [x] Fresh Risk, Reliability, and Readability reviews approved after selector fix.

## Notes
- No adapter registration or run-now routing changes in this slice.
- No credential submission, security-question/CAPTCHA automation, export hot path, or auto-login enablement.
- BHD session checker stub fails safe as expired until real CDP verification exists.