### PR TITLE
feat(bank-adapters): split Banreservas portal bank codes

### DIFF
--- a/openspec/changes/multi-bank-auto-login/tasks.md
+++ b/openspec/changes/multi-bank-auto-login/tasks.md
@@ -121,23 +121,51 @@ Gate: full gates + FRESH 4R review + Judgment Day before merge; PR3B1 <=400 line
 ### PR5B2: Banreservas Personas/Empresas read-only adapter skeletons (COMPLETE — slice 2)
 
 **IDENTITY NOTE — Banreservas Personas vs Empresas:** Both variants share
-`bankCode: "banreservas"` but are TWO completely different tech stacks (Angular
-SPA vs ASP.NET WebForms frameset). The current bankCode-keyed registry maps one
-bankCode → one adapter. Personas and Empresas cannot both be registered directly
-without either: (a) a single Banreservas entry with portalVariant routing, or
-(b) evolving the registry to support portalVariant-keyed resolution. Neither
-registration happens in PR5B2 — skeletons only. Registration is deferred to
-PR5.2 or later when the registry routing strategy is decided.
+the Banreservas brand but are TWO completely different tech stacks (Angular
+SPA vs ASP.NET WebForms frameset). The bankCode-keyed registry maps one
+bankCode → one adapter, so shared `bankCode: "banreservas"` would cause
+`Map.set` collisions. PR5B3 resolves this by adopting distinct portal-specific
+bank codes (`banreservas_personas`, `banreservas_empresas`).
 
 - [x] 5.1b Create `src/modules/bank-adapters/banreservas.ts`: Banreservas Personas + Empresas skeletons with scraper profiles/selectors, portal configs from recon, `createScraper`/`createSessionChecker` stubs, `createAutoLoginStrategy` stubs (not enabled). Profile fields preserve core recon handoff facts for PR5C/D/E.
-- [x] 5.1b-tests Tests: `banreservas.test.ts` — shared bankCode, portalVariant differentiation, date format/pagination/inputStrategy divergence, stub scrapers return `needs_admin_action` with exact `safeErrorSummary`, stub session checkers return `expired` with exact `safeSummary`, full profile field assertions, portal config assertions.
+- [x] 5.1b-tests Tests: `banreservas.test.ts` — portal-specific bankCodes, portalVariant differentiation, date format/pagination/inputStrategy divergence, stub scrapers return `needs_admin_action` with exact `safeErrorSummary`, stub session checkers return `expired` with exact `safeSummary`, full profile field assertions, portal config assertions.
 - Gate: full gates; <=400 changed lines; NO auto-login enablement.
 
-### PR5B shared deferred tasks (after PR5B2)
+### PR5B3: Banreservas identity strategy — portal-specific bank codes (COMPLETE — slice 3)
 
