### PR TITLE
feat(bank-adapters): register multi-bank run-now routing

### DIFF
--- a/openspec/changes/multi-bank-auto-login/tasks.md
+++ b/openspec/changes/multi-bank-auto-login/tasks.md
@@ -163,9 +163,13 @@ group metadata. Do this in a small identity PR before parser/registry wiring.
 
 ### PR5B shared deferred tasks (after PR5B3)
 
-- [ ] 5.2 Register `bhd`, `banreservas_personas`, and `banreservas_empresas` in the registry; add matching run-now support codes while UI groups Banreservas variants by brand metadata (deferred to keep PR5B slices skeleton-only).
+- [x] 5.2 Register `bhd`, `banreservas_personas`, and `banreservas_empresas` in the registry; add matching run-now support codes while UI labels variants distinctly (brand grouping UX is future work).
+  - [x] 5.2a `src/modules/bank-adapters/registry.ts`: Import BHD/Banreservas adapters, register all three in `bankAdapterRegistry`
+  - [x] 5.2b `src/lib/banks.ts`: Expand `SUPPORTED_RUN_NOW_BANK_CODES` to `["popular", "bhd", "banreservas_personas", "banreservas_empresas"]`; replace single `banreservas` BANKS entry with portal-specific entries
+  - [x] 5.2c `src/lib/banks.ts`: Add `bankDisplayName()` Spanish labels; UI never shows raw underscored codes
+  - [x] 5.2d Tests: registry (8 new), banks (6 new), trigger-scrape-button (4 updated), run-action-affordances (6 updated), scrape-runs/page (1 fixture fix), run-now scheduler/API/consumer route-by-bankCode tests for `bhd`, `banreservas_personas`, and `banreservas_empresas`. All pass. Total changed lines: 381 (352 ins, 29 del) across 12 files.
 - [ ] 5.3 Expand `src/worker/scraper/auto-login.portal-drift.test.ts`: Banreservas+BHD pre-submit incompatible-flow fixtures (assert NO fill/submit) + post-submit unknown-flow fixtures. **BLOCKED**: file belongs to PR4 (auto-login infrastructure); deferred.
-- [ ] 5.4 Tests: route by `bhd`, `banreservas_personas`, and `banreservas_empresas` bankCode; read-only scrape parity; unknown fails closed ("Este banco aún no está disponible para actualización automática"); portal-drift incompatible pre-submit blocks fill; per-bank adapter kill switch.
+- [ ] 5.4 Tests: read-only scrape parity; unknown fails closed ("Este banco aún no está disponible para actualización automática"); portal-drift incompatible pre-submit blocks fill; per-bank adapter kill switch.
 - Gate: full gates; <=400 lines; NO auto-login enablement.
 
 ## PR6: Banreservas/BHD auto-login enablement

--- a/src/app/admin/scrape-runs/page.test.tsx
+++ b/src/app/admin/scrape-runs/page.test.tsx
@@ -52,7 +52,7 @@ const runs: AdminScrapeRun[] = [
   },
   {
     id: "run-2",
-    bankId: "banreservas",
+    bankId: "banreservas_personas",
     status: "succeeded",
     startedAt: "2026-06-07T12:00:00.000Z",
     endedAt: "2026-06-07T12:02:00.000Z",

--- a/src/app/api/scrape-runs/consumer-defaults-popular-cdp.test.ts
+++ b/src/app/api/scrape-runs/consumer-defaults-popular-cdp.test.ts
@@ -270,4 +270,39 @@ describe("resolveDefaultScraper — bankCode registry routing", () => {
     const scraper = resolveDefaultScraper("popular");
     expect(typeof scraper.collect).toBe("function");
   });
+
+  it("routes 'bhd' to the BHD adapter scraper (not Popular)", async () => {
+    // DEV_PREVIEW is enabled so a Popular fallback would return `collected`.
+    // The BHD adapter returns needs_admin_action with its own safeErrorSummary.
+    process.env.RD_SYNC_DEV_PREVIEW = "enabled";
+
+    const scraper = resolveDefaultScraper("bhd");
+    const result = await scraper.collect();
+
+    expect(result.status).toBe("needs_admin_action");
+    expect(result.safeErrorSummary).toBe("BHD Personal adapter is a skeleton");
+    expect(result.movements).toEqual([]);
+  });
+
+  it("routes 'banreservas_personas' to the Banreservas Personas adapter scraper (not Popular)", async () => {
+    process.env.RD_SYNC_DEV_PREVIEW = "enabled";
+
+    const scraper = resolveDefaultScraper("banreservas_personas");
+    const result = await scraper.collect();
+
+    expect(result.status).toBe("needs_admin_action");
+    expect(result.safeErrorSummary).toBe("Banreservas Personas adapter is a skeleton");
+    expect(result.movements).toEqual([]);
+  });
+
+  it("routes 'banreservas_empresas' to the Banreservas Empresas adapter scraper (not Popular)", async () => {
+    process.env.RD_SYNC_DEV_PREVIEW = "enabled";
+
+    const scraper = resolveDefaultScraper("banreservas_empresas");
+    const result = await scraper.collect();
+
+    expect(result.status).toBe("needs_admin_action");
+    expect(result.safeErrorSummary).toBe("Banreservas Empresas adapter is a skeleton");
+    expect(result.movements).toEqual([]);
+  });
 });

--- a/src/app/api/scrape-runs/run-now.route.test.ts
+++ b/src/app/api/scrape-runs/run-now.route.test.ts
@@ -160,6 +160,94 @@ describe("POST /api/scrape-runs/run-now", () => {
     expect(queue.addCalls).toEqual([]);
   });
 
+  it("schedules a BHD ingestion run when bankId='bhd' is requested", async () => {
+    const scrapeRuns = new InMemoryScrapeRunRepository();
+    const queue = new FakeQueue();
+    const handler = createPostScrapeRunNowHandler({
+      scrapeRuns,
+      queue,
+      now: () => new Date("2026-06-09T12:15:00.000Z"),
+      createRunId: () => "bhd-manual-run",
+    });
+
+    const response = await handler(
+      new Request("http://localhost/api/scrape-runs/run-now", {
+        method: "POST",
+        headers: {
+          "x-rd-sync-user-id": "admin-1",
+          "x-rd-sync-role": "admin",
+        },
+        body: JSON.stringify({ bankId: "bhd" }),
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(202);
+    expect(body).toEqual({
+      run: {
+        runId: "bhd-manual-run",
+        bankId: "bhd",
+        accountFingerprint: "popular-0000000000",
+        status: "queued",
+      },
+    });
+    expect(queue.addCalls[0]?.data.bankId).toBe("bhd");
+  });
+
+  it("schedules a Banreservas Personas run when bankId='banreservas_personas' is requested", async () => {
+    const scrapeRuns = new InMemoryScrapeRunRepository();
+    const queue = new FakeQueue();
+    const handler = createPostScrapeRunNowHandler({
+      scrapeRuns,
+      queue,
+      now: () => new Date("2026-06-09T12:15:00.000Z"),
+      createRunId: () => "br-personas-run",
+    });
+
+    const response = await handler(
+      new Request("http://localhost/api/scrape-runs/run-now", {
+        method: "POST",
+        headers: {
+          "x-rd-sync-user-id": "admin-1",
+          "x-rd-sync-role": "admin",
+        },
+        body: JSON.stringify({ bankId: "banreservas_personas" }),
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(202);
+    expect(body.run.bankId).toBe("banreservas_personas");
+    expect(queue.addCalls[0]?.data.bankId).toBe("banreservas_personas");
+  });
+
+  it("schedules a Banreservas Empresas run when bankId='banreservas_empresas' is requested", async () => {
+    const scrapeRuns = new InMemoryScrapeRunRepository();
+    const queue = new FakeQueue();
+    const handler = createPostScrapeRunNowHandler({
+      scrapeRuns,
+      queue,
+      now: () => new Date("2026-06-09T12:15:00.000Z"),
+      createRunId: () => "br-empresas-run",
+    });
+
+    const response = await handler(
+      new Request("http://localhost/api/scrape-runs/run-now", {
+        method: "POST",
+        headers: {
+          "x-rd-sync-user-id": "admin-1",
+          "x-rd-sync-role": "admin",
+        },
+        body: JSON.stringify({ bankId: "banreservas_empresas" }),
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(202);
+    expect(body.run.bankId).toBe("banreservas_empresas");
+    expect(queue.addCalls[0]?.data.bankId).toBe("banreservas_empresas");
+  });
+
   it("returns 400 with a safe message when an unknown bankId is requested", async () => {
     const scrapeRuns = new InMemoryScrapeRunRepository();
     const queue = new FakeQueue();

--- a/src/app/api/scrape-runs/run-now.test.ts
+++ b/src/app/api/scrape-runs/run-now.test.ts
@@ -433,6 +433,105 @@ describe("scheduleIngestionRunNow — active-run lock", () => {
   });
 });
 
+describe("scheduleIngestionRunNow — route-by-bankCode (newly enabled run-now banks)", () => {
+  it("routes a bhd request through the scheduler with bankId 'bhd' (not fallback to Popular)", async () => {
+    const scrapeRuns = new InMemoryScrapeRunRepository();
+    const queue = new FakeQueue();
+
+    const result = await scheduleIngestionRunNow(
+      {
+        principal: { id: "admin-1", role: "admin" },
+        bankId: "bhd",
+      },
+      {
+        scrapeRuns,
+        queue,
+        now: () => new Date("2026-06-09T12:00:00.000Z"),
+        createRunId: () => "run-bhd-now",
+      },
+    );
+
+    expect(result).toEqual({
+      runId: "run-bhd-now",
+      bankId: "bhd",
+      accountFingerprint: "popular-0000000000",
+      status: "queued",
+    });
+    expect(await scrapeRuns.list({})).toMatchObject([
+      { id: "run-bhd-now", bankId: "bhd", status: "queued" },
+    ]);
+    expect(queue.addCalls[0]?.data.bankId).toBe("bhd");
+  });
+
+  it("routes a banreservas_personas request through the scheduler with bankId 'banreservas_personas'", async () => {
+    const scrapeRuns = new InMemoryScrapeRunRepository();
+    const queue = new FakeQueue();
+
+    const result = await scheduleIngestionRunNow(
+      {
+        principal: { id: "admin-1", role: "admin" },
+        bankId: "banreservas_personas",
+      },
+      {
+        scrapeRuns,
+        queue,
+        now: () => new Date("2026-06-09T12:00:00.000Z"),
+        createRunId: () => "run-br-personas",
+      },
+    );
+
+    expect(result).toMatchObject({
+      runId: "run-br-personas",
+      bankId: "banreservas_personas",
+      status: "queued",
+    });
+    expect(queue.addCalls[0]?.data.bankId).toBe("banreservas_personas");
+  });
+
+  it("routes a banreservas_empresas request through the scheduler with bankId 'banreservas_empresas'", async () => {
+    const scrapeRuns = new InMemoryScrapeRunRepository();
+    const queue = new FakeQueue();
+
+    const result = await scheduleIngestionRunNow(
+      {
+        principal: { id: "admin-1", role: "admin" },
+        bankId: "banreservas_empresas",
+      },
+      {
+        scrapeRuns,
+        queue,
+        now: () => new Date("2026-06-09T12:00:00.000Z"),
+        createRunId: () => "run-br-empresas",
+      },
+    );
+
+    expect(result).toMatchObject({
+      runId: "run-br-empresas",
+      bankId: "banreservas_empresas",
+      status: "queued",
+    });
+    expect(queue.addCalls[0]?.data.bankId).toBe("banreservas_empresas");
+  });
+
+  it("does NOT accept unsupported 'banreservas' (must use portal-specific codes)", async () => {
+    const scrapeRuns = new InMemoryScrapeRunRepository();
+    const queue = new FakeQueue();
+
+    await expect(
+      scheduleIngestionRunNow(
+        {
+          principal: { id: "admin-1", role: "admin" },
+          bankId: "banreservas",
+        },
+        { scrapeRuns, queue },
+      ),
+    ).rejects.toThrow(/Unsupported bank for manual run/);
+
+    expect(await scrapeRuns.list({})).toEqual([]);
+    expect(queue.addCalls).toEqual([]);
+  });
+});
+
 describe("scheduleIngestionRunNow — queue failure recovery", () => {
   it("marks the persisted run failed with a SAFE summary (no raw queue error) when the queue throws", async () => {
     const scrapeRuns = new InMemoryScrapeRunRepository();

--- a/src/components/admin/run-action-affordances.test.tsx
+++ b/src/components/admin/run-action-affordances.test.tsx
@@ -229,8 +229,14 @@ describe("scrapeRunStatusLabel / bankDisplayName — label maps", () => {
 
   it("maps every supported bankId to its display name (no raw id leakage)", () => {
     expect(bankDisplayName("popular")).toBe("Banco Popular");
-    expect(bankDisplayName("banreservas")).toBe("Banreservas");
     expect(bankDisplayName("bhd")).toBe("BHD");
+    expect(bankDisplayName("banreservas_personas")).toBe("Banreservas Personas");
+    expect(bankDisplayName("banreservas_empresas")).toBe("Banreservas Empresas");
+  });
+
+  it("never exposes raw underscored codes to the operator UI", () => {
+    expect(bankDisplayName("banreservas_personas")).not.toContain("_");
+    expect(bankDisplayName("banreservas_empresas")).not.toContain("_");
   });
 
   it("falls back to the raw bankId when no display name is registered (defensive)", () => {

--- a/src/components/admin/trigger-scrape-button.test.tsx
+++ b/src/components/admin/trigger-scrape-button.test.tsx
@@ -15,16 +15,23 @@ import {
 } from "./trigger-scrape-button";
 import { toast } from "sonner";
 
-describe("SUPPORTED_RUN_NOW_BANK_CODES — bankCode whitelist", () => {
-  it("exposes Popular as the only currently supported bank", () => {
-    expect(SUPPORTED_RUN_NOW_BANK_CODES).toEqual(["popular"]);
+describe("SUPPORTED_RUN_NOW_BANK_CODES — bankCode whitelist (PR5.2)", () => {
+  it("exposes all four supported bank codes", () => {
+    expect(SUPPORTED_RUN_NOW_BANK_CODES).toEqual([
+      "popular",
+      "bhd",
+      "banreservas_personas",
+      "banreservas_empresas",
+    ]);
     expect(DEFAULT_RUN_NOW_BANK_CODE).toBe("popular");
   });
 
-  it("recognises popular as supported and rejects every other bankCode", () => {
+  it("recognises all four bank codes as supported and rejects unknown codes", () => {
     expect(isSupportedRunNowBankCode("popular")).toBe(true);
+    expect(isSupportedRunNowBankCode("bhd")).toBe(true);
+    expect(isSupportedRunNowBankCode("banreservas_personas")).toBe(true);
+    expect(isSupportedRunNowBankCode("banreservas_empresas")).toBe(true);
     expect(isSupportedRunNowBankCode("banreservas")).toBe(false);
-    expect(isSupportedRunNowBankCode("bhd")).toBe(false);
     expect(isSupportedRunNowBankCode("")).toBe(false);
   });
 });

--- a/src/components/admin/trigger-scrape-button.tsx
+++ b/src/components/admin/trigger-scrape-button.tsx
@@ -25,9 +25,9 @@ export {
 interface TriggerScrapeButtonProps {
   /**
    * Bank the new run should target. The page-level "Run now" trigger is not
-   * attached to a specific card, so it falls back to the Popular profile (the
-   * only scraper currently shipping). Per-row affordances should always pass
-   * the card's `bankId` explicitly.
+   * attached to a specific card, so it falls back to the Popular default.
+   * Multiple banks are now supported for manual runs; per-row affordances
+   * should always pass the card's `bankId` explicitly.
    */
   bankId?: string;
   /**

--- a/src/lib/banks.test.ts
+++ b/src/lib/banks.test.ts
@@ -4,20 +4,33 @@ import { bankAdapterRegistry } from "../modules/bank-adapters/registry";
 import {
   DEFAULT_RUN_NOW_BANK_CODE,
   SUPPORTED_RUN_NOW_BANK_CODES,
+  bankDisplayName,
   isSupportedRunNowBankCode,
 } from "./banks";
 
-describe("SUPPORTED_RUN_NOW_BANK_CODES — canonical bankCode whitelist", () => {
-  it("exposes Popular as the only currently supported bank code in PR1", () => {
-    expect(SUPPORTED_RUN_NOW_BANK_CODES).toEqual(["popular"]);
+describe("SUPPORTED_RUN_NOW_BANK_CODES — canonical bankCode whitelist (PR5.2)", () => {
+  it("exposes all four supported bank codes", () => {
+    expect(SUPPORTED_RUN_NOW_BANK_CODES).toEqual([
+      "popular",
+      "bhd",
+      "banreservas_personas",
+      "banreservas_empresas",
+    ]);
     expect(DEFAULT_RUN_NOW_BANK_CODE).toBe("popular");
   });
 
-  it("recognises popular as supported and rejects every other bankCode", () => {
+  it("recognises all four bank codes as supported", () => {
     expect(isSupportedRunNowBankCode("popular")).toBe(true);
+    expect(isSupportedRunNowBankCode("bhd")).toBe(true);
+    expect(isSupportedRunNowBankCode("banreservas_personas")).toBe(true);
+    expect(isSupportedRunNowBankCode("banreservas_empresas")).toBe(true);
+  });
+
+  it("rejects unknown and partial-match bank codes", () => {
     expect(isSupportedRunNowBankCode("banreservas")).toBe(false);
-    expect(isSupportedRunNowBankCode("bhd")).toBe(false);
+    expect(isSupportedRunNowBankCode("bhd_personal")).toBe(false);
     expect(isSupportedRunNowBankCode("")).toBe(false);
+    expect(isSupportedRunNowBankCode("unknown")).toBe(false);
   });
 });
 
@@ -31,5 +44,18 @@ describe("SUPPORTED_RUN_NOW_BANK_CODES — registry parity (derived from registr
     expect([...SUPPORTED_RUN_NOW_BANK_CODES]).toEqual([
       ...bankAdapterRegistry.supportedBankCodes(),
     ]);
+  });
+});
+
+describe("bankDisplayName — operator-facing labels (no raw underscored codes)", () => {
+  it("maps supported bank codes to professional Spanish display names", () => {
+    expect(bankDisplayName("popular")).toBe("Banco Popular");
+    expect(bankDisplayName("bhd")).toBe("BHD");
+    expect(bankDisplayName("banreservas_personas")).toBe("Banreservas Personas");
+    expect(bankDisplayName("banreservas_empresas")).toBe("Banreservas Empresas");
+  });
+
+  it("falls back to the raw bankId when no display name is registered", () => {
+    expect(bankDisplayName("unknown-bank")).toBe("unknown-bank");
   });
 });

--- a/src/lib/banks.ts
+++ b/src/lib/banks.ts
@@ -32,9 +32,15 @@ export const BANKS: Record<string, BankMeta> = {
     color: "#54AD4D",
     logoSrc: "/banks/bhd.svg",
   },
-  banreservas: {
-    id: "banreservas",
-    name: "Banreservas",
+  banreservas_personas: {
+    id: "banreservas_personas",
+    name: "Banreservas Personas",
+    color: "#264E72",
+    logoSrc: "/banks/banreservas.svg",
+  },
+  banreservas_empresas: {
+    id: "banreservas_empresas",
+    name: "Banreservas Empresas",
     color: "#264E72",
     logoSrc: "/banks/banreservas.svg",
   },
@@ -64,12 +70,18 @@ export function getBankMeta(bankId: string): BankMeta {
  * `src/modules/bank-adapters/registry.ts` (and implementing the scraper
  * profile).
  */
-export const SUPPORTED_RUN_NOW_BANK_CODES = ["popular"] as const;
+export const SUPPORTED_RUN_NOW_BANK_CODES = [
+  "popular",
+  "bhd",
+  "banreservas_personas",
+  "banreservas_empresas",
+] as const;
 export type SupportedRunNowBankCode = (typeof SUPPORTED_RUN_NOW_BANK_CODES)[number];
 
 /**
  * Bank the page-level "Run now" trigger targets when no card is selected.
- * Falls back to the only scraper currently shipping.
+ * Multiple banks are now supported for manual runs; this remains the default
+ * when the UI has no card-level bank context.
  */
 export const DEFAULT_RUN_NOW_BANK_CODE: SupportedRunNowBankCode = "popular";
 

--- a/src/modules/bank-adapters/registry.test.ts
+++ b/src/modules/bank-adapters/registry.test.ts
@@ -91,7 +91,7 @@ describe("createBankAdapterRegistry — CDP endpoint uniqueness guard (MEDIUM-2)
   });
 });
 
-describe("bankAdapterRegistry — default instance (Popular registered in PR1)", () => {
+describe("bankAdapterRegistry — default instance (PR5.2: Popular + BHD + Banreservas registered)", () => {
   it("resolves the Popular adapter by its canonical bankCode", () => {
     const adapter = bankAdapterRegistry.get("popular");
 
@@ -99,14 +99,51 @@ describe("bankAdapterRegistry — default instance (Popular registered in PR1)",
     expect(adapter?.bankCode).toBe("popular");
   });
 
-  it("exposes only Popular as supported in PR1 (Banreservas/BHD land in PR5)", () => {
-    expect(bankAdapterRegistry.supportedBankCodes()).toEqual(["popular"]);
+  it("resolves BHD Personal adapter by bankCode 'bhd'", () => {
+    const adapter = bankAdapterRegistry.get("bhd");
+
+    expect(adapter).toBeDefined();
+    expect(adapter?.bankCode).toBe("bhd");
+  });
+
+  it("resolves Banreservas Personas adapter by bankCode 'banreservas_personas'", () => {
+    const adapter = bankAdapterRegistry.get("banreservas_personas");
+
+    expect(adapter).toBeDefined();
+    expect(adapter?.bankCode).toBe("banreservas_personas");
+  });
+
+  it("resolves Banreservas Empresas adapter by bankCode 'banreservas_empresas'", () => {
+    const adapter = bankAdapterRegistry.get("banreservas_empresas");
+
+    expect(adapter).toBeDefined();
+    expect(adapter?.bankCode).toBe("banreservas_empresas");
+  });
+
+  it("exposes all four supported bank codes (no Banreservas Map overwrite)", () => {
+    expect(bankAdapterRegistry.supportedBankCodes()).toEqual([
+      "popular",
+      "bhd",
+      "banreservas_personas",
+      "banreservas_empresas",
+    ]);
+  });
+
+  it("both Banreservas portal adapters are retrievable without collision", () => {
+    const personas = bankAdapterRegistry.get("banreservas_personas");
+    const empresas = bankAdapterRegistry.get("banreservas_empresas");
+
+    expect(personas).toBeDefined();
+    expect(empresas).toBeDefined();
+    expect(personas).not.toBe(empresas);
+    expect(personas?.bankCode).toBe("banreservas_personas");
+    expect(empresas?.bankCode).toBe("banreservas_empresas");
   });
 
   it("returns undefined for an explicit unknown bankCode (never falls back to Popular)", () => {
     expect(bankAdapterRegistry.get("banreservas")).toBeUndefined();
-    expect(bankAdapterRegistry.get("bhd")).toBeUndefined();
     expect(bankAdapterRegistry.get("unknown-bank")).toBeUndefined();
+    expect(bankAdapterRegistry.get("")).toBeUndefined();
   });
 
   it("the Popular adapter's createScraper yields a usable IngestionScraper (lazy, no env read at import)", () => {

--- a/src/modules/bank-adapters/registry.ts
+++ b/src/modules/bank-adapters/registry.ts
@@ -31,6 +31,11 @@ import {
   popularBankCode,
   popularPortalFixture,
 } from "./popular";
+import { bhdPersonalAdapter } from "./bhd";
+import {
+  banreservasPersonasAdapter,
+  banreservasEmpresasAdapter,
+} from "./banreservas";
 
 /**
  * Placeholder for the auto-login strategy contract. PR4 fleshes this out into
@@ -226,12 +231,16 @@ const popularAdapter: BankAdapter = createPopularBankAdapter({
 });
 
 /**
- * Default bank adapter registry. PR1 registers only Popular; Banreservas and
- * BHD adapters are added in PR5. Routing and run-now validation resolve
- * through this instance so an explicit unknown `bankCode` fails closed.
+ * Default bank adapter registry. PR5.2 registers Popular, BHD Personal,
+ * Banreservas Personas, and Banreservas Empresas. Routing and run-now
+ * validation resolve through this instance so an explicit unknown
+ * `bankCode` fails closed.
  */
 export const bankAdapterRegistry: BankAdapterRegistry = createBankAdapterRegistry([
   popularAdapter,
+  bhdPersonalAdapter,
+  banreservasPersonasAdapter,
+  banreservasEmpresasAdapter,
 ]);
 
 // Re-export the canonical Popular code alongside the registry for convenience.


### PR DESCRIPTION
## Summary
- Registers BHD and portal-specific Banreservas skeleton adapters in the default bank adapter registry.
- Expands run-now support to popular, bhd, banreservas_personas, and banreservas_empresas.
- Adds scheduler/API/consumer route-by-bankCode tests to prove new codes do not fall back to Popular.

## PR stack
- Base branch: feature/multi-bank-auto-login-pr5-bank-mapping.
- This PR builds on PR5A fixtures, PR5B1 BHD skeleton, PR5B2 Banreservas skeletons, and PR5B3 identity strategy.

## Verification
- [x] pnpm test — full suite passed during review.
- [x] targeted 8 touched test files — 113 passed.
- [x] pnpm lint.
- [x] pnpm typecheck.
- [x] git diff --check.
- [x] Fresh Risk, Reliability, and Readability reviews approved after tasks.md scope fix.

## Notes
- No real extraction implementation in this slice.
- No credential submission, CAPTCHA/OneSpan/MFA automation, export hot path, or auto-login enablement.
- Brand grouping UX remains future work; current UI labels variants distinctly without leaking raw underscored codes.