### PR TITLE
feat(bank-adapters): add Banreservas skeleton adapters

### DIFF
--- a/openspec/changes/multi-bank-auto-login/tasks.md
+++ b/openspec/changes/multi-bank-auto-login/tasks.md
@@ -118,7 +118,7 @@ Gate: full gates + FRESH 4R review + Judgment Day before merge; PR3B1 <=400 line
 - [x] 5.1a-tests Tests: `bhd.test.ts` — identity (bankCode=bhd, portalVariant=personal), auto-login throws, stub scraper returns `needs_admin_action` with exact `safeErrorSummary`, stub session checker returns `expired` with exact `safeSummary`, full profile field assertions (selectors, column mapping, formats, pagination), portal config assertions (baseUrl, CDP env, login allowlist).
 - Gate: full gates; <=400 changed lines; NO auto-login enablement; NO registration in registry.
 
-### PR5B2: Banreservas Personas/Empresas read-only adapter skeletons (DEFERRED — slice 2)
+### PR5B2: Banreservas Personas/Empresas read-only adapter skeletons (COMPLETE — slice 2)
 
 **IDENTITY NOTE — Banreservas Personas vs Empresas:** Both variants share
 `bankCode: "banreservas"` but are TWO completely different tech stacks (Angular
@@ -129,8 +129,8 @@ without either: (a) a single Banreservas entry with portalVariant routing, or
 registration happens in PR5B2 — skeletons only. Registration is deferred to
 PR5.2 or later when the registry routing strategy is decided.
 
-- [ ] 5.1b Create `src/modules/bank-adapters/banreservas.ts`: Banreservas Personas + Empresas skeletons with scraper profiles/selectors, portal configs from recon, `createScraper`/`createSessionChecker` stubs, `createAutoLoginStrategy` stubs (not enabled). Profile fields preserve core recon handoff facts for PR5C/D/E.
-- [ ] 5.1b-tests Tests: `banreservas.test.ts` — shared bankCode, portalVariant differentiation, date format/pagination/inputStrategy divergence, stub scrapers return `needs_admin_action` with exact `safeErrorSummary`, stub session checkers return `expired` with exact `safeSummary`, full profile field assertions, portal config assertions.
+- [x] 5.1b Create `src/modules/bank-adapters/banreservas.ts`: Banreservas Personas + Empresas skeletons with scraper profiles/selectors, portal configs from recon, `createScraper`/`createSessionChecker` stubs, `createAutoLoginStrategy` stubs (not enabled). Profile fields preserve core recon handoff facts for PR5C/D/E.
+- [x] 5.1b-tests Tests: `banreservas.test.ts` — shared bankCode, portalVariant differentiation, date format/pagination/inputStrategy divergence, stub scrapers return `needs_admin_action` with exact `safeErrorSummary`, stub session checkers return `expired` with exact `safeSummary`, full profile field assertions, portal config assertions.
 - Gate: full gates; <=400 changed lines; NO auto-login enablement.
 
 ### PR5B shared deferred tasks (after PR5B2)

--- a/src/modules/bank-adapters/banreservas.test.ts
+++ b/src/modules/bank-adapters/banreservas.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+import {
+  banreservasBankCode,
+  banreservasPersonasPortalVariant,
+  banreservasEmpresasPortalVariant,
+  banreservasPersonasScraperProfile,
+  banreservasEmpresasScraperProfile,
+  banreservasPersonasAdapter,
+  banreservasEmpresasAdapter,
+  banreservasPersonasPortalConfig,
+  banreservasEmpresasPortalConfig,
+  createBanreservasAutoLoginStrategy,
+} from "./banreservas";
+
+describe("Banreservas adapter identity + portal variant disambiguation", () => {
+  it("shared bankCode = banreservas; variants differ", () => {
+    expect(banreservasBankCode).toBe("banreservas");
+    expect(banreservasPersonasAdapter.bankCode).toBe("banreservas");
+    expect(banreservasEmpresasAdapter.bankCode).toBe("banreservas");
+    expect(banreservasPersonasAdapter.portalVariant).toBe("personas");
+    expect(banreservasEmpresasAdapter.portalVariant).toBe("empresas");
+    expect(banreservasPersonasPortalVariant).toBe("personas");
+    expect(banreservasEmpresasPortalVariant).toBe("empresas");
+  });
+
+  it("both share bankCode but have distinct portalVariant", () => {
+    expect(banreservasPersonasAdapter.bankCode).toBe(banreservasEmpresasAdapter.bankCode);
+    expect(banreservasPersonasAdapter.portalVariant).not.toBe(banreservasEmpresasAdapter.portalVariant);
+  });
+});
+
+describe("Banreservas stub scrapers — fail-safe skeleton contract", () => {
+  it("Personas: needs_admin_action + empty movements + exact safeErrorSummary", async () => {
+    const r = await banreservasPersonasAdapter.createScraper().collect();
+    expect(r.status).toBe("needs_admin_action");
+    expect(r.movements).toEqual([]);
+    expect(r.safeErrorSummary).toBe("Banreservas Personas adapter is a skeleton");
+  });
+
+  it("Empresas: needs_admin_action + empty movements + exact safeErrorSummary", async () => {
+    const r = await banreservasEmpresasAdapter.createScraper().collect();
+    expect(r.status).toBe("needs_admin_action");
+    expect(r.movements).toEqual([]);
+    expect(r.safeErrorSummary).toBe("Banreservas Empresas adapter is a skeleton");
+  });
+});
+
+describe("Banreservas stub session checkers — fail-safe expired + safe summary", () => {
+  it("Personas: expired with safe summary", async () => {
+    const r = await banreservasPersonasAdapter.createSessionChecker().check();
+    expect(r.status).toBe("expired");
+    expect(r.safeSummary).toBe("Bank session expired or requires verification");
+  });
+
+  it("Empresas: expired with safe summary", async () => {
+    const r = await banreservasEmpresasAdapter.createSessionChecker().check();
+    expect(r.status).toBe("expired");
+    expect(r.safeSummary).toBe("Bank session expired or requires verification");
+  });
+});
+
+describe("Banreservas auto-login stub — not implemented", () => {
+  it("createBanreservasAutoLoginStrategy throws", () => {
+    expect(() => createBanreservasAutoLoginStrategy()).toThrow(/not implemented/i);
+  });
+
+  it("Personas + Empresas adapters both throw", () => {
+    expect(() => banreservasPersonasAdapter.createAutoLoginStrategy()).toThrow(/not implemented/i);
+    expect(() => banreservasEmpresasAdapter.createAutoLoginStrategy()).toThrow(/not implemented/i);
+  });
+});
+
+describe("Banreservas Personas profile — recon-derived selectors/facts", () => {
+  it("identity, login, rootElement, fingerprint, searchMode, inputStrategy", () => {
+    expect(banreservasPersonasScraperProfile.bankId).toBe("banreservas");
+    expect(banreservasPersonasScraperProfile.portalVariant).toBe("personas");
+    expect(banreservasPersonasScraperProfile.loginUrl).toBe(
+      "https://tubanco.banreservas.com/TuBancoBanreservas/#/administrationGeneral/login",
+    );
+    expect(banreservasPersonasScraperProfile.rootElement).toBe("icb-app");
+    expect(banreservasPersonasScraperProfile.accountFingerprint).toBe("banreservas-XXXXXXXXXX");
+    expect(banreservasPersonasScraperProfile.defaultSearchMode).toBe("current-month");
+    expect(banreservasPersonasScraperProfile.inputStrategy).toBe("trusted-click+angular-events");
+  });
+
+  it("login selectors + submit inactive class", () => {
+    expect(banreservasPersonasScraperProfile.selectors).toMatchObject({
+      usernameInput: "input[formControlName='username']#step01",
+      passwordInput: "input[formControlName='password']#step02",
+      submitLink: "a.ipswich-main-buttons-link.default.big",
+      submitInactiveClass: "inactive",
+    });
+  });
+
+  it("transaction table selectors: row, date, description, reference, debit, balance", () => {
+    expect(banreservasPersonasScraperProfile.selectors).toMatchObject({
+      transactionRow: "div.rivera_row",
+      rowDate: "div.rivera_row_info_legend span.marmaris[data-type='date']",
+      rowDescription: "div.rivera_row_info_title span.marmaris[data-type='string']",
+      rowReference: "div.rivera_row_info_subtitle span.marmaris[data-type='textResourceKey']",
+      rowDebit: "div.rivera_row_simple",
+      rowBalance: "div.rivera_row_simple.highlighted",
+    });
+  });
+
+  it("loadMore pagination, calendar, formats", () => {
+    expect(banreservasPersonasScraperProfile.selectors.loadMore).toBe("div.florida_wrapper_loader_default");
+    expect(banreservasPersonasScraperProfile.selectors.calendar).toEqual({
+      root: "div.memphis-main-block.memphis-main-dayView",
+      prevMonth: "a.leftArrow",
+      nextMonth: "a.rightArrow",
+      dayCell: "a.memphis-day-value",
+      todayReset: "a.memphis-day-button-reset",
+    });
+    expect(banreservasPersonasScraperProfile.formats).toEqual({
+      date: "DD/MM/YYYY", amount: "-1,234.56", currencyPrefix: "DOP",
+    });
+  });
+});
+
+describe("Banreservas Empresas profile — recon-derived selectors/facts", () => {
+  it("identity, login, landing, framework, inputStrategy", () => {
+    expect(banreservasEmpresasScraperProfile.bankId).toBe("banreservas");
+    expect(banreservasEmpresasScraperProfile.portalVariant).toBe("empresas");
+    expect(banreservasEmpresasScraperProfile.loginUrl).toBe("https://www.banreservas.com.do/TuBancoEmpresas/Login.aspx");
+    expect(banreservasEmpresasScraperProfile.landingUrl).toBe("https://www.banreservas.com.do/TuBancoEmpresas/Default.aspx");
+    expect(banreservasEmpresasScraperProfile.framework).toBe("aspnet-webforms+devexpress");
+    expect(banreservasEmpresasScraperProfile.inputStrategy).toBe("type+postback");
+  });
+
+  it("frames, routes, login selectors", () => {
+    expect(banreservasEmpresasScraperProfile.frames).toEqual({ top: "topFrame", left: "leftFrame", main: "mainFrame" });
+    expect(banreservasEmpresasScraperProfile.routes).toEqual({
+      accounts: "/TuBancoEmpresas/Pages/Accounts/Accounts.aspx",
+      statementPdf: "/TuBancoEmpresas/Pages/Accounts/AccountStatusPDF.aspx",
+    });
+    expect(banreservasEmpresasScraperProfile.selectors).toMatchObject({
+      usernameInput: "input#ctl00_MainHolder_LoginView_UserName",
+      passwordInput: "input#ctl00_MainHolder_LoginView_Password",
+      captchaInput: "input#ctl00_MainHolder_LoginView_tbCaptcha",
+      submitButton: "input#ctl00_MainHolder_LoginView_btnLogin",
+    });
+  });
+
+  it("transaction grid + date query selectors", () => {
+    expect(banreservasEmpresasScraperProfile.selectors).toMatchObject({
+      accountsGrid: "table#ctl00_MainHolder_AccountGrid_AccountASPxGridView_DXMainTable",
+      transactionGrid: "table#ctl00_MainHolder_AccountTransactionGrid_ASPxGridViewTransactions",
+      transactionRow: "tr[id*='_DXDataRow'].dxgvDataRow",
+      dateFrom: "input#ctl00_MainHolder_period_dateTextBoxDateFrom",
+      dateTo: "input#ctl00_MainHolder_period_dateTextBoxDateTo",
+      consultarButton: "a#ctl00_MainHolder_period_linkButtonConsultar",
+    });
+  });
+
+  it("formats: DD/MM/YY (2-digit year), no currency prefix, DOP balance", () => {
+    expect(banreservasEmpresasScraperProfile.formats).toEqual({
+      date: "DD/MM/YY", amount: "1,234.56", balancePrefix: "DOP",
+    });
+  });
+});
+
+describe("Banreservas portal configs", () => {
+  it("Personas: baseUrl, CDP env, profile dir, start URL, selectors, login allowlist", () => {
+    expect(banreservasPersonasPortalConfig.bankCode).toBe("banreservas");
+    expect(banreservasPersonasPortalConfig.baseUrl).toBe("https://tubanco.banreservas.com");
+    expect(banreservasPersonasPortalConfig.loginPathAllowlist).toContain("/#/administrationGeneral/login");
+    expect(banreservasPersonasPortalConfig.cdpUrlEnv).toBe("RD_SYNC_BANK_BANRESERVAS_PERSONAS_CDP_URL");
+    expect(banreservasPersonasPortalConfig.profileDirEnv).toBe("RD_SYNC_BANK_BANRESERVAS_PERSONAS_PROFILE_DIR");
+    expect(banreservasPersonasPortalConfig.startUrlEnv).toBe("RD_SYNC_BANK_BANRESERVAS_PERSONAS_START_URL");
+    expect(banreservasPersonasPortalConfig.usernameSelector).toBe("input[formControlName='username']#step01");
+    expect(banreservasPersonasPortalConfig.passwordSelector).toBe("input[formControlName='password']#step02");
+    expect(banreservasPersonasPortalConfig.submitSelector).toBe("a.ipswich-main-buttons-link.default.big");
+    expect(banreservasPersonasPortalConfig.incompatibleFlowSelector).toBeUndefined();
+  });
+
+  it("Empresas: baseUrl, CDP env, profile dir, start URL, selectors, login allowlist", () => {
+    expect(banreservasEmpresasPortalConfig.bankCode).toBe("banreservas");
+    expect(banreservasEmpresasPortalConfig.baseUrl).toBe("https://www.banreservas.com.do");
+    expect(banreservasEmpresasPortalConfig.loginPathAllowlist).toContain("/TuBancoEmpresas/Login.aspx");
+    expect(banreservasEmpresasPortalConfig.cdpUrlEnv).toBe("RD_SYNC_BANK_BANRESERVAS_EMPRESAS_CDP_URL");
+    expect(banreservasEmpresasPortalConfig.profileDirEnv).toBe("RD_SYNC_BANK_BANRESERVAS_EMPRESAS_PROFILE_DIR");
+    expect(banreservasEmpresasPortalConfig.startUrlEnv).toBe("RD_SYNC_BANK_BANRESERVAS_EMPRESAS_START_URL");
+    expect(banreservasEmpresasPortalConfig.usernameSelector).toBe("input#ctl00_MainHolder_LoginView_UserName");
+    expect(banreservasEmpresasPortalConfig.passwordSelector).toBe("input#ctl00_MainHolder_LoginView_Password");
+    expect(banreservasEmpresasPortalConfig.submitSelector).toBe("input#ctl00_MainHolder_LoginView_btnLogin");
+    expect(banreservasEmpresasPortalConfig.incompatibleFlowSelector).toBeUndefined();
+  });
+});
+
+describe("Banreservas skeletons — no registration assumptions", () => {
+  it("shared bankCode documents registry limitation; portalVariant is disambiguation key", () => {
+    expect(banreservasPersonasAdapter.bankCode).toBe(banreservasEmpresasAdapter.bankCode);
+    expect(banreservasPersonasAdapter.portalVariant).not.toBe(banreservasEmpresasAdapter.portalVariant);
+  });
+});

--- a/src/modules/bank-adapters/banreservas.ts
+++ b/src/modules/bank-adapters/banreservas.ts
@@ -1,0 +1,130 @@
+/** Banreservas Personas + Empresas — read-only adapter skeletons (PR5B2). */
+/* PR5B2 NOTE: Both variants share `bankCode: "banreservas"` but are TWO
+   completely different tech stacks (Angular SPA vs ASP.NET WebForms frameset).
+   Registration/routing is deferred to PR5.2+ when a routing strategy exists. */
+
+import type { IngestionScraper } from "../../worker/queues";
+import type { CdpSessionChecker } from "../../modules/bank-sessions";
+import type { BankAdapter, BankAutoLoginStrategy } from "./registry";
+
+export const banreservasBankCode = "banreservas" as const;
+export const banreservasPersonasPortalVariant = "personas" as const;
+export const banreservasEmpresasPortalVariant = "empresas" as const;
+
+// ── Personas (Angular SPA — tubanco.banreservas.com) ─────────────────────
+
+export const banreservasPersonasScraperProfile = {
+  bankId: banreservasBankCode,
+  portalVariant: banreservasPersonasPortalVariant,
+  loginUrl: "https://tubanco.banreservas.com/TuBancoBanreservas/#/administrationGeneral/login",
+  rootElement: "icb-app",
+  accountFingerprint: "banreservas-XXXXXXXXXX",
+  defaultSearchMode: "current-month",
+  inputStrategy: "trusted-click+angular-events" as const,
+  selectors: {
+    usernameInput: "input[formControlName='username']#step01",
+    passwordInput: "input[formControlName='password']#step02",
+    submitLink: "a.ipswich-main-buttons-link.default.big",
+    submitInactiveClass: "inactive",
+    periodChipLabel: "span.oldham-panel-title-text",
+    periodOption: "a.oldham-panel-link",
+    calendar: {
+      root: "div.memphis-main-block.memphis-main-dayView",
+      prevMonth: "a.leftArrow",
+      nextMonth: "a.rightArrow",
+      dayCell: "a.memphis-day-value",
+      todayReset: "a.memphis-day-button-reset",
+    },
+    transactionRow: "div.rivera_row",
+    rowDate: "div.rivera_row_info_legend span.marmaris[data-type='date']",
+    rowDescription: "div.rivera_row_info_title span.marmaris[data-type='string']",
+    rowReference: "div.rivera_row_info_subtitle span.marmaris[data-type='textResourceKey']",
+    rowDebit: "div.rivera_row_simple",
+    rowBalance: "div.rivera_row_simple.highlighted",
+    loadMore: "div.florida_wrapper_loader_default",
+    searchInput: "input.estambul_input",
+  },
+  formats: { date: "DD/MM/YYYY", amount: "-1,234.56", currencyPrefix: "DOP" },
+} as const;
+
+export const banreservasPersonasPortalConfig = {
+  bankCode: banreservasBankCode,
+  baseUrl: "https://tubanco.banreservas.com",
+  loginPathAllowlist: ["/#/administrationGeneral/login"] as readonly string[],
+  cdpUrlEnv: "RD_SYNC_BANK_BANRESERVAS_PERSONAS_CDP_URL",
+  profileDirEnv: "RD_SYNC_BANK_BANRESERVAS_PERSONAS_PROFILE_DIR",
+  startUrlEnv: "RD_SYNC_BANK_BANRESERVAS_PERSONAS_START_URL",
+  usernameSelector: banreservasPersonasScraperProfile.selectors.usernameInput,
+  passwordSelector: banreservasPersonasScraperProfile.selectors.passwordInput,
+  submitSelector: banreservasPersonasScraperProfile.selectors.submitLink,
+  incompatibleFlowSelector: undefined,
+} as const;
+
+// ── Empresas (ASP.NET WebForms frameset — www.banreservas.com.do) ────────
+
+export const banreservasEmpresasScraperProfile = {
+  bankId: banreservasBankCode,
+  portalVariant: banreservasEmpresasPortalVariant,
+  loginUrl: "https://www.banreservas.com.do/TuBancoEmpresas/Login.aspx",
+  landingUrl: "https://www.banreservas.com.do/TuBancoEmpresas/Default.aspx",
+  framework: "aspnet-webforms+devexpress" as const,
+  frames: { top: "topFrame", left: "leftFrame", main: "mainFrame" },
+  routes: {
+    accounts: "/TuBancoEmpresas/Pages/Accounts/Accounts.aspx",
+    statementPdf: "/TuBancoEmpresas/Pages/Accounts/AccountStatusPDF.aspx",
+  },
+  inputStrategy: "type+postback" as const,
+  selectors: {
+    usernameInput: "input#ctl00_MainHolder_LoginView_UserName",
+    passwordInput: "input#ctl00_MainHolder_LoginView_Password",
+    captchaInput: "input#ctl00_MainHolder_LoginView_tbCaptcha",
+    submitButton: "input#ctl00_MainHolder_LoginView_btnLogin",
+    accountsGrid: "table#ctl00_MainHolder_AccountGrid_AccountASPxGridView_DXMainTable",
+    dateFrom: "input#ctl00_MainHolder_period_dateTextBoxDateFrom",
+    dateTo: "input#ctl00_MainHolder_period_dateTextBoxDateTo",
+    consultarButton: "a#ctl00_MainHolder_period_linkButtonConsultar",
+    transactionGrid: "table#ctl00_MainHolder_AccountTransactionGrid_ASPxGridViewTransactions",
+    transactionRow: "tr[id*='_DXDataRow'].dxgvDataRow",
+    exportPdf: "a#ctl00_MainHolder_AccountTransactionGrid_linkButtonGeneratePDF",
+    exportCsv: "a#ctl00_MainHolder_AccountTransactionGrid_linkButtonCSV",
+    exportExcel: "a#ctl00_MainHolder_AccountTransactionGrid_linkButton2",
+  },
+  formats: { date: "DD/MM/YY", amount: "1,234.56", balancePrefix: "DOP" },
+} as const;
+
+export const banreservasEmpresasPortalConfig = {
+  bankCode: banreservasBankCode,
+  baseUrl: "https://www.banreservas.com.do",
+  loginPathAllowlist: ["/TuBancoEmpresas/Login.aspx"] as readonly string[],
+  cdpUrlEnv: "RD_SYNC_BANK_BANRESERVAS_EMPRESAS_CDP_URL",
+  profileDirEnv: "RD_SYNC_BANK_BANRESERVAS_EMPRESAS_PROFILE_DIR",
+  startUrlEnv: "RD_SYNC_BANK_BANRESERVAS_EMPRESAS_START_URL",
+  usernameSelector: banreservasEmpresasScraperProfile.selectors.usernameInput,
+  passwordSelector: banreservasEmpresasScraperProfile.selectors.passwordInput,
+  submitSelector: banreservasEmpresasScraperProfile.selectors.submitButton,
+  incompatibleFlowSelector: undefined,
+} as const;
+
+// ── Auto-login stub ──────────────────────────────────────────────────────
+
+export function createBanreservasAutoLoginStrategy(): BankAutoLoginStrategy {
+  throw new Error("Banreservas auto-login strategy is not implemented yet (PR6)");
+}
+
+// ── Adapter factories + stubs ────────────────────────────────────────────
+
+function createPersonasAdapter(opts: { createScraper: () => IngestionScraper; createSessionChecker: () => CdpSessionChecker }): BankAdapter & { readonly portalVariant: string; createSessionChecker(): CdpSessionChecker } {
+  return { bankCode: banreservasBankCode, portalVariant: banreservasPersonasPortalVariant, createScraper: opts.createScraper, createSessionChecker: opts.createSessionChecker, createAutoLoginStrategy: createBanreservasAutoLoginStrategy };
+}
+
+function createEmpresasAdapter(opts: { createScraper: () => IngestionScraper; createSessionChecker: () => CdpSessionChecker }): BankAdapter & { readonly portalVariant: string; createSessionChecker(): CdpSessionChecker } {
+  return { bankCode: banreservasBankCode, portalVariant: banreservasEmpresasPortalVariant, createScraper: opts.createScraper, createSessionChecker: opts.createSessionChecker, createAutoLoginStrategy: createBanreservasAutoLoginStrategy };
+}
+
+const personasStubScraper: IngestionScraper = { collect: async () => ({ status: "needs_admin_action" as const, movements: [], safeErrorSummary: "Banreservas Personas adapter is a skeleton" }) };
+const empresasStubScraper: IngestionScraper = { collect: async () => ({ status: "needs_admin_action" as const, movements: [], safeErrorSummary: "Banreservas Empresas adapter is a skeleton" }) };
+/** Fail-safe: returns expired until real CDP session checker exists (PR5C/D/E). */
+const stubSessionChecker: CdpSessionChecker = { check: async () => ({ status: "expired", checkedAt: new Date().toISOString(), safeSummary: "Bank session expired or requires verification" }) };
+
+export const banreservasPersonasAdapter = createPersonasAdapter({ createScraper: () => personasStubScraper, createSessionChecker: () => stubSessionChecker });
+export const banreservasEmpresasAdapter = createEmpresasAdapter({ createScraper: () => empresasStubScraper, createSessionChecker: () => stubSessionChecker });


### PR DESCRIPTION
## Summary
- Adds Banreservas Personas and Empresas read-only adapter skeletons with recon-derived scraper profiles.
- Adds fail-safe scraper/session checker stubs and tests for visible stub contracts.
- Documents the shared bankCode/portalVariant routing limitation and keeps registry/routing deferred.

## PR stack
- Base branch: feature/multi-bank-auto-login-pr5-bank-mapping.
- This PR intentionally contains only PR5B2 Banreservas skeleton work on top of recon + PR5A fixtures + PR5B1 BHD skeleton.

## Verification
- [x] pnpm test -- src/modules/bank-adapters/banreservas.test.ts — 19/19 pass.
- [x] pnpm test -- src/modules/bank-adapters/ — 83/83 pass.
- [x] pnpm test — full suite passed during review.
- [x] pnpm lint.
- [x] pnpm typecheck.
- [x] git diff --check.
- [x] Fresh Risk, Reliability, and Readability reviews approved after adding missing assertions.

## Notes
- No adapter registration or run-now routing changes in this slice.
- No credential submission, CAPTCHA/OneSpan/MFA automation, export hot path, or auto-login enablement.
- Banreservas Personas and Empresas share bankCode=banreservas; future registration needs explicit portalVariant routing or registry evolution.