-- [ ] 5.2 Register banreservas/bhd in registry; add to `SUPPORTED_RUN_NOW_BANK_CODES` for read-only run-now (deferred to keep PR5B slices skeleton-only).
+**DECISION:** Adopt distinct portal-specific bank codes for the two Banreservas
+portals. The codebase keys `BankAdapterRegistry` (`Map.set`), `BankCredentialRepository`
+(unique `bankCode`), and scrape-run routing by `bankCode`. A shared
+`bankCode: "banreservas"` would cause Map collisions and prevent both adapters
+from being registered simultaneously. Therefore:
+- Personas: `bankCode: "banreservas_personas"`
+- Empresas: `bankCode: "banreservas_empresas"`
+- Display grouping: `banreservasBankGroupCode: "banreservas"` (metadata only, not
+  used for registry/credential routing). UI can render both under Banreservas
+  branding via this group code in a future PR.
+
+**SCOPE:** Identity strategy only in skeletons — no registration, no credential
+wiring, no run-now changes, no UI changes.
+
+**FUTURE PORTAL IDENTITY RULE:** Apply the same pattern to any bank brand that
+gets more than one operational portal. The adapter/credential/scrape-run
+`bankCode` identifies the portal, not only the brand; brand grouping belongs in
+metadata/display fields. When BHD Empresarial becomes available, split BHD into
+portal-specific codes before implementation (for example `bhd_personal` and
+`bhd_empresarial`) instead of registering two adapters as `bhd`. If Popular later
+adds another distinct portal/stack, use the same migration pattern (for example
+`popular_personal` plus the new portal code) while keeping Popular branding as
+group metadata. Do this in a small identity PR before parser/registry wiring.
+
+- [x] 5.1c Update `src/modules/bank-adapters/banreservas.ts`: Replace single `banreservasBankCode` with `banreservasPersonasBankCode` ("banreservas_personas"), `banreservasEmpresasBankCode` ("banreservas_empresas"), and `banreservasBankGroupCode` ("banreservas"). Update scraper profiles, portal configs, and adapter factories to use portal-specific bankCodes.
+- [x] 5.1c-tests Tests: `banreservas.test.ts` — assert distinct bankCodes, no collision, group code independent of adapter bankCodes, registry-safe registration possible, portalVariant preserved.
+- Gate: full gates; <=400 changed lines; NO auto-login enablement; NO registration in registry.
+
+### PR5B shared deferred tasks (after PR5B3)
+
+- [ ] 5.2 Register `bhd`, `banreservas_personas`, and `banreservas_empresas` in the registry; add matching run-now support codes while UI groups Banreservas variants by brand metadata (deferred to keep PR5B slices skeleton-only).
 - [ ] 5.3 Expand `src/worker/scraper/auto-login.portal-drift.test.ts`: Banreservas+BHD pre-submit incompatible-flow fixtures (assert NO fill/submit) + post-submit unknown-flow fixtures. **BLOCKED**: file belongs to PR4 (auto-login infrastructure); deferred.
-- [ ] 5.4 Tests: route by banreservas/bhd bankCode; read-only scrape parity; unknown fails closed ("Este banco aún no está disponible para actualización automática"); portal-drift incompatible pre-submit blocks fill; per-bank adapter kill switch.
+- [ ] 5.4 Tests: route by `bhd`, `banreservas_personas`, and `banreservas_empresas` bankCode; read-only scrape parity; unknown fails closed ("Este banco aún no está disponible para actualización automática"); portal-drift incompatible pre-submit blocks fill; per-bank adapter kill switch.
 - Gate: full gates; <=400 lines; NO auto-login enablement.
 
 ## PR6: Banreservas/BHD auto-login enablement

--- a/src/modules/bank-adapters/banreservas.test.ts
+++ b/src/modules/bank-adapters/banreservas.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
-  banreservasBankCode,
+  banreservasBankGroupCode,
+  banreservasPersonasBankCode,
+  banreservasEmpresasBankCode,
   banreservasPersonasPortalVariant,
   banreservasEmpresasPortalVariant,
   banreservasPersonasScraperProfile,
@@ -11,20 +13,23 @@ import {
   banreservasEmpresasPortalConfig,
   createBanreservasAutoLoginStrategy,
 } from "./banreservas";
