### PR TITLE
feat(observability): wire browser capacity metrics alert and audit (PR2B.2)

### DIFF
--- a/openspec/changes/multi-bank-auto-login/tasks.md
+++ b/openspec/changes/multi-bank-auto-login/tasks.md
@@ -53,7 +53,7 @@ Tracker branch `feature/multi-bank-auto-login` (base = current/main per repo con
 ## PR2B: Browser capacity/backpressure + metrics (deferred)
 
 - [x] 2B.1 Add and wire browser semaphore/backpressure into the production Popular CDP scraper path (`RD_SYNC_BANK_BROWSER_MAX_CONCURRENCY`, bounded queue, acquire timeout, safe throttled result, release in `finally`).
-- [ ] 2B.2 Capacity metrics exporter/alert wiring deferred; removed standalone test-only metrics scaffolding from PR2B rather than marking production metrics complete.
+- [x] 2B.2 Capacity metrics exporter/alert wiring: poll-based `BrowserCapacityMonitor` (`src/modules/observability/browser-capacity-monitor.ts`) samples the real shared `BrowserSemaphore` and alerts/audits via the existing `AdminAlertSink`/`AuditSink` (no Prometheus/statsd/external exporter — no metrics backend exists in this codebase, by explicit user decision). Capacity is reported host-wide, not per-bank, because the underlying semaphore is a process-global singleton shared across all banks.
 - [x] 2B.3 Add deterministic throttle/capacity tests for scraper backpressure. No HTTP 503/Retry-After surface is implemented in this worker-only slice.
 - [x] 2B.4 Keep Banreservas/BHD placeholder portal configs deferred to PR5; no production-looking placeholder selectors in PR2B unless real read-only adapters land.
 - Gate: full gates; <=400 changed-line target; no credential vault or auto-login logic.

--- a/src/app/api/defaults-global-sharing.test.ts
+++ b/src/app/api/defaults-global-sharing.test.ts
@@ -21,6 +21,7 @@ const GLOBAL_KEYS = [
   "__rdSyncAuditSink",
   "__rdSyncIngestionConsumer",
   "__rdSyncSessionMonitor",
+  "__rdSyncBrowserCapacityMonitor",
 ] as const;
 
 function clearGlobalSingletons() {
@@ -300,6 +301,64 @@ describe("defaultSessionMonitor — globalThis sharing and single-start guard", 
     expect(monitorB).toBe(monitorA);
 
     // Clean up the timer started above
+    monitorA?.stop();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Browser capacity monitor — globalThis sharing + single-start guard
+// ---------------------------------------------------------------------------
+
+describe("defaultBrowserCapacityMonitor — globalThis sharing and single-start guard", () => {
+  beforeEach(() => {
+    clearGlobalSingletons();
+    vi.resetModules();
+    delete process.env.RD_SYNC_BROWSER_CAPACITY_MONITOR;
+  });
+
+  afterEach(() => {
+    clearGlobalSingletons();
+    vi.resetModules();
+    delete process.env.RD_SYNC_BROWSER_CAPACITY_MONITOR;
+  });
+
+  it("null monitor is shared across module graphs when disabled", async () => {
+    const { defaultBrowserCapacityMonitor: monitorA } = await import(
+      "./scrape-runs/consumer-defaults"
+    );
+
+    vi.resetModules();
+
+    const { defaultBrowserCapacityMonitor: monitorB } = await import(
+      "./scrape-runs/consumer-defaults"
+    );
+
+    expect(monitorA).toBeNull();
+    expect(monitorB).toBeNull();
+  });
+
+  it("is idempotent across two module graphs (no double timer)", async () => {
+    process.env.RD_SYNC_BROWSER_CAPACITY_MONITOR = "enabled";
+
+    // Same rationale as the session monitor test above: the module-level
+    // singleton is constructed and started at import time, so idempotency is
+    // observed via the globalThis anchor reusing the SAME (already-started)
+    // instance across a simulated second module graph.
+    const { defaultBrowserCapacityMonitor: monitorA } = await import(
+      "./scrape-runs/consumer-defaults"
+    );
+
+    expect(monitorA).not.toBeNull();
+    monitorA?.start(); // second call must be a no-op (handle guard)
+
+    vi.resetModules();
+
+    const { defaultBrowserCapacityMonitor: monitorB } = await import(
+      "./scrape-runs/consumer-defaults"
+    );
+
+    expect(monitorB).toBe(monitorA);
+
     monitorA?.stop();
   });
 });

--- a/src/app/api/scrape-runs/capacity-monitor-defaults.test.ts
+++ b/src/app/api/scrape-runs/capacity-monitor-defaults.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// resolveDefaultBrowserCapacityMonitor — env-gated wiring
+//
+// consumer-defaults.ts also caches a module-load-time singleton on
+// globalThis, but that anchor persists across vi.resetModules() within the
+// same worker (resetModules only clears the module registry, not
+// globalThis) — so this test exercises the resolver function directly,
+// mirroring resolveDefaultSessionMonitor's own test in
+// src/app/api/bank-sessions/defaults.test.ts. Kept minimal per the line budget.
+// ---------------------------------------------------------------------------
+
+describe("resolveDefaultBrowserCapacityMonitor — env branches", () => {
+  afterEach(() => {
+    delete process.env.RD_SYNC_BROWSER_CAPACITY_MONITOR;
+    delete process.env.RD_SYNC_REDIS_URL;
+    vi.resetModules();
+  });
+
+  it("returns null when RD_SYNC_BROWSER_CAPACITY_MONITOR is not set to 'enabled'", async () => {
+    delete process.env.RD_SYNC_BROWSER_CAPACITY_MONITOR;
+    process.env.RD_SYNC_REDIS_URL = "redis://localhost:6379";
+
+    const { resolveDefaultBrowserCapacityMonitor } = await import("./consumer-defaults");
+
+    expect(resolveDefaultBrowserCapacityMonitor()).toBeNull();
+  });
+
+  it("returns a monitor with start/stop/tick/lastState when RD_SYNC_BROWSER_CAPACITY_MONITOR=enabled", async () => {
+    process.env.RD_SYNC_BROWSER_CAPACITY_MONITOR = "enabled";
+    process.env.RD_SYNC_REDIS_URL = "redis://localhost:6379";
+
+    const { resolveDefaultBrowserCapacityMonitor } = await import("./consumer-defaults");
+    const monitor = resolveDefaultBrowserCapacityMonitor();
+
+    expect(monitor).not.toBeNull();
+    expect(typeof monitor?.start).toBe("function");
+    expect(typeof monitor?.stop).toBe("function");
+    expect(typeof monitor?.tick).toBe("function");
+    expect(typeof monitor?.lastState).toBe("function");
+  });
+});

--- a/src/app/api/scrape-runs/consumer-defaults.ts
+++ b/src/app/api/scrape-runs/consumer-defaults.ts
@@ -3,6 +3,11 @@ import type { IngestionJob, IngestionScraper } from "../../../worker/queues";
 import { createInMemoryIngestionConsumer, type InMemoryIngestionConsumer } from "../../../worker/ingestion-consumer";
 import { redactDiagnosticText } from "../../../worker/scraper";
 import { resolveDefaultAlertSink } from "../../../worker/alerts/email-alert-sink";
+import { getBrowserCapacitySnapshotFromEnv } from "../../../worker/scraper/browser-runtime";
+import {
+  createBrowserCapacityMonitor,
+  type BrowserCapacityMonitor,
+} from "../../../modules/observability/browser-capacity-monitor";
 import { bankAdapterRegistry } from "../../../modules/bank-adapters/registry";
 import { defaultAuditSink } from "../audit/defaults";
 import { defaultTransactionRepository } from "../transactions/defaults";
@@ -111,3 +116,60 @@ function getOrCreateDefaultIngestionConsumer(): InMemoryIngestionConsumer | unde
 
 export const defaultIngestionConsumer: InMemoryIngestionConsumer | undefined =
   getOrCreateDefaultIngestionConsumer();
+
+// ---------------------------------------------------------------------------
+// defaultBrowserCapacityMonitor
+//
+// Env-gated wiring for the host-wide browser capacity monitor, mirroring
+// resolveDefaultSessionMonitor in src/app/api/bank-sessions/defaults.ts.
+//
+// Relevant env vars:
+//   RD_SYNC_BROWSER_CAPACITY_MONITOR              — "enabled" activates the monitor
+//   RD_SYNC_BROWSER_CAPACITY_CHECK_INTERVAL_MS    — poll interval ms (default 60000, min 30000)
+// ---------------------------------------------------------------------------
+
+const CAPACITY_MIN_INTERVAL_MS = 30_000;
+const CAPACITY_DEFAULT_INTERVAL_MS = 60_000;
+
+function resolveCapacityIntervalMs(): number {
+  const raw = process.env.RD_SYNC_BROWSER_CAPACITY_CHECK_INTERVAL_MS;
+  if (!raw) return CAPACITY_DEFAULT_INTERVAL_MS;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return CAPACITY_DEFAULT_INTERVAL_MS;
+  return Math.max(parsed, CAPACITY_MIN_INTERVAL_MS);
+}
+
+/**
+ * Returns a browser capacity monitor wired to the real shared BrowserSemaphore
+ * singleton, the default alert sink, and the default audit sink — or null
+ * when RD_SYNC_BROWSER_CAPACITY_MONITOR !== "enabled".
+ */
+export function resolveDefaultBrowserCapacityMonitor(): BrowserCapacityMonitor | null {
+  if (process.env.RD_SYNC_BROWSER_CAPACITY_MONITOR !== "enabled") {
+    return null;
+  }
+
+  return createBrowserCapacityMonitor({
+    sample: getBrowserCapacitySnapshotFromEnv,
+    alertSink: resolveDefaultAlertSink(),
+    auditSink: defaultAuditSink,
+    intervalMs: resolveCapacityIntervalMs(),
+  });
+}
+
+const capacityGlobalRegistry = globalThis as typeof globalThis & {
+  __rdSyncBrowserCapacityMonitor?: BrowserCapacityMonitor | null;
+};
+
+// Sentinel distinguishes "not yet initialised" from "null (disabled)".
+if (!("__rdSyncBrowserCapacityMonitor" in capacityGlobalRegistry)) {
+  capacityGlobalRegistry.__rdSyncBrowserCapacityMonitor = resolveDefaultBrowserCapacityMonitor();
+}
+
+// This module already eagerly constructs defaultIngestionConsumer above at
+// load time, so the capacity monitor follows the same eager side-effecting
+// pattern — start() is idempotent (internal handle guard).
+export const defaultBrowserCapacityMonitor: BrowserCapacityMonitor | null =
+  capacityGlobalRegistry.__rdSyncBrowserCapacityMonitor ?? null;
+
+defaultBrowserCapacityMonitor?.start();

--- a/src/modules/audit/bank-actions.ts
+++ b/src/modules/audit/bank-actions.ts
@@ -44,3 +44,8 @@ export const BANK_SESSION_ACTIONS = {
   RESTORED: "bank_session.restored",
   UNAVAILABLE: "bank_session.unavailable",
 } as const;
+
+export const BANK_BROWSER_CAPACITY_ACTIONS = {
+  WARNING: "bank_browser_capacity.warning",
+  RECOVERED: "bank_browser_capacity.recovered",
+} as const;

--- a/src/modules/observability/browser-capacity-monitor.test.ts
+++ b/src/modules/observability/browser-capacity-monitor.test.ts
@@ -60,6 +60,7 @@ function snapshot(
 
 const SUSTAIN_MS = 5 * 60_000;
 const OVER = snapshot(2, 5, 2, 0); // queueDepth 5 > 2*max(2)=4
+const AT_THRESHOLD = snapshot(2, 4, 2, 0); // queueDepth 4 === 2*max(2)
 
 function baseDeps(
   overrides: Partial<BrowserCapacityMonitorDeps> = {},
@@ -93,6 +94,23 @@ describe("createBrowserCapacityMonitor — normal / not-yet-sustained", () => {
 
     expect(state.status).toBe("normal");
     expect(calls).toHaveLength(0);
+  });
+
+  it("does not alert at the exact threshold boundary after the sustain window", async () => {
+    const { clock, advance } = makeFakeClock(0);
+    const { alertSink, calls } = makeAlertSink();
+    const { auditSink, events } = makeAuditSink();
+    const monitor = createBrowserCapacityMonitor(
+      baseDeps({ sample: makeSampleQueue([AT_THRESHOLD]), alertSink, auditSink, clock }),
+    );
+
+    await monitor.tick();
+    advance(SUSTAIN_MS);
+    const state = await monitor.tick();
+
+    expect(state.status).toBe("normal");
+    expect(calls).toHaveLength(0);
+    expect(events).toHaveLength(0);
   });
 
   it("never reports over_capacity when max is 0 (no NaN/Infinity from the multiplier math)", async () => {
@@ -172,6 +190,24 @@ describe("createBrowserCapacityMonitor — recovery", () => {
 
     await monitor.tick(); // further normal tick must not re-alert recovery
     expect(calls).toHaveLength(2);
+  });
+
+  it("treats the exact threshold boundary as recovery after over_capacity", async () => {
+    const { clock, advance } = makeFakeClock(0);
+    const { alertSink, calls } = makeAlertSink();
+    const { auditSink, events } = makeAuditSink();
+    const monitor = createBrowserCapacityMonitor(
+      baseDeps({ sample: makeSampleQueue([OVER, OVER, AT_THRESHOLD]), alertSink, auditSink, clock }),
+    );
+
+    await monitor.tick();
+    advance(SUSTAIN_MS);
+    await monitor.tick();
+    advance(1000);
+
+    expect((await monitor.tick()).status).toBe("recovered");
+    expect(calls[1]).toMatchObject({ status: "recovered", queueDepth: 4, max: 2 });
+    expect(events[1].action).toBe("bank_browser_capacity.recovered");
   });
 });
 

--- a/src/modules/observability/browser-capacity-monitor.test.ts
+++ b/src/modules/observability/browser-capacity-monitor.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createBrowserCapacityMonitor,
+  type BrowserCapacityMonitorDeps,
+} from "./browser-capacity-monitor";
+import type { BrowserCapacitySnapshot } from "../../worker/scraper/browser-runtime";
+import type { AuditEvent } from "../audit";
+
+// ---------------------------------------------------------------------------
+// Test helpers — fake clock, sample queue, sinks
+// ---------------------------------------------------------------------------
+
+function makeFakeClock(startMs: number): { clock: () => Date; advance(ms: number): void } {
+  let now = startMs;
+  return { clock: () => new Date(now), advance: (ms) => { now += ms; } };
+}
+
+function makeSampleQueue(snapshots: BrowserCapacitySnapshot[]): () => BrowserCapacitySnapshot {
+  let index = 0;
+  return () => snapshots[Math.min(index++, snapshots.length - 1)];
+}
+
+interface CapacityAlertCall {
+  status: "over_capacity" | "recovered";
+  active: number;
+  queueDepth: number;
+  max: number;
+  throttleEventsInWindow: number;
+  checkedAt: string;
+}
+
+function makeAlertSink(): {
+  alertSink: { notifyCapacityAttention: (event: CapacityAlertCall) => Promise<void> };
+  calls: CapacityAlertCall[];
+} {
+  const calls: CapacityAlertCall[] = [];
+  return {
+    alertSink: { notifyCapacityAttention: async (event) => { calls.push(event); } },
+    calls,
+  };
+}
+
+function makeAuditSink(): {
+  auditSink: { record: (event: AuditEvent) => Promise<void> };
+  events: AuditEvent[];
+} {
+  const events: AuditEvent[] = [];
+  return { auditSink: { record: async (event) => { events.push(event); } }, events };
+}
+
+function snapshot(
+  active: number,
+  queueDepth: number,
+  max: number,
+  throttleCount: number,
+): BrowserCapacitySnapshot {
+  return { active, queueDepth, max, throttleCount };
+}
+
+const SUSTAIN_MS = 5 * 60_000;
+const OVER = snapshot(2, 5, 2, 0); // queueDepth 5 > 2*max(2)=4
+
+function baseDeps(
+  overrides: Partial<BrowserCapacityMonitorDeps> = {},
+): BrowserCapacityMonitorDeps {
+  return { sample: makeSampleQueue([snapshot(1, 0, 2, 0)]), intervalMs: 60_000, ...overrides };
+}
+
+describe("createBrowserCapacityMonitor — normal / not-yet-sustained", () => {
+  it("does not alert or audit when queueDepth is within threshold", async () => {
+    const { alertSink, calls } = makeAlertSink();
+    const { auditSink, events } = makeAuditSink();
+    const monitor = createBrowserCapacityMonitor(baseDeps({ alertSink, auditSink }));
+
+    const state = await monitor.tick();
+
+    expect(state.status).toBe("normal");
+    expect(calls).toHaveLength(0);
+    expect(events).toHaveLength(0);
+  });
+
+  it("does not alert before the sustain window elapses", async () => {
+    const { clock, advance } = makeFakeClock(0);
+    const { alertSink, calls } = makeAlertSink();
+    const monitor = createBrowserCapacityMonitor(
+      baseDeps({ sample: makeSampleQueue([OVER]), alertSink, clock }),
+    );
+
+    await monitor.tick();
+    advance(SUSTAIN_MS - 1000);
+    const state = await monitor.tick();
+
+    expect(state.status).toBe("normal");
+    expect(calls).toHaveLength(0);
+  });
+
+  it("never reports over_capacity when max is 0 (no NaN/Infinity from the multiplier math)", async () => {
+    const { clock, advance } = makeFakeClock(0);
+    const { alertSink, calls } = makeAlertSink();
+    const monitor = createBrowserCapacityMonitor(
+      baseDeps({ sample: makeSampleQueue([snapshot(0, 3, 0, 1)]), alertSink, clock }),
+    );
+
+    await monitor.tick();
+    advance(SUSTAIN_MS);
+    const state = await monitor.tick();
+
+    expect(state.status).toBe("normal");
+    expect(calls).toHaveLength(0);
+  });
+});
+
+describe("createBrowserCapacityMonitor — sustained over threshold", () => {
+  it("alerts and audits exactly once on crossing into sustained over_capacity, not again while still sustained, and tracks lastState()", async () => {
+    const { clock, advance } = makeFakeClock(0);
+    const { alertSink, calls } = makeAlertSink();
+    const { auditSink, events } = makeAuditSink();
+    const monitor = createBrowserCapacityMonitor(
+      baseDeps({ sample: makeSampleQueue([OVER]), alertSink, auditSink, clock }),
+    );
+
+    expect(monitor.lastState()).toBeNull();
+    await monitor.tick(); // overThresholdSinceMs = 0
+    advance(SUSTAIN_MS);
+    const state = await monitor.tick(); // now sustained
+
+    expect(state.status).toBe("over_capacity");
+    expect(monitor.lastState()).toEqual(state);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({ status: "over_capacity", active: 2, queueDepth: 5, max: 2 });
+    expect(events).toHaveLength(1);
+    expect(events[0].action).toBe("bank_browser_capacity.warning");
+    expect(events[0].target).toBe("browser_capacity");
+    expect(events[0].targetId).toBeNull();
+
+    advance(60_000);
+    await monitor.tick(); // still sustained — must NOT re-alert
+
+    expect(calls).toHaveLength(1);
+    expect(events).toHaveLength(1);
+  });
+});
+
+describe("createBrowserCapacityMonitor — recovery", () => {
+  it("alerts and audits exactly once on recovery (fires immediately, no further re-alert on a later normal tick)", async () => {
+    const { clock, advance } = makeFakeClock(0);
+    const { alertSink, calls } = makeAlertSink();
+    const { auditSink, events } = makeAuditSink();
+    const monitor = createBrowserCapacityMonitor(
+      baseDeps({
+        sample: makeSampleQueue([OVER, OVER, snapshot(1, 0, 2, 0)]),
+        alertSink,
+        auditSink,
+        clock,
+      }),
+    );
+
+    await monitor.tick();
+    advance(SUSTAIN_MS);
+    await monitor.tick(); // sustained -> over_capacity alert fired
+    expect(calls).toHaveLength(1);
+
+    advance(1000); // recovery does not need to be sustained — fires immediately
+    const recoveredState = await monitor.tick();
+
+    expect(recoveredState.status).toBe("recovered");
+    expect(calls).toHaveLength(2);
+    expect(calls[1]).toMatchObject({ status: "recovered", active: 1, queueDepth: 0, max: 2 });
+    expect(events).toHaveLength(2);
+    expect(events[1].action).toBe("bank_browser_capacity.recovered");
+
+    await monitor.tick(); // further normal tick must not re-alert recovery
+    expect(calls).toHaveLength(2);
+  });
+});
+
+describe("createBrowserCapacityMonitor — early drop resets the sustain timer", () => {
+  it("requires a fresh 5-minute window after dropping under threshold before reaching sustain", async () => {
+    const { clock, advance } = makeFakeClock(0);
+    const { alertSink, calls } = makeAlertSink();
+    const monitor = createBrowserCapacityMonitor(
+      baseDeps({
+        sample: makeSampleQueue([OVER, snapshot(1, 0, 2, 0), OVER]),
+        alertSink,
+        clock,
+      }),
+    );
+
+    await monitor.tick(); // over, since t=0
+    advance(SUSTAIN_MS - 1000);
+    await monitor.tick(); // drops to normal before sustain — resets, no alert (never alerted)
+    expect(calls).toHaveLength(0);
+
+    advance(SUSTAIN_MS - 1000); // not enough from the fresh window start
+    const stillNotSustained = await monitor.tick();
+    expect(stillNotSustained.status).toBe("normal");
+    expect(calls).toHaveLength(0);
+  });
+});
+
+describe("createBrowserCapacityMonitor — throttleEventsInWindow", () => {
+  it("reports the delta in throttleCount since the previous tick, never negative", async () => {
+    const monitor = createBrowserCapacityMonitor(
+      baseDeps({
+        sample: makeSampleQueue([snapshot(1, 0, 2, 3), snapshot(1, 0, 2, 7), snapshot(1, 0, 2, 0)]),
+      }),
+    );
+
+    expect((await monitor.tick()).throttleEventsInWindow).toBe(3); // first observation: delta from 0
+    expect((await monitor.tick()).throttleEventsInWindow).toBe(4);
+    expect((await monitor.tick()).throttleEventsInWindow).toBe(0); // would-be-negative delta clamped to 0
+  });
+});
+
+describe("createBrowserCapacityMonitor — sink failures are swallowed", () => {
+  it("never rejects tick() when alertSink or auditSink throw", async () => {
+    const { clock, advance } = makeFakeClock(0);
+    const throwingAlertSink = {
+      notifyCapacityAttention: async () => { throw new Error("alert transport down"); },
+    };
+    const throwingAuditSink = { record: async () => { throw new Error("audit sink down"); } };
+
+    const monitor = createBrowserCapacityMonitor(
+      baseDeps({
+        sample: makeSampleQueue([OVER]),
+        alertSink: throwingAlertSink,
+        auditSink: throwingAuditSink,
+        clock,
+      }),
+    );
+
+    await monitor.tick();
+    advance(SUSTAIN_MS);
+    await expect(monitor.tick()).resolves.toMatchObject({ status: "over_capacity" });
+  });
+});
+
+describe("createBrowserCapacityMonitor — start/stop scheduling", () => {
+  it("wires start() to schedule() and stop() to clearSchedule(), both idempotent", () => {
+    const scheduleCalls: Array<{ fn: () => void; ms: number }> = [];
+    const clearCalls: unknown[] = [];
+    let handleCounter = 0;
+
+    const monitor = createBrowserCapacityMonitor(
+      baseDeps({
+        schedule: (fn, ms) => { scheduleCalls.push({ fn, ms }); return ++handleCounter; },
+        clearSchedule: (handle) => { clearCalls.push(handle); },
+        intervalMs: 30_000,
+      }),
+    );
+
+    monitor.start();
+    monitor.start(); // idempotent
+    expect(scheduleCalls).toHaveLength(1);
+    expect(scheduleCalls[0].ms).toBe(30_000);
+
+    monitor.stop();
+    monitor.stop(); // idempotent
+    expect(clearCalls).toHaveLength(1);
+  });
+});

--- a/src/modules/observability/browser-capacity-monitor.ts
+++ b/src/modules/observability/browser-capacity-monitor.ts
@@ -1,0 +1,199 @@
+import type { AuditSink } from "../audit";
+import { createAuditEvent } from "../audit";
+import { BANK_BROWSER_CAPACITY_ACTIONS } from "../audit/bank-actions";
+import type { AdminAlertSink } from "../../worker/queues/index";
+import type { BrowserCapacitySnapshot } from "../../worker/scraper/browser-runtime";
+
+// ---------------------------------------------------------------------------
+// BrowserCapacityState
+//
+// Host-wide gauge — the underlying BrowserSemaphore is a process-global
+// singleton shared across all banks (see getSharedBrowserSemaphore in
+// browser-runtime.ts), so there is intentionally no bankId dimension here.
+// ---------------------------------------------------------------------------
+
+export interface BrowserCapacityState {
+  status: "normal" | "over_capacity" | "recovered";
+  active: number;
+  queueDepth: number;
+  max: number;
+  throttleEventsInWindow: number;
+  checkedAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// BrowserCapacityMonitorDeps
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ScheduleHandle = any;
+
+export interface BrowserCapacityMonitorDeps {
+  sample: () => BrowserCapacitySnapshot;
+  alertSink?: Pick<AdminAlertSink, "notifyCapacityAttention">;
+  auditSink?: Pick<AuditSink, "record">;
+  intervalMs: number;
+  /** Sustain window before an over-threshold condition alerts. Default 5 min. */
+  sustainedThresholdMs?: number;
+  /** queueDepth > max * multiplier triggers the over-threshold condition. Default 2. */
+  queueDepthMultiplier?: number;
+  clock?: () => Date;
+  /** Injectable scheduler; defaults to setInterval/clearInterval. */
+  schedule?: (fn: () => void, ms: number) => ScheduleHandle;
+  clearSchedule?: (handle: ScheduleHandle) => void;
+}
+
+export interface BrowserCapacityMonitor {
+  tick(): Promise<BrowserCapacityState>;
+  start(): void;
+  stop(): void;
+  lastState(): BrowserCapacityState | null;
+}
+
+const DEFAULT_SUSTAINED_THRESHOLD_MS = 5 * 60_000;
+const DEFAULT_QUEUE_DEPTH_MULTIPLIER = 2;
+const AUDIT_ACTOR = "system:browser-capacity-monitor";
+
+/**
+ * Polls the host-wide BrowserSemaphore capacity and alerts/audits on
+ * sustained over-capacity, mirroring createBankSessionMonitor's shape and
+ * transition discipline (alert+audit only on transition, sink failures never
+ * break tick()).
+ *
+ * Transition rules:
+ *   - queueDepth > max * queueDepthMultiplier sustained >= sustainedThresholdMs
+ *     → alert + audit "over_capacity" exactly once per episode (alertedForCurrentEpisode guard)
+ *   - queueDepth drops back to/under threshold after an alerted episode
+ *     → alert + audit "recovered" exactly once, firing immediately (no sustain required)
+ *   - dropping under threshold before reaching sustain resets the timer with no alert
+ *   - max <= 0 never produces a false over-capacity (guarded explicitly)
+ */
+export function createBrowserCapacityMonitor(
+  deps: BrowserCapacityMonitorDeps,
+): BrowserCapacityMonitor {
+  const {
+    sample,
+    alertSink,
+    auditSink,
+    intervalMs,
+    sustainedThresholdMs = DEFAULT_SUSTAINED_THRESHOLD_MS,
+    queueDepthMultiplier = DEFAULT_QUEUE_DEPTH_MULTIPLIER,
+    clock = () => new Date(),
+    schedule = setInterval,
+    clearSchedule = clearInterval,
+  } = deps;
+
+  let previousState: BrowserCapacityState | null = null;
+  let previousThrottleCount = 0;
+  let overThresholdSinceMs: number | null = null;
+  let alertedForCurrentEpisode = false;
+  let handle: ScheduleHandle | null = null;
+
+  async function tick(): Promise<BrowserCapacityState> {
+    const snap = sample();
+    const now = clock().getTime();
+    const checkedAt = new Date(now).toISOString();
+
+    const throttleEventsInWindow = Math.max(0, snap.throttleCount - previousThrottleCount);
+    previousThrottleCount = snap.throttleCount;
+
+    const isOverThreshold = snap.max > 0 && snap.queueDepth > snap.max * queueDepthMultiplier;
+    overThresholdSinceMs = isOverThreshold ? (overThresholdSinceMs ?? now) : null;
+    const sustained = isOverThreshold && now - (overThresholdSinceMs as number) >= sustainedThresholdMs;
+
+    let status: BrowserCapacityState["status"] = sustained ? "over_capacity" : "normal";
+    let transitionAction: string | null = null;
+
+    if (sustained && !alertedForCurrentEpisode) {
+      alertedForCurrentEpisode = true;
+      transitionAction = BANK_BROWSER_CAPACITY_ACTIONS.WARNING;
+    } else if (!isOverThreshold && alertedForCurrentEpisode) {
+      status = "recovered";
+      alertedForCurrentEpisode = false;
+      transitionAction = BANK_BROWSER_CAPACITY_ACTIONS.RECOVERED;
+    }
+
+    const state: BrowserCapacityState = {
+      status,
+      active: snap.active,
+      queueDepth: snap.queueDepth,
+      max: snap.max,
+      throttleEventsInWindow,
+      checkedAt,
+    };
+    previousState = state;
+
+    if (transitionAction) {
+      const eventStatus = status === "recovered" ? "recovered" : "over_capacity";
+      await emitAlert(alertSink, { ...state, status: eventStatus });
+      await emitAudit(auditSink, transitionAction, state);
+    }
+
+    return state;
+  }
+
+  return {
+    tick,
+
+    start() {
+      if (handle !== null) return; // idempotent
+      handle = schedule(() => {
+        void tick().catch(() => undefined);
+      }, intervalMs);
+    },
+
+    stop() {
+      if (handle === null) return;
+      clearSchedule(handle);
+      handle = null;
+    },
+
+    lastState() {
+      return previousState;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+async function emitAlert(
+  alertSink: Pick<AdminAlertSink, "notifyCapacityAttention"> | undefined,
+  event: { status: "over_capacity" | "recovered" } & Omit<BrowserCapacityState, "status">,
+): Promise<void> {
+  if (!alertSink?.notifyCapacityAttention) return;
+  try {
+    await alertSink.notifyCapacityAttention(event);
+  } catch {
+    // Alert failures must never propagate.
+  }
+}
+
+async function emitAudit(
+  auditSink: Pick<AuditSink, "record"> | undefined,
+  action: string,
+  state: BrowserCapacityState,
+): Promise<void> {
+  if (!auditSink) return;
+  try {
+    const event = createAuditEvent({
+      actorId: AUDIT_ACTOR,
+      actorRole: "system",
+      action,
+      target: "browser_capacity",
+      targetId: null,
+      // Strictly numeric/status/timestamp fields — no secrets, no URLs.
+      metadata: {
+        active: state.active,
+        queueDepth: state.queueDepth,
+        max: state.max,
+        throttleEventsInWindow: state.throttleEventsInWindow,
+        checkedAt: state.checkedAt,
+      },
+    });
+    await auditSink.record(event);
+  } catch {
+    // Audit failures must never propagate.
+  }
+}

--- a/src/worker/alerts/email-alert-sink.test.ts
+++ b/src/worker/alerts/email-alert-sink.test.ts
@@ -387,3 +387,68 @@ describe("createEmailAlertSink — notifySessionAttention: expired", () => {
     expect(messages[0].to).toBe("team@acme.com");
   });
 });
+
+// ---------------------------------------------------------------------------
+// notifyCapacityAttention — email shape
+// ---------------------------------------------------------------------------
+
+describe("createEmailAlertSink — notifyCapacityAttention", () => {
+  it("uses a 'warning' subject and includes only numeric fields + checkedAt for over_capacity", async () => {
+    const { transport, messages } = makeTransport();
+    const sink = createEmailAlertSink({ transport, recipient: "ops@example.com" });
+
+    await sink.notifyCapacityAttention!({
+      status: "over_capacity",
+      active: 2,
+      queueDepth: 9,
+      max: 2,
+      throttleEventsInWindow: 4,
+      checkedAt: "2026-01-01T00:00:00.000Z",
+    });
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0].subject).toBe("[RD-Sync] Bank browser capacity warning");
+    const body = messages[0].text;
+    expect(body).toContain("2");
+    expect(body).toContain("9");
+    expect(body).toContain("4");
+    expect(body).toContain("2026-01-01T00:00:00.000Z");
+    expect(body).toContain("/admin/scrape-runs");
+  });
+
+  it("uses a 'recovered' subject for recovered status", async () => {
+    const { transport, messages } = makeTransport();
+    const sink = createEmailAlertSink({ transport, recipient: "ops@example.com" });
+
+    await sink.notifyCapacityAttention!({
+      status: "recovered",
+      active: 1,
+      queueDepth: 0,
+      max: 2,
+      throttleEventsInWindow: 0,
+      checkedAt: "2026-01-01T00:05:00.000Z",
+    });
+
+    expect(messages[0].subject).toBe("[RD-Sync] Bank browser capacity recovered");
+  });
+
+  it("does not throw when transport.send rejects", async () => {
+    const throwingTransport: EmailTransport = {
+      send: async () => {
+        throw new Error("SMTP down");
+      },
+    };
+    const sink = createEmailAlertSink({ transport: throwingTransport, recipient: "ops@example.com" });
+
+    await expect(
+      sink.notifyCapacityAttention!({
+        status: "over_capacity",
+        active: 2,
+        queueDepth: 9,
+        max: 2,
+        throttleEventsInWindow: 1,
+        checkedAt: "2026-01-01T00:00:00.000Z",
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/worker/alerts/email-alert-sink.ts
+++ b/src/worker/alerts/email-alert-sink.ts
@@ -66,6 +66,32 @@ export function createEmailAlertSink(options: {
         // Transport failures must never propagate.
       }
     },
+
+    async notifyCapacityAttention(event) {
+      const { status, active, queueDepth, max, throttleEventsInWindow, checkedAt } = event;
+
+      const subject =
+        status === "over_capacity"
+          ? "[RD-Sync] Bank browser capacity warning"
+          : "[RD-Sync] Bank browser capacity recovered";
+
+      const text = [
+        `Status            : ${status}`,
+        `Active sessions   : ${active}`,
+        `Queue depth       : ${queueDepth}`,
+        `Max concurrency   : ${max}`,
+        `Throttle events   : ${throttleEventsInWindow}`,
+        `Checked at        : ${checkedAt}`,
+        ``,
+        `Review at /admin/scrape-runs`,
+      ].join("\n");
+
+      try {
+        await options.transport.send({ to: options.recipient, subject, text });
+      } catch {
+        // Transport failures must never propagate.
+      }
+    },
   };
 }
 

--- a/src/worker/queues/index.ts
+++ b/src/worker/queues/index.ts
@@ -62,6 +62,19 @@ export interface AdminAlertSink {
     safeSummary: string;
     checkedAt: string;
   }): Promise<void>;
+  /**
+   * Optional so existing implementers/mocks keep compiling without changes.
+   * Payload is strictly numeric (+ status/checkedAt) — no bankId, since the
+   * underlying BrowserSemaphore is a host-wide, process-global singleton.
+   */
+  notifyCapacityAttention?(event: {
+    status: "over_capacity" | "recovered";
+    active: number;
+    queueDepth: number;
+    max: number;
+    throttleEventsInWindow: number;
+    checkedAt: string;
+  }): Promise<void>;
 }
 
 export interface IngestionProcessorDependencies {

--- a/src/worker/scraper/browser-runtime.test.ts
+++ b/src/worker/scraper/browser-runtime.test.ts
@@ -5,6 +5,8 @@ import {
   ensureCdpBrowser,
   createEnsureBrowserFromEnv,
   createEnsureBrowserForBank,
+  createAcquireBrowserSlotFromEnv,
+  getBrowserCapacitySnapshotFromEnv,
   assertCdpLoopback,
   resolveBankBrowserEnv,
   BrowserSemaphore,
@@ -602,5 +604,40 @@ describe("BrowserSemaphore", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getBrowserCapacitySnapshotFromEnv — samples the REAL shared semaphore
+// ---------------------------------------------------------------------------
+
+describe("getBrowserCapacitySnapshotFromEnv", () => {
+  it("reflects the live capacity and throttleCount of the shared singleton, not a fresh instance", async () => {
+    const env = {
+      RD_SYNC_BANK_BROWSER_MAX_CONCURRENCY: "1",
+      RD_SYNC_BANK_BROWSER_QUEUE_LIMIT: "0",
+    };
+
+    // Drive the same env-keyed singleton that createAcquireBrowserSlotFromEnv
+    // uses, so we can assert the snapshot reflects real, live state.
+    const acquire = createAcquireBrowserSlotFromEnv(env);
+
+    const before = getBrowserCapacitySnapshotFromEnv(env);
+    expect(before).toEqual({ active: 0, queueDepth: 0, max: 1, throttleCount: 0 });
+
+    const held = await acquire();
+    expect(held.kind).toBe("acquired");
+
+    const duringHold = getBrowserCapacitySnapshotFromEnv(env);
+    expect(duringHold.active).toBe(1);
+
+    // queueLimit=0 means the next acquire immediately throttles.
+    const throttled = await acquire();
+    expect(throttled.kind).toBe("throttled");
+
+    const afterThrottle = getBrowserCapacitySnapshotFromEnv(env);
+    expect(afterThrottle).toEqual({ active: 1, queueDepth: 0, max: 1, throttleCount: 1 });
+
+    if (held.kind === "acquired") await held.release();
   });
 });

--- a/src/worker/scraper/browser-runtime.ts
+++ b/src/worker/scraper/browser-runtime.ts
@@ -289,6 +289,23 @@ export function createAcquireBrowserSlotFromEnv(
   return () => semaphore.acquire({ timeoutMs });
 }
 
+/** Capacity snapshot extended with the cumulative throttled-acquire count. */
+export interface BrowserCapacitySnapshot extends BrowserCapacity {
+  throttleCount: number;
+}
+
+/**
+ * Samples the REAL process-global shared BrowserSemaphore (same singleton
+ * resolution as createAcquireBrowserSlotFromEnv, keyed by `max:queueLimit`).
+ * The semaphore is host-wide, not per-bank — there is no bankId dimension.
+ */
+export function getBrowserCapacitySnapshotFromEnv(
+  env: Record<string, string | undefined> = process.env,
+): BrowserCapacitySnapshot {
+  const semaphore = getSharedBrowserSemaphore(env);
+  return { ...semaphore.capacity(), throttleCount: semaphore.throttleCount };
+}
+
 function getSharedBrowserSemaphore(env: Record<string, string | undefined>): BrowserSemaphore {
   const max = parseOptionalPositiveInt(
     env.RD_SYNC_BANK_BROWSER_MAX_CONCURRENCY,


### PR DESCRIPTION
## Chain Context

```text
feature/multi-bank-auto-login          ← tracker branch
 ├── ✅ PR #1-2 adapter registry + browser/CDP isolation (merged)
 ├── ✅ PR #3 browser backpressure (PR2B, merged) — deferred 2B.2 (capacity metrics)
 ├── ✅ PR #5-8 credential vault (merged)
 ├── ✅ PR #9-15 Banreservas/BHD read-only adapters (merged, separate chain off pr5-bank-mapping)
 └── 📍 feature/multi-bank-auto-login-pr2b2-capacity-metrics-exporter (this PR — PR2B.2)
```

Base for this PR: `feature/multi-bank-auto-login` (tracker), not `main`. Branched directly off the tracker (not off the PR5 parser chain) since this completes deferred PR2B scope and is unrelated to the PR5 bank parsers.

## Summary

Converts `BrowserSemaphore.capacity()`/`throttleCount` (already production-wired since PR2B) into real alert + audit observability, closing out the task PR2B explicitly deferred.

- New `BrowserCapacityMonitor` (`src/modules/observability/browser-capacity-monitor.ts`): polls the real shared `BrowserSemaphore` singleton, mirrors `createBankSessionMonitor`'s transition discipline (alert/audit only on state change, sink failures never break `tick()`).
- Threshold (from `design.md` Observability section): `queueDepth > 2x max concurrency` sustained **5 minutes** → warning alert + audit; clears → recovery alert + audit, exactly once per episode.
- Throttle events reported as the delta in `throttleCount` between ticks.
- Reuses the **existing** `AdminAlertSink` (new optional `notifyCapacityAttention`, implemented in `email-alert-sink.ts`) and `AuditSink` (`BANK_BROWSER_CAPACITY_ACTIONS.WARNING/RECOVERED`) — no new sink/exporter infra.
- Opt-in via `RD_SYNC_BROWSER_CAPACITY_MONITOR=enabled` (default disabled), wired in `consumer-defaults.ts` mirroring `resolveDefaultSessionMonitor`'s globalThis sentinel anchor.

## Architecture decision (asked, not assumed)

No metrics backend (Prometheus/statsd/Datadog) exists anywhere in this codebase. Rather than invent one, the user explicitly chose: reuse `AdminAlertSink`/`AuditSink` only — no exporter, no admin JSON metrics endpoint, no generic `MetricsSink` abstraction. Documented in `tasks.md`.

**Known deviation from design wording**: `design.md` lists `bank_browser_capacity` under "per-bank metrics keyed by bankCode," but `BrowserSemaphore` is a single process-global singleton shared across all banks (`getSharedBrowserSemaphore`, keyed only by `max:queueLimit`). This PR reports it honestly as a **host-wide gauge with no bankId dimension** rather than fabricating a fake per-bank partition of a global resource.

## Changes

| Area | Change |
|------|--------|
| `src/worker/scraper/browser-runtime.ts` | New `getBrowserCapacitySnapshotFromEnv` — samples the real shared semaphore singleton. |
| `src/modules/observability/browser-capacity-monitor.ts` | New: poll-based monitor, sustain/recovery state machine. |
| `src/worker/queues/index.ts` | `AdminAlertSink` gains optional `notifyCapacityAttention` (no breaking change to existing implementers). |
| `src/worker/alerts/email-alert-sink.ts` | Implements `notifyCapacityAttention` (strictly numeric payload, no secrets/URLs). |
| `src/modules/audit/bank-actions.ts` | Adds `BANK_BROWSER_CAPACITY_ACTIONS`. |
| `src/app/api/scrape-runs/consumer-defaults.ts` | Env-gated default wiring + eager start, mirrors existing session-monitor pattern. |
| `openspec/changes/multi-bank-auto-login/tasks.md` | Marks 2B.2 complete with an honest note on scope/host-wide gauge. |
| Tests | New monitor test suite (sustain/recovery/reset/throttle-delta/sink-failure-isolation/max<=0 guard), sink + snapshot + cross-module-graph singleton coverage. |

## Non-goals / Deferred

- No Prometheus/statsd/Datadog/admin metrics endpoint — explicit user decision, no existing backend to extend.
- No per-bank capacity partitioning — the underlying semaphore is host-wide; faking a per-bank split was rejected as a fake metric.
- No changes to PR5 bank parsers (`popular.ts`, `bhd.ts`, `banreservas.ts`) or their fixtures/tests.
- No changes to `registry.ts` or `popular-cdp.ts` — purely additive, no existing call site touched.

## Review Budget — documented exception

- Diff: 789 insertions / 1 deletion = 790 changed lines, over the usual 400-line budget.
- **size:exception**, accepted explicitly by the project owner. Production code alone is 324 lines (close to budget); the overage is almost entirely TDD coverage of a single cohesive state machine (9 distinct transition/edge-case behaviors) plus a cross-module-graph singleton regression test added after fresh review. Splitting by file does not get any resulting PR under 400 either (the monitor module + its own tests alone are 461 lines), so it was kept as one coherent change rather than producing two equally-oversized PRs.

## Verification

- [x] `pnpm test` — 820 passed / 38 skipped
- [x] `pnpm lint` — exit 0
- [x] `pnpm typecheck` — exit 0
- [x] `git diff --check` — exit 0
- [x] Fresh-context independent code review: 0 CRITICAL, 0 HIGH, 1 MEDIUM (fixed — added the cross-module-graph singleton test), 1 SUGGESTION (test trim, not applied — left for a future pass, not blocking)