### PR TITLE
feat(bank-adapters): parse BHD personal transactions

### DIFF
--- a/openspec/changes/multi-bank-auto-login/tasks.md
+++ b/openspec/changes/multi-bank-auto-login/tasks.md
@@ -174,6 +174,16 @@ group metadata. Do this in a small identity PR before parser/registry wiring.
 - [ ] 5.4c Per-bank adapter kill switch — **BLOCKED**: requires PR4 `BankAdapterConfig` model and admin toggle wiring. Deferred to PR4 branch.
 - Gate: full gates; <=400 lines; NO auto-login enablement.
 
+### PR5C: BHD Personal read-only DOM extraction (parser + integration)
+
+**SCOPE:** Replace the BHD skeleton stub scraper/parser with real transaction
+parsing from sanitized DOM/table-like fixtures. This is NOT auto-login.
+Session checker remains fail-safe (returns `expired`).
+
+- [x] 5.5a Add `parseBhdDate`, `parseBhdAmount`, `parseBhdTransactionRows` to `src/modules/bank-adapters/bhd.ts`: pure helpers that parse BHD Personal DD/MM/YYYY dates, RD$ amounts, and fixture rows into normalized `BankMovement` objects matching the Popular/adapter contract.
+- [x] 5.5a-tests TDD: `bhd.test.ts` — 30 new tests (36 total) covering date parsing (happy + impossible calendar/error), amount parsing (RD$ prefix, empty/malformed), transaction row parsing (fixture round-trip, confirmation→reference, no balance leakage, custom overrides, malformed rejection, debit/credit exclusivity, optional field normalization).
+- Gate: targeted BHD tests + fixture tests; <=400 changed lines; session checker remains fail-safe; no auto-login enablement.
+
 ## PR6: Banreservas/BHD auto-login enablement
 
 - [ ] 6.1 Implement banreservas/bhd `createAutoLoginStrategy` (username/password-only; safe fallback->`needs_admin_action` on corporate/token/incompatible flow).

--- a/src/modules/bank-adapters/bhd.test.ts
+++ b/src/modules/bank-adapters/bhd.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 import {
   bhdPersonalAdapter, bhdPersonalScraperProfile,
   bhdPersonalPortalConfig, bhdBankCode,
+  parseBhdDate, parseBhdAmount, parseBhdTransactionRows,
 } from "./bhd";
+import { bhdPersonalTransactions } from "./fixtures/bhd-personal";
 
 describe("BHD Personal adapter identity + skeleton contract", () => {
   it("bankCode=bhd, portalVariant=personal, auto-login not implemented", () => {
@@ -62,5 +64,235 @@ describe("BHD portal config", () => {
     expect(bhdPersonalPortalConfig.baseUrl).toBe("https://ibp.bhd.com.do");
     expect(bhdPersonalPortalConfig.loginPathAllowlist).toContain("/#/login");
     expect(bhdPersonalPortalConfig.cdpUrlEnv).toBe("RD_SYNC_BANK_BHD_CDP_URL");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseBhdDate — DD/MM/YYYY → ISO 8601 with Santo Domingo offset
+// ---------------------------------------------------------------------------
+
+describe("parseBhdDate", () => {
+  it("parses DD/MM/YYYY to ISO 8601 with -04:00 offset", () => {
+    expect(parseBhdDate("27/06/2026")).toBe("2026-06-27T00:00:00-04:00");
+  });
+
+  it("parses zero-padded day and month", () => {
+    expect(parseBhdDate("01/01/2025")).toBe("2025-01-01T00:00:00-04:00");
+  });
+
+  it("parses 31/12/2024 year boundary", () => {
+    expect(parseBhdDate("31/12/2024")).toBe("2024-12-31T00:00:00-04:00");
+  });
+
+  it("throws on non-DD/MM/YYYY format", () => {
+    expect(() => parseBhdDate("2026-06-27")).toThrow("Invalid BHD date format");
+  });
+
+  it("throws on short year", () => {
+    expect(() => parseBhdDate("27/06/26")).toThrow("Invalid BHD date format");
+  });
+
+  it("throws on empty string", () => {
+    expect(() => parseBhdDate("")).toThrow("Invalid BHD date format");
+  });
+
+  it("throws on impossible month 13", () => {
+    expect(() => parseBhdDate("27/13/2026")).toThrow("Invalid BHD date format");
+  });
+
+  it("throws on impossible day 32", () => {
+    expect(() => parseBhdDate("32/06/2026")).toThrow("Invalid BHD date format");
+  });
+
+  it("throws on day 31 for 30-day month (April)", () => {
+    expect(() => parseBhdDate("31/04/2026")).toThrow("Invalid BHD date format");
+  });
+
+  it("throws on Feb 30", () => {
+    expect(() => parseBhdDate("30/02/2026")).toThrow("Invalid BHD date format");
+  });
+
+  it("throws on Feb 29 in non-leap year", () => {
+    expect(() => parseBhdDate("29/02/2025")).toThrow("Invalid BHD date format");
+  });
+
+  it("accepts Feb 29 in leap year 2024", () => {
+    expect(parseBhdDate("29/02/2024")).toBe("2024-02-29T00:00:00-04:00");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseBhdAmount — "RD$ 1,234.56" → { value, direction }
+// ---------------------------------------------------------------------------
+
+describe("parseBhdAmount", () => {
+  it("parses positive RD$ credit amount", () => {
+    const r = parseBhdAmount("RD$ 15,000.00");
+    expect(r.value).toBe(15000);
+    expect(r.direction).toBe("credit");
+  });
+
+  it("parses debit amount from the debit column", () => {
+    const r = parseBhdAmount("RD$ 679.51");
+    expect(r.value).toBeCloseTo(679.51);
+    // Direction is determined by column context, not the amount string.
+    // parseBhdAmount returns credit for positive; the row parser maps debit column → debit.
+    expect(r.direction).toBe("credit");
+  });
+
+  it("parses zero amount as credit", () => {
+    const r = parseBhdAmount("RD$ 0.00");
+    expect(r.value).toBe(0);
+    expect(r.direction).toBe("credit");
+  });
+
+  it("throws on malformed amount", () => {
+    expect(() => parseBhdAmount("RD$ --")).toThrow("Invalid BHD amount format");
+  });
+
+  it("throws on empty string", () => {
+    expect(() => parseBhdAmount("")).toThrow("Invalid BHD amount format");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseBhdTransactionRows — BhdPersonalTransaction[] → BankMovement[]
+// ---------------------------------------------------------------------------
+
+describe("parseBhdTransactionRows", () => {
+  it("parses fixture transactions into BankMovement objects", () => {
+    const movements = parseBhdTransactionRows(bhdPersonalTransactions);
+
+    expect(movements).toHaveLength(2);
+
+    expect(movements[0]).toMatchObject({
+      bankId: "bhd",
+      accountFingerprint: "bhd-XXXXXXXXXX",
+      postedAt: "2026-06-27T00:00:00-04:00",
+      amount: "15000.00",
+      currency: "DOP",
+      direction: "credit",
+      concept: "DEPOSITO EN EFECTIVO",
+    });
+    expect(movements[0].reference).toBe("2638001");
+
+    expect(movements[1]).toMatchObject({
+      bankId: "bhd",
+      accountFingerprint: "bhd-XXXXXXXXXX",
+      postedAt: "2026-06-27T00:00:00-04:00",
+      amount: "679.51",
+      currency: "DOP",
+      direction: "debit",
+      concept: "Fondo reservado Visa Db: 20260627",
+    });
+    expect(movements[1].reference).toBe("2638002");
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(parseBhdTransactionRows([])).toEqual([]);
+  });
+
+  it("includes confirmation number as reference", () => {
+    const movements = parseBhdTransactionRows(bhdPersonalTransactions);
+    for (const m of movements) {
+      expect(typeof m.reference).toBe("string");
+      expect(m.reference!.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("does not include balance in the output movement", () => {
+    const movements = parseBhdTransactionRows(bhdPersonalTransactions);
+    for (const m of movements) {
+      expect(JSON.stringify(m)).not.toContain("balance");
+    }
+  });
+
+  it("accepts custom bankId and accountFingerprint overrides", () => {
+    const movements = parseBhdTransactionRows(bhdPersonalTransactions, {
+      bankId: "bhd-custom",
+      accountFingerprint: "bhd-custom-fp",
+    });
+    expect(movements[0].bankId).toBe("bhd-custom");
+    expect(movements[0].accountFingerprint).toBe("bhd-custom-fp");
+  });
+
+  it("rejects malformed dates in transaction rows", () => {
+    expect(() =>
+      parseBhdTransactionRows([
+        { ...bhdPersonalTransactions[0], date: "2026-06-27" },
+      ]),
+    ).toThrow("Invalid BHD date format");
+  });
+
+  it("rejects malformed amounts in transaction rows", () => {
+    expect(() =>
+      parseBhdTransactionRows([
+        { ...bhdPersonalTransactions[0], debit: "RD$ --", credit: "" },
+      ]),
+    ).toThrow("Invalid BHD amount format");
+  });
+
+  it("rejects row where both debit and credit are populated", () => {
+    expect(() =>
+      parseBhdTransactionRows([
+        {
+          ...bhdPersonalTransactions[0],
+          debit: "RD$ 100.00",
+          credit: "RD$ 200.00",
+        },
+      ]),
+    ).toThrow("ambiguous");
+  });
+
+  it("rejects row where both debit and credit are empty", () => {
+    expect(() =>
+      parseBhdTransactionRows([
+        {
+          ...bhdPersonalTransactions[0],
+          debit: "",
+          credit: "",
+        },
+      ]),
+    ).toThrow("missing");
+  });
+
+  it("normalizes whitespace-only confirmationNumber to null", () => {
+    const movements = parseBhdTransactionRows([
+      {
+        ...bhdPersonalTransactions[0],
+        confirmationNumber: "   ",
+      },
+    ]);
+    expect(movements[0].reference).toBeNull();
+  });
+
+  it("trims whitespace from confirmationNumber", () => {
+    const movements = parseBhdTransactionRows([
+      {
+        ...bhdPersonalTransactions[0],
+        confirmationNumber: " 2638001 ",
+      },
+    ]);
+    expect(movements[0].reference).toBe("2638001");
+  });
+
+  it("normalizes whitespace-only receipt to null in metadata", () => {
+    const movements = parseBhdTransactionRows([
+      {
+        ...bhdPersonalTransactions[0],
+        receipt: "   ",
+      },
+    ]);
+    expect(movements[0].metadata!.receipt).toBeNull();
+  });
+
+  it("trims whitespace from receipt", () => {
+    const movements = parseBhdTransactionRows([
+      {
+        ...bhdPersonalTransactions[0],
+        receipt: " 0000000000 ",
+      },
+    ]);
+    expect(movements[0].metadata!.receipt).toBe("0000000000");
   });
 });

--- a/src/modules/bank-adapters/bhd.ts
+++ b/src/modules/bank-adapters/bhd.ts
@@ -2,9 +2,11 @@
 /* PR5B NOTE: BHD is NOT registered in the bankCode-keyed registry yet. Registration
    lands in PR5.2 or later; this file exports the skeleton for testing only. */
 
+import type { BankMovement, TransactionDirection } from "../../modules/transactions";
 import type { IngestionScraper } from "../../worker/queues";
 import type { CdpSessionChecker } from "../../modules/bank-sessions";
 import type { BankAdapter, BankAutoLoginStrategy } from "./registry";
+import type { BhdPersonalTransaction } from "./fixtures/types";
 
 export const bhdBankCode = "bhd" as const;
 export const bhdPersonalPortalVariant = "personal" as const;
@@ -47,6 +49,114 @@ export const bhdPersonalPortalConfig = {
   submitSelector: bhdPersonalScraperProfile.selectors.submitButton,
   incompatibleFlowSelector: undefined,
 } as const;
+
+// ---------------------------------------------------------------------------
+// Transaction parser — BHD Personal DD/MM/YYYY + RD$ amounts → BankMovement
+// ---------------------------------------------------------------------------
+
+const SANTO_DOMINGO_OFFSET = "-04:00";
+
+export interface BhdPersonalParseOptions {
+  accountFingerprint?: string;
+  bankId?: string;
+  currency?: string;
+}
+
+export function parseBhdDate(value: string): string {
+  const match = /^(\d{2})\/(\d{2})\/(\d{4})$/.exec(value.trim());
+  if (!match) throw new Error("Invalid BHD date format");
+
+  const [, dayStr, monthStr, yearStr] = match;
+  const day = Number(dayStr);
+  const month = Number(monthStr);
+  const year = Number(yearStr);
+
+  // Validate month range.
+  if (month < 1 || month > 12) throw new Error("Invalid BHD date format");
+
+  // Validate day range for the given month (including leap-year check for Feb).
+  const daysInMonth = new Date(year, month, 0).getDate();
+  if (day < 1 || day > daysInMonth) throw new Error("Invalid BHD date format");
+
+  return `${yearStr}-${monthStr}-${dayStr}T00:00:00${SANTO_DOMINGO_OFFSET}`;
+}
+
+export function parseBhdAmount(value: string): { value: number; direction: TransactionDirection } {
+  const normalized = value
+    .replace(/RD\$/gi, "")
+    .replace(/,/g, "")
+    .trim();
+  if (normalized === "") throw new Error("Invalid BHD amount format");
+  const amount = Number(normalized);
+  if (!Number.isFinite(amount)) throw new Error("Invalid BHD amount format");
+
+  return {
+    value: amount,
+    direction: amount < 0 ? "debit" : "credit",
+  };
+}
+
+function normalizeOptionalField(value: string): string | null {
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function parseBhdTransactionRows(
+  rows: readonly BhdPersonalTransaction[],
+  options: BhdPersonalParseOptions = {},
+): BankMovement[] {
+  return rows.map((row) => {
+    const postedAt = parseBhdDate(row.date);
+
+    // Debit and credit are separate columns — exactly one must be populated.
+    const debitText = row.debit.trim();
+    const creditText = row.credit.trim();
+
+    let amount: number;
+    let direction: TransactionDirection;
+
+    if (debitText && creditText) {
+      throw new Error(
+        `BHD parser: ambiguous amount — both debit ("${debitText}") and credit ("${creditText}") are populated`,
+      );
+    }
+
+    if (!debitText && !creditText) {
+      throw new Error(
+        "BHD parser: missing amount — both debit and credit columns are empty",
+      );
+    }
+
+    if (debitText) {
+      const parsed = parseBhdAmount(debitText);
+      amount = parsed.value;
+      direction = "debit";
+    } else {
+      const parsed = parseBhdAmount(creditText);
+      amount = parsed.value;
+      direction = "credit";
+    }
+
+    return {
+      bankId: options.bankId ?? bhdBankCode,
+      accountFingerprint: options.accountFingerprint ?? bhdPersonalScraperProfile.accountFingerprint,
+      postedAt,
+      amount: Math.abs(amount).toFixed(2),
+      currency: options.currency ?? "DOP",
+      direction,
+      reference: normalizeOptionalField(row.confirmationNumber),
+      concept: normalizeText(row.description),
+      originator: null,
+      metadata: {
+        receipt: normalizeOptionalField(row.receipt),
+      },
+    };
+  });
+}
+
+function normalizeText(value: string): string {
+  return value.trim().replace(/\s+/g, " ");
+}
 
 export function createBhdAutoLoginStrategy(): BankAutoLoginStrategy {
   throw new Error("BHD auto-login strategy is not implemented yet (PR6)");


### PR DESCRIPTION
## Summary
- Adds BHD Personal read-only transaction parsing helpers for DD/MM/YYYY dates, RD$ amounts, and sanitized table rows.
- Fails closed on malformed BHD rows, impossible calendar dates, and invalid debit/credit column states.
- Updates PR5 task metadata to record the BHD extraction sub-slice while leaving PR4-dependent work blocked.

## Changes
| File | Change |
|------|--------|
| `src/modules/bank-adapters/bhd.ts` | Adds pure BHD parsing helpers for dates, amounts, row normalization, debit/credit mapping, and optional field normalization. |
| `src/modules/bank-adapters/bhd.test.ts` | Adds 30 behavior-focused parser tests, including review-remediated fail-closed cases. |
| `openspec/changes/multi-bank-auto-login/tasks.md` | Adds PR5C BHD Personal DOM extraction slice status. |

## Test Plan
- [x] `pnpm test -- src/modules/bank-adapters/bhd.test.ts`
- [x] `pnpm test -- src/modules/bank-adapters/fixtures/__tests__/bank-transaction-fixtures.test.ts`
- [x] `pnpm test`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `git diff --check`

## Review Notes
- Changed lines: 352 insertions, 0 deletions across 3 files.
- Fresh review initially requested fixes for debit/credit exclusivity, impossible dates, and optional field normalization.
- Remediation completed; fresh re-review approved with no findings.
- No credential submission, no auto-login enablement, no MFA/CAPTCHA/OneSpan automation, and no export hot path.
- This repository currently has no GitHub issues or `type:*` labels, so this PR follows the existing RD-Sync PR practice.