+import { createBankAdapterRegistry } from "./registry";
 
 describe("Banreservas adapter identity + portal variant disambiguation", () => {
-  it("shared bankCode = banreservas; variants differ", () => {
-    expect(banreservasBankCode).toBe("banreservas");
-    expect(banreservasPersonasAdapter.bankCode).toBe("banreservas");
-    expect(banreservasEmpresasAdapter.bankCode).toBe("banreservas");
+  it("distinct portal-specific bank codes; group code for display", () => {
+    expect(banreservasBankGroupCode).toBe("banreservas");
+    expect(banreservasPersonasBankCode).toBe("banreservas_personas");
+    expect(banreservasEmpresasBankCode).toBe("banreservas_empresas");
+    expect(banreservasPersonasAdapter.bankCode).toBe("banreservas_personas");
+    expect(banreservasEmpresasAdapter.bankCode).toBe("banreservas_empresas");
     expect(banreservasPersonasAdapter.portalVariant).toBe("personas");
     expect(banreservasEmpresasAdapter.portalVariant).toBe("empresas");
     expect(banreservasPersonasPortalVariant).toBe("personas");
     expect(banreservasEmpresasPortalVariant).toBe("empresas");
   });
 
-  it("both share bankCode but have distinct portalVariant", () => {
-    expect(banreservasPersonasAdapter.bankCode).toBe(banreservasEmpresasAdapter.bankCode);
+  it("adapters have distinct bankCodes — registry-safe (no Map collision)", () => {
+    expect(banreservasPersonasAdapter.bankCode).not.toBe(banreservasEmpresasAdapter.bankCode);
     expect(banreservasPersonasAdapter.portalVariant).not.toBe(banreservasEmpresasAdapter.portalVariant);
   });
 });
@@ -72,7 +77,7 @@ describe("Banreservas auto-login stub — not implemented", () => {
 
 describe("Banreservas Personas profile — recon-derived selectors/facts", () => {
   it("identity, login, rootElement, fingerprint, searchMode, inputStrategy", () => {
-    expect(banreservasPersonasScraperProfile.bankId).toBe("banreservas");
+    expect(banreservasPersonasScraperProfile.bankId).toBe("banreservas_personas");
     expect(banreservasPersonasScraperProfile.portalVariant).toBe("personas");
     expect(banreservasPersonasScraperProfile.loginUrl).toBe(
       "https://tubanco.banreservas.com/TuBancoBanreservas/#/administrationGeneral/login",
@@ -120,7 +125,7 @@ describe("Banreservas Personas profile — recon-derived selectors/facts", () =>
 
 describe("Banreservas Empresas profile — recon-derived selectors/facts", () => {
   it("identity, login, landing, framework, inputStrategy", () => {
-    expect(banreservasEmpresasScraperProfile.bankId).toBe("banreservas");
+    expect(banreservasEmpresasScraperProfile.bankId).toBe("banreservas_empresas");
     expect(banreservasEmpresasScraperProfile.portalVariant).toBe("empresas");
     expect(banreservasEmpresasScraperProfile.loginUrl).toBe("https://www.banreservas.com.do/TuBancoEmpresas/Login.aspx");
     expect(banreservasEmpresasScraperProfile.landingUrl).toBe("https://www.banreservas.com.do/TuBancoEmpresas/Default.aspx");
@@ -162,7 +167,7 @@ describe("Banreservas Empresas profile — recon-derived selectors/facts", () =>
 
 describe("Banreservas portal configs", () => {
   it("Personas: baseUrl, CDP env, profile dir, start URL, selectors, login allowlist", () => {
-    expect(banreservasPersonasPortalConfig.bankCode).toBe("banreservas");
+    expect(banreservasPersonasPortalConfig.bankCode).toBe("banreservas_personas");
     expect(banreservasPersonasPortalConfig.baseUrl).toBe("https://tubanco.banreservas.com");
     expect(banreservasPersonasPortalConfig.loginPathAllowlist).toContain("/#/administrationGeneral/login");
     expect(banreservasPersonasPortalConfig.cdpUrlEnv).toBe("RD_SYNC_BANK_BANRESERVAS_PERSONAS_CDP_URL");
@@ -175,7 +180,7 @@ describe("Banreservas portal configs", () => {
   });
 
   it("Empresas: baseUrl, CDP env, profile dir, start URL, selectors, login allowlist", () => {
-    expect(banreservasEmpresasPortalConfig.bankCode).toBe("banreservas");
+    expect(banreservasEmpresasPortalConfig.bankCode).toBe("banreservas_empresas");
     expect(banreservasEmpresasPortalConfig.baseUrl).toBe("https://www.banreservas.com.do");
     expect(banreservasEmpresasPortalConfig.loginPathAllowlist).toContain("/TuBancoEmpresas/Login.aspx");
     expect(banreservasEmpresasPortalConfig.cdpUrlEnv).toBe("RD_SYNC_BANK_BANRESERVAS_EMPRESAS_CDP_URL");
@@ -189,8 +194,18 @@ describe("Banreservas portal configs", () => {
 });
 
 describe("Banreservas skeletons — no registration assumptions", () => {
-  it("shared bankCode documents registry limitation; portalVariant is disambiguation key", () => {
-    expect(banreservasPersonasAdapter.bankCode).toBe(banreservasEmpresasAdapter.bankCode);
-    expect(banreservasPersonasAdapter.portalVariant).not.toBe(banreservasEmpresasAdapter.portalVariant);
+  it("distinct bankCodes enable future registry registration without Map overwrite", () => {
+    const registry = createBankAdapterRegistry([banreservasPersonasAdapter, banreservasEmpresasAdapter], {});
+
+    expect(registry.get("banreservas_personas")).toBe(banreservasPersonasAdapter);
+    expect(registry.get("banreservas_empresas")).toBe(banreservasEmpresasAdapter);
+    expect(registry.get("banreservas")).toBeUndefined();
+    expect(registry.supportedBankCodes()).toEqual(["banreservas_personas", "banreservas_empresas"]);
+  });
+
+  it("group code is independent of adapter bankCodes (display/metadata only)", () => {
+    expect(banreservasBankGroupCode).toBe("banreservas");
+    expect(banreservasBankGroupCode).not.toBe(banreservasPersonasAdapter.bankCode);
+    expect(banreservasBankGroupCode).not.toBe(banreservasEmpresasAdapter.bankCode);
   });
 });

--- a/src/modules/bank-adapters/banreservas.ts
+++ b/src/modules/bank-adapters/banreservas.ts
@@ -1,20 +1,31 @@
-/** Banreservas Personas + Empresas — read-only adapter skeletons (PR5B2). */
-/* PR5B2 NOTE: Both variants share `bankCode: "banreservas"` but are TWO
-   completely different tech stacks (Angular SPA vs ASP.NET WebForms frameset).
-   Registration/routing is deferred to PR5.2+ when a routing strategy exists. */
+/** Banreservas Personas + Empresas — read-only adapter skeletons (PR5B2/PR5B3). */
 
 import type { IngestionScraper } from "../../worker/queues";
 import type { CdpSessionChecker } from "../../modules/bank-sessions";
 import type { BankAdapter, BankAutoLoginStrategy } from "./registry";
 
-export const banreservasBankCode = "banreservas" as const;
+/**
+ * Portal-specific bank codes for Banreservas Personas and Empresas.
+ *
+ * Both variants share the same brand but are completely different tech stacks
+ * (Angular SPA vs ASP.NET WebForms frameset). The codebase keys adapters,
+ * credentials, and scrape-run routing by `bankCode`, so each portal MUST have
+ * a unique bankCode to avoid `Map.set` collisions in `BankAdapterRegistry` and
+ * unique-constraint violations in `BankCredentialRepository`.
+ *
+ * `banreservasBankGroupCode` is a display/metadata grouping concept only — it
+ * is NOT used for registry routing or credential storage.
+ */
+export const banreservasBankGroupCode = "banreservas" as const;
+export const banreservasPersonasBankCode = "banreservas_personas" as const;
+export const banreservasEmpresasBankCode = "banreservas_empresas" as const;
 export const banreservasPersonasPortalVariant = "personas" as const;
 export const banreservasEmpresasPortalVariant = "empresas" as const;
 
 // ── Personas (Angular SPA — tubanco.banreservas.com) ─────────────────────
 
 export const banreservasPersonasScraperProfile = {
-  bankId: banreservasBankCode,
+  bankId: banreservasPersonasBankCode,
   portalVariant: banreservasPersonasPortalVariant,
   loginUrl: "https://tubanco.banreservas.com/TuBancoBanreservas/#/administrationGeneral/login",
   rootElement: "icb-app",
@@ -48,7 +59,7 @@ export const banreservasPersonasScraperProfile = {
 } as const;
 
 export const banreservasPersonasPortalConfig = {
-  bankCode: banreservasBankCode,
+  bankCode: banreservasPersonasBankCode,
   baseUrl: "https://tubanco.banreservas.com",
   loginPathAllowlist: ["/#/administrationGeneral/login"] as readonly string[],
   cdpUrlEnv: "RD_SYNC_BANK_BANRESERVAS_PERSONAS_CDP_URL",
@@ -63,7 +74,7 @@ export const banreservasPersonasPortalConfig = {
 // ── Empresas (ASP.NET WebForms frameset — www.banreservas.com.do) ────────
 
 export const banreservasEmpresasScraperProfile = {
-  bankId: banreservasBankCode,
+  bankId: banreservasEmpresasBankCode,
   portalVariant: banreservasEmpresasPortalVariant,
   loginUrl: "https://www.banreservas.com.do/TuBancoEmpresas/Login.aspx",
   landingUrl: "https://www.banreservas.com.do/TuBancoEmpresas/Default.aspx",
@@ -93,7 +104,7 @@ export const banreservasEmpresasScraperProfile = {
 } as const;
 
 export const banreservasEmpresasPortalConfig = {
-  bankCode: banreservasBankCode,
+  bankCode: banreservasEmpresasBankCode,
   baseUrl: "https://www.banreservas.com.do",
   loginPathAllowlist: ["/TuBancoEmpresas/Login.aspx"] as readonly string[],
   cdpUrlEnv: "RD_SYNC_BANK_BANRESERVAS_EMPRESAS_CDP_URL",
@@ -114,11 +125,11 @@ export function createBanreservasAutoLoginStrategy(): BankAutoLoginStrategy {
 // ── Adapter factories + stubs ────────────────────────────────────────────
 
 function createPersonasAdapter(opts: { createScraper: () => IngestionScraper; createSessionChecker: () => CdpSessionChecker }): BankAdapter & { readonly portalVariant: string; createSessionChecker(): CdpSessionChecker } {
-  return { bankCode: banreservasBankCode, portalVariant: banreservasPersonasPortalVariant, createScraper: opts.createScraper, createSessionChecker: opts.createSessionChecker, createAutoLoginStrategy: createBanreservasAutoLoginStrategy };
+  return { bankCode: banreservasPersonasBankCode, portalVariant: banreservasPersonasPortalVariant, createScraper: opts.createScraper, createSessionChecker: opts.createSessionChecker, createAutoLoginStrategy: createBanreservasAutoLoginStrategy };
 }
 
 function createEmpresasAdapter(opts: { createScraper: () => IngestionScraper; createSessionChecker: () => CdpSessionChecker }): BankAdapter & { readonly portalVariant: string; createSessionChecker(): CdpSessionChecker } {
-  return { bankCode: banreservasBankCode, portalVariant: banreservasEmpresasPortalVariant, createScraper: opts.createScraper, createSessionChecker: opts.createSessionChecker, createAutoLoginStrategy: createBanreservasAutoLoginStrategy };
+  return { bankCode: banreservasEmpresasBankCode, portalVariant: banreservasEmpresasPortalVariant, createScraper: opts.createScraper, createSessionChecker: opts.createSessionChecker, createAutoLoginStrategy: createBanreservasAutoLoginStrategy };
 }
 
 const personasStubScraper: IngestionScraper = { collect: async () => ({ status: "needs_admin_action" as const, movements: [], safeErrorSummary: "Banreservas Personas adapter is a skeleton" }) };


### PR DESCRIPTION
## Summary
- Splits Banreservas Personas and Empresas into portal-specific bank codes: banreservas_personas and banreservas_empresas.
- Keeps banreservas as brand/group metadata only, not registry/credential routing identity.
- Documents the future identity rule for BHD Empresarial and any future Popular multi-portal work.

## Why
The current registry, credential repository, scrape-run routing, and run-now support are bankCode-keyed. A shared banreservas bankCode would collide in Map-based adapter registration and prevent separate portal credentials.

## Verification
- [x] pnpm test src/modules/bank-adapters/banreservas.test.ts — 20/20 pass.
- [x] pnpm test src/modules/bank-adapters/ — 84/84 pass during review.
- [x] pnpm typecheck.
- [x] pnpm lint.
- [x] git diff --check.
- [x] Fresh Risk, Reliability, and Readability reviews approved after underscore-code fix.

## Notes
- No registry/run-now/schema/UI changes in this slice.
- No credential submission, CAPTCHA/OneSpan/MFA automation, export hot path, or auto-login enablement.
- Bank codes use underscores because browser-runtime validates codes with /^[a-z0-9_]+$/.