### PR TITLE
feat(bank-adapters): parse Banreservas Personas transactions

### DIFF
--- a/openspec/changes/multi-bank-auto-login/tasks.md
+++ b/openspec/changes/multi-bank-auto-login/tasks.md
@@ -184,6 +184,16 @@ Session checker remains fail-safe (returns `expired`).
 - [x] 5.5a-tests TDD: `bhd.test.ts` — 30 new tests (36 total) covering date parsing (happy + impossible calendar/error), amount parsing (RD$ prefix, empty/malformed), transaction row parsing (fixture round-trip, confirmation→reference, no balance leakage, custom overrides, malformed rejection, debit/credit exclusivity, optional field normalization).
 - Gate: targeted BHD tests + fixture tests; <=400 changed lines; session checker remains fail-safe; no auto-login enablement.
 
+### PR5D: Banreservas Personas read-only DOM extraction (parser) [COMPLETE]
+
+**SCOPE:** Add pure transaction parsing functions for Banreservas Personas
+DOM/table-like fixtures. This is NOT auto-login. Session checker remains
+fail-safe (returns `expired`).
+
+- [x] 5.6a Add `parseBanreservasPersonasDate`, `parseBanreservasPersonasAmount`, `parseBanreservasPersonasTransactionRows` to `src/modules/bank-adapters/banreservas.ts`: pure helpers that parse Banreservas Personas DD/MM/YYYY dates, raw amounts (no RD$ prefix, negative for debits), and fixture rows into normalized `BankMovement` objects matching the adapter contract.
+- [x] 5.6a-tests TDD: `banreservas.test.ts` — 32 new tests (52 total) covering date parsing (happy + impossible calendar/error), amount parsing (raw format, empty/malformed, negative debits), transaction row parsing (fixture round-trip, pipe-separated reference normalization, no balance leakage, custom overrides, malformed rejection, debit/credit exclusivity, optional field normalization, absolute amount output).
+- Gate: targeted Banreservas tests + fixture tests; <=400 changed lines; session checker remains fail-safe; no auto-login enablement.
+
 ## PR6: Banreservas/BHD auto-login enablement
 
 - [ ] 6.1 Implement banreservas/bhd `createAutoLoginStrategy` (username/password-only; safe fallback->`needs_admin_action` on corporate/token/incompatible flow).

--- a/src/modules/bank-adapters/banreservas.test.ts
+++ b/src/modules/bank-adapters/banreservas.test.ts
@@ -12,8 +12,12 @@ import {
   banreservasPersonasPortalConfig,
   banreservasEmpresasPortalConfig,
   createBanreservasAutoLoginStrategy,
+  parseBanreservasPersonasDate,
+  parseBanreservasPersonasAmount,
+  parseBanreservasPersonasTransactionRows,
 } from "./banreservas";
 import { createBankAdapterRegistry } from "./registry";
+import { banreservasPersonasTransactions } from "./fixtures/banreservas-personas";
 
 describe("Banreservas adapter identity + portal variant disambiguation", () => {
   it("distinct portal-specific bank codes; group code for display", () => {
@@ -196,7 +200,6 @@ describe("Banreservas portal configs", () => {
 describe("Banreservas skeletons — no registration assumptions", () => {
   it("distinct bankCodes enable future registry registration without Map overwrite", () => {
     const registry = createBankAdapterRegistry([banreservasPersonasAdapter, banreservasEmpresasAdapter], {});
-
     expect(registry.get("banreservas_personas")).toBe(banreservasPersonasAdapter);
     expect(registry.get("banreservas_empresas")).toBe(banreservasEmpresasAdapter);
     expect(registry.get("banreservas")).toBeUndefined();
@@ -207,5 +210,211 @@ describe("Banreservas skeletons — no registration assumptions", () => {
     expect(banreservasBankGroupCode).toBe("banreservas");
     expect(banreservasBankGroupCode).not.toBe(banreservasPersonasAdapter.bankCode);
     expect(banreservasBankGroupCode).not.toBe(banreservasEmpresasAdapter.bankCode);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseBanreservasPersonasDate — DD/MM/YYYY → ISO 8601 with Santo Domingo offset
+// ---------------------------------------------------------------------------
+
+describe("parseBanreservasPersonasDate", () => {
+  it("parses DD/MM/YYYY to ISO 8601 with -04:00 offset", () => {
+    expect(parseBanreservasPersonasDate("29/06/2026")).toBe("2026-06-29T00:00:00-04:00");
+  });
+
+  it("parses zero-padded day and month", () => {
+    expect(parseBanreservasPersonasDate("01/01/2025")).toBe("2025-01-01T00:00:00-04:00");
+  });
+
+  it("parses 31/12/2024 year boundary", () => {
+    expect(parseBanreservasPersonasDate("31/12/2024")).toBe("2024-12-31T00:00:00-04:00");
+  });
+
+  it.each([
+    ["2026-06-29", "non-DD/MM/YYYY format (ISO)"],
+    ["29/06/26", "short year (DD/MM/YY)"],
+    ["", "empty string"],
+    ["29/13/2026", "impossible month 13"],
+    ["32/06/2026", "impossible day 32"],
+    ["31/04/2026", "day 31 for 30-day month (April)"],
+    ["30/02/2026", "Feb 30"],
+    ["29/02/2025", "Feb 29 in non-leap year"],
+  ])("throws on %s (%s)", (input) => {
+    expect(() => parseBanreservasPersonasDate(input)).toThrow("Invalid Banreservas Personas date format");
+  });
+
+  it("accepts Feb 29 in leap year 2024", () => {
+    expect(parseBanreservasPersonasDate("29/02/2024")).toBe("2024-02-29T00:00:00-04:00");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseBanreservasPersonasAmount — "44,000.00" or "-5,000.00" → { value, direction }
+// ---------------------------------------------------------------------------
+
+describe("parseBanreservasPersonasAmount", () => {
+  it("parses positive credit amount", () => {
+    const r = parseBanreservasPersonasAmount("44,000.00");
+    expect(r.value).toBe(44000);
+    expect(r.direction).toBe("credit");
+  });
+
+  it("parses negative debit amount", () => {
+    const r = parseBanreservasPersonasAmount("-5,000.00");
+    expect(r.value).toBe(-5000);
+    expect(r.direction).toBe("debit");
+  });
+
+  it("parses zero amount as credit", () => {
+    const r = parseBanreservasPersonasAmount("0.00");
+    expect(r.value).toBe(0);
+    expect(r.direction).toBe("credit");
+  });
+
+  it("parses amount without thousands separator", () => {
+    const r = parseBanreservasPersonasAmount("1234.56");
+    expect(r.value).toBeCloseTo(1234.56);
+    expect(r.direction).toBe("credit");
+  });
+
+  it("parses large grouped amount (1,234,567.89)", () => {
+    const r = parseBanreservasPersonasAmount("1,234,567.89");
+    expect(r.value).toBe(1234567.89);
+    expect(r.direction).toBe("credit");
+  });
+
+  it.each([
+    ["44,00.00", "malformed grouping (2-digit group)"],
+    ["4,4,000.00", "malformed grouping (extra comma)"],
+    [",100.00", "leading comma"],
+    ["100,.00", "trailing comma before decimal"],
+    ["1,23.456", "non-standard group size"],
+  ])("rejects malformed comma grouping: %s (%s)", (input) => {
+    expect(() => parseBanreservasPersonasAmount(input)).toThrow("Invalid Banreservas Personas amount format");
+  });
+
+  it.each([
+    ["abc", "non-numeric"],
+    ["", "empty string"],
+    ["--5000", "double negative"],
+  ])("throws on %s (%s)", (input) => {
+    expect(() => parseBanreservasPersonasAmount(input)).toThrow("Invalid Banreservas Personas amount format");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseBanreservasPersonasTransactionRows — fixture round-trip → BankMovement[]
+// ---------------------------------------------------------------------------
+
+describe("parseBanreservasPersonasTransactionRows", () => {
+  it("parses fixture transactions into BankMovement objects", () => {
+    const movements = parseBanreservasPersonasTransactionRows(banreservasPersonasTransactions);
+    expect(movements).toHaveLength(2);
+
+    expect(movements[0]).toMatchObject({
+      bankId: "banreservas_personas",
+      accountFingerprint: "banreservas-XXXXXXXXXX",
+      postedAt: "2026-06-29T00:00:00-04:00",
+      amount: "44000.00",
+      currency: "DOP",
+      direction: "credit",
+      concept: "TRANSFERENCIA RECIBIDA",
+    });
+    expect(movements[0].reference).toBe("Nro. transacción: 408900123456 | Número de referencia: 408900123");
+
+    expect(movements[1]).toMatchObject({
+      bankId: "banreservas_personas",
+      accountFingerprint: "banreservas-XXXXXXXXXX",
+      postedAt: "2026-06-28T00:00:00-04:00",
+      amount: "5000.00",
+      currency: "DOP",
+      direction: "debit",
+      concept: "TRANSFERENCIA A COMERCIO DEMO",
+    });
+    expect(movements[1].reference).toBe("Nro. transacción: 408900234567 | Número de referencia: 408900234");
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(parseBanreservasPersonasTransactionRows([])).toEqual([]);
+  });
+
+  it("accepts custom bankId and accountFingerprint overrides", () => {
+    const movements = parseBanreservasPersonasTransactionRows(banreservasPersonasTransactions, {
+      bankId: "banreservas-custom",
+      accountFingerprint: "banreservas-custom-fp",
+    });
+    expect(movements[0].bankId).toBe("banreservas-custom");
+    expect(movements[0].accountFingerprint).toBe("banreservas-custom-fp");
+  });
+
+  it("rejects malformed dates in transaction rows", () => {
+    expect(() =>
+      parseBanreservasPersonasTransactionRows([{ ...banreservasPersonasTransactions[0], date: "2026-06-29" }]),
+    ).toThrow("Invalid Banreservas Personas date format");
+  });
+
+  it("rejects malformed amounts in transaction rows", () => {
+    expect(() =>
+      parseBanreservasPersonasTransactionRows([
+        { ...banreservasPersonasTransactions[0], debit: "abc", credit: "" },
+      ]),
+    ).toThrow("Invalid Banreservas Personas amount format");
+  });
+
+  it("rejects malformed comma grouping in transaction rows", () => {
+    expect(() =>
+      parseBanreservasPersonasTransactionRows([
+        { ...banreservasPersonasTransactions[0], debit: "", credit: "44,00.00" },
+      ]),
+    ).toThrow("Invalid Banreservas Personas amount format");
+  });
+
+  it("rejects row where both debit and credit are populated", () => {
+    expect(() =>
+      parseBanreservasPersonasTransactionRows([
+        { ...banreservasPersonasTransactions[0], debit: "-5,000.00", credit: "44,000.00" },
+      ]),
+    ).toThrow("ambiguous");
+  });
+
+  it("rejects row where both debit and credit are empty", () => {
+    expect(() =>
+      parseBanreservasPersonasTransactionRows([
+        { ...banreservasPersonasTransactions[0], debit: "", credit: "" },
+      ]),
+    ).toThrow("missing");
+  });
+
+  it("rejects debit column with positive amount (sign/column mismatch)", () => {
+    expect(() =>
+      parseBanreservasPersonasTransactionRows([
+        { ...banreservasPersonasTransactions[0], debit: "5,000.00", credit: "" },
+      ]),
+    ).toThrow("sign/column mismatch");
+  });
+
+  it("rejects credit column with negative amount (sign/column mismatch)", () => {
+    expect(() =>
+      parseBanreservasPersonasTransactionRows([
+        { ...banreservasPersonasTransactions[0], debit: "", credit: "-1,000.00" },
+      ]),
+    ).toThrow("sign/column mismatch");
+  });
+
+  it("normalizes whitespace-only reference to null", () => {
+    const movements = parseBanreservasPersonasTransactionRows([
+      { ...banreservasPersonasTransactions[0], reference: "   " },
+    ]);
+    expect(movements[0].reference).toBeNull();
+  });
+
+  it("trims whitespace from reference", () => {
+    const movements = parseBanreservasPersonasTransactionRows([
+      {
+        ...banreservasPersonasTransactions[0],
+        reference: "  # Nro. transacción : 408900123456 | Número de referencia : 408900123  ",
+      },
+    ]);
+    expect(movements[0].reference).toBe("Nro. transacción: 408900123456 | Número de referencia: 408900123");
   });
 });

--- a/src/modules/bank-adapters/banreservas.ts
+++ b/src/modules/bank-adapters/banreservas.ts
@@ -1,8 +1,11 @@
-/** Banreservas Personas + Empresas — read-only adapter skeletons (PR5B2/PR5B3). */
+/** Banreservas Personas + Empresas — read-only adapter skeletons (PR5B2/PR5B3)
+ *  + Personas DOM extraction parser (PR5D/PR5F). */
 
+import type { BankMovement, TransactionDirection } from "../../modules/transactions";
 import type { IngestionScraper } from "../../worker/queues";
 import type { CdpSessionChecker } from "../../modules/bank-sessions";
 import type { BankAdapter, BankAutoLoginStrategy } from "./registry";
+import type { BanreservasPersonasTransaction } from "./fixtures/types";
 
 /**
  * Portal-specific bank codes for Banreservas Personas and Empresas.
@@ -120,6 +123,152 @@ export const banreservasEmpresasPortalConfig = {
 
 export function createBanreservasAutoLoginStrategy(): BankAutoLoginStrategy {
   throw new Error("Banreservas auto-login strategy is not implemented yet (PR6)");
+}
+
+// ---------------------------------------------------------------------------
+// Transaction parser — Banreservas Personas DD/MM/YYYY + comma amounts → BankMovement
+// ---------------------------------------------------------------------------
+
+const SANTO_DOMINGO_OFFSET = "-04:00";
+
+export interface BanreservasPersonasParseOptions {
+  accountFingerprint?: string;
+  bankId?: string;
+  currency?: string;
+}
+
+export function parseBanreservasPersonasDate(value: string): string {
+  const match = /^(\d{2})\/(\d{2})\/(\d{4})$/.exec(value.trim());
+  if (!match) throw new Error("Invalid Banreservas Personas date format");
+
+  const [, dayStr, monthStr, yearStr] = match;
+  const day = Number(dayStr);
+  const month = Number(monthStr);
+  const year = Number(yearStr);
+
+  // Validate month range.
+  if (month < 1 || month > 12) throw new Error("Invalid Banreservas Personas date format");
+
+  // Validate day range for the given month (including leap-year check for Feb).
+  const daysInMonth = new Date(year, month, 0).getDate();
+  if (day < 1 || day > daysInMonth) throw new Error("Invalid Banreservas Personas date format");
+
+  return `${yearStr}-${monthStr}-${dayStr}T00:00:00${SANTO_DOMINGO_OFFSET}`;
+}
+
+export function parseBanreservasPersonasAmount(value: string): { value: number; direction: TransactionDirection } {
+  const trimmed = value.trim();
+  if (trimmed === "") throw new Error("Invalid Banreservas Personas amount format");
+
+  // Validate comma grouping BEFORE stripping: commas must follow standard
+  // thousands grouping (exactly 3 digits after each comma).  This rejects
+  // malformed inputs like "44,00.00" or "4,4,000.00" that a blind strip-all-commas
+  // approach would silently accept.
+  const hasCommas = trimmed.includes(",");
+  if (hasCommas && !/^-?\d{1,3}(,\d{3})+(\.\d+)?$/.test(trimmed)) {
+    throw new Error("Invalid Banreservas Personas amount format");
+  }
+
+  const normalized = trimmed.replace(/,/g, "");
+  // Reject malformed patterns: leading/trailing dots, double negatives, etc.
+  if (!/^-?\d+(\.\d+)?$/.test(normalized)) {
+    throw new Error("Invalid Banreservas Personas amount format");
+  }
+
+  const amount = Number(normalized);
+  if (!Number.isFinite(amount)) throw new Error("Invalid Banreservas Personas amount format");
+
+  return {
+    value: amount,
+    direction: amount < 0 ? "debit" : "credit",
+  };
+}
+
+function normalizeText(value: string): string {
+  return value.trim().replace(/\s+/g, " ");
+}
+
+/**
+ * Parse the Banreservas Personas pipe-separated reference field into a
+ * human-readable string. The raw reference is in the form:
+ *   `# Nro. transacción : 408900123456 | Número de referencia : 408900123`
+ * We normalize to: `Nro. transacción: 408900123456 | Número de referencia: 408900123`
+ */
+function parseBanreservasPersonasReference(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return null;
+
+  // Split on pipe and normalize each part: strip leading `# ` and trim whitespace.
+  const parts = trimmed.split("|").map((part) => {
+    const cleaned = part.trim().replace(/^#\s*/, "");
+    // Collapse whitespace around colon: `Nro. transacción :` → `Nro. transacción:`
+    return cleaned.replace(/\s*:\s*/, ": ");
+  });
+
+  return parts.join(" | ");
+}
+
+export function parseBanreservasPersonasTransactionRows(
+  rows: readonly BanreservasPersonasTransaction[],
+  options: BanreservasPersonasParseOptions = {},
+): BankMovement[] {
+  return rows.map((row) => {
+    const postedAt = parseBanreservasPersonasDate(row.date);
+
+    // Debit and credit are separate columns — exactly one must be populated.
+    const debitText = row.debit.trim();
+    const creditText = row.credit.trim();
+
+    let amount: number;
+    let direction: TransactionDirection;
+
+    if (debitText && creditText) {
+      throw new Error(
+        `Banreservas Personas parser: ambiguous amount — both debit ("${debitText}") and credit ("${creditText}") are populated`,
+      );
+    }
+
+    if (!debitText && !creditText) {
+      throw new Error(
+        "Banreservas Personas parser: missing amount — both debit and credit columns are empty",
+      );
+    }
+
+    if (debitText) {
+      const parsed = parseBanreservasPersonasAmount(debitText);
+      // Sign/column mismatch: positive amount in debit column is invalid.
+      if (parsed.direction !== "debit") {
+        throw new Error(
+          `Banreservas Personas parser: sign/column mismatch — debit column contains positive amount "${debitText}"`,
+        );
+      }
+      amount = parsed.value;
+      direction = parsed.direction;
+    } else {
+      const parsed = parseBanreservasPersonasAmount(creditText);
+      // Sign/column mismatch: negative amount in credit column is invalid.
+      if (parsed.direction !== "credit") {
+        throw new Error(
+          `Banreservas Personas parser: sign/column mismatch — credit column contains negative amount "${creditText}"`,
+        );
+      }
+      amount = parsed.value;
+      direction = parsed.direction;
+    }
+
+    return {
+      bankId: options.bankId ?? banreservasPersonasBankCode,
+      accountFingerprint: options.accountFingerprint ?? banreservasPersonasScraperProfile.accountFingerprint,
+      postedAt,
+      amount: Math.abs(amount).toFixed(2),
+      currency: options.currency ?? "DOP",
+      direction,
+      reference: parseBanreservasPersonasReference(row.reference),
+      concept: normalizeText(row.description),
+      originator: null,
+      metadata: null,
+    };
+  });
 }
 
 // ── Adapter factories + stubs ────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds Banreservas Personas read-only transaction parsing helpers for DD/MM/YYYY dates, Personas amount format, and pipe-separated references.
- Fails closed on malformed amount grouping, impossible calendar dates, ambiguous/missing debit-credit states, and sign/column mismatches.
- Updates PR5 task metadata to record the Banreservas Personas extraction sub-slice while leaving Empresas and PR4-dependent work pending.

## Changes
| File | Change |
|------|--------|
| `src/modules/bank-adapters/banreservas.ts` | Adds Banreservas Personas parser helpers for dates, amounts, references, row normalization, and debit/credit validation. |
| `src/modules/bank-adapters/banreservas.test.ts` | Adds behavior-focused Personas parser tests, including review-remediated financial fail-closed cases. |
| `openspec/changes/multi-bank-auto-login/tasks.md` | Adds PR5D Banreservas Personas parser slice status. |

## Test Plan
- [x] `pnpm vitest run src/modules/bank-adapters/banreservas.test.ts src/modules/bank-adapters/fixtures/__tests__/bank-transaction-fixtures.test.ts`
- [x] `pnpm test`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `git diff --check`

## Review Notes
- Changed lines: 370 insertions, 2 deletions across 3 files.
- Fresh review initially requested sign/column mismatch fixes.
- Re-review requested malformed comma-grouping rejection and budget compaction.
- Final fresh re-review approved with no findings.
- No credential submission, no auto-login enablement, no MFA/CAPTCHA/OneSpan automation, and no export hot path.
- This repository currently has no GitHub issues or `type:*` labels, so this PR follows the existing RD-Sync PR practice.