### PR TITLE
feat(bank-adapters): parse Banreservas Empresas transactions

### DIFF
--- a/openspec/changes/multi-bank-auto-login/tasks.md
+++ b/openspec/changes/multi-bank-auto-login/tasks.md
@@ -194,6 +194,23 @@ fail-safe (returns `expired`).
 - [x] 5.6a-tests TDD: `banreservas.test.ts` — 32 new tests (52 total) covering date parsing (happy + impossible calendar/error), amount parsing (raw format, empty/malformed, negative debits), transaction row parsing (fixture round-trip, pipe-separated reference normalization, no balance leakage, custom overrides, malformed rejection, debit/credit exclusivity, optional field normalization, absolute amount output).
 - Gate: targeted Banreservas tests + fixture tests; <=400 changed lines; session checker remains fail-safe; no auto-login enablement.
 
+### PR5E: Banreservas Empresas read-only DOM extraction (parser) [COMPLETE]
+
+**SCOPE:** Add pure transaction parsing functions for Banreservas Empresas
+ASP.NET WebForms DevExpress grid fixtures. This is NOT auto-login. Session
+checker remains fail-safe (returns `expired`).
+
+**Key Empresas format differences from Personas:**
+- Date format: DD/MM/YY (2-digit year, assumes 2000+)
+- Amounts: Always positive; direction determined by column (debit/credit), not by sign
+- Balance: "DOP " prefixed but NOT leaked into output
+- Reference: `transactionNumber` field (plain ID, not pipe-separated)
+
+- [x] 5.7a Add `parseBanreservasEmpresasDate`, `parseBanreservasEmpresasAmount`, `parseBanreservasEmpresasTransactionRows` to `src/modules/bank-adapters/banreservas.ts`: pure helpers that parse Banreservas Empresas DD/MM/YY dates (2-digit year → 2000+), positive-only amounts (column-based debit/credit classification), and fixture rows into normalized `BankMovement` objects matching the adapter contract.
+- [x] 5.7a-tests TDD: `banreservas.test.ts` — 44 tests (99 total) covering date parsing (DD/MM/YY happy + impossible calendar/error + leap year), amount parsing (positive-only, comma grouping validation, negative rejection, >2 decimal precision rejection), transaction row parsing (fixture round-trip with amount format assertion, transactionNumber→reference, no balance leakage, ambiguous/missing amount rejection, sign/column mismatch, malformed inactive-zero column rejection, whitespace normalization).
+- [x] 5.7b Add `accountFingerprint` to `banreservasEmpresasScraperProfile` ("banreservas-empresas-XXXXXXXXXX") matching Personas pattern; add profile assertion in existing test.
+- Gate: targeted Banreservas tests (99 pass) + full suite (997 pass) + typecheck + lint; 400 changed lines (at budget); session checker remains fail-safe; no auto-login enablement.
+
 ## PR6: Banreservas/BHD auto-login enablement
 
 - [ ] 6.1 Implement banreservas/bhd `createAutoLoginStrategy` (username/password-only; safe fallback->`needs_admin_action` on corporate/token/incompatible flow).

--- a/src/modules/bank-adapters/banreservas.test.ts
+++ b/src/modules/bank-adapters/banreservas.test.ts
@@ -15,9 +15,13 @@ import {
   parseBanreservasPersonasDate,
   parseBanreservasPersonasAmount,
   parseBanreservasPersonasTransactionRows,
+  parseBanreservasEmpresasDate,
+  parseBanreservasEmpresasAmount,
+  parseBanreservasEmpresasTransactionRows,
 } from "./banreservas";
 import { createBankAdapterRegistry } from "./registry";
 import { banreservasPersonasTransactions } from "./fixtures/banreservas-personas";
+import { banreservasEmpresasTransactions } from "./fixtures/banreservas-empresas";
 
 describe("Banreservas adapter identity + portal variant disambiguation", () => {
   it("distinct portal-specific bank codes; group code for display", () => {
@@ -131,6 +135,7 @@ describe("Banreservas Empresas profile — recon-derived selectors/facts", () =>
   it("identity, login, landing, framework, inputStrategy", () => {
     expect(banreservasEmpresasScraperProfile.bankId).toBe("banreservas_empresas");
     expect(banreservasEmpresasScraperProfile.portalVariant).toBe("empresas");
+    expect(banreservasEmpresasScraperProfile.accountFingerprint).toBe("banreservas-empresas-XXXXXXXXXX");
     expect(banreservasEmpresasScraperProfile.loginUrl).toBe("https://www.banreservas.com.do/TuBancoEmpresas/Login.aspx");
     expect(banreservasEmpresasScraperProfile.landingUrl).toBe("https://www.banreservas.com.do/TuBancoEmpresas/Default.aspx");
     expect(banreservasEmpresasScraperProfile.framework).toBe("aspnet-webforms+devexpress");
@@ -416,5 +421,242 @@ describe("parseBanreservasPersonasTransactionRows", () => {
       },
     ]);
     expect(movements[0].reference).toBe("Nro. transacción: 408900123456 | Número de referencia: 408900123");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseBanreservasEmpresasDate — DD/MM/YY (2-digit year) → ISO 8601
+// ---------------------------------------------------------------------------
+
+describe("parseBanreservasEmpresasDate", () => {
+  it("parses DD/MM/YY to ISO 8601 with -04:00 offset (assumes 2000+)", () => {
+    expect(parseBanreservasEmpresasDate("29/06/26")).toBe("2026-06-29T00:00:00-04:00");
+  });
+
+  it("parses zero-padded day and month", () => {
+    expect(parseBanreservasEmpresasDate("01/01/25")).toBe("2025-01-01T00:00:00-04:00");
+  });
+
+  it("parses 31/12/24 year boundary", () => {
+    expect(parseBanreservasEmpresasDate("31/12/24")).toBe("2024-12-31T00:00:00-04:00");
+  });
+
+  it("parses 01/01/00 as 2000", () => {
+    expect(parseBanreservasEmpresasDate("01/01/00")).toBe("2000-01-01T00:00:00-04:00");
+  });
+
+  it.each([
+    ["2026-06-29", "non-DD/MM/YY format (ISO)"],
+    ["29/06/2026", "4-digit year (DD/MM/YYYY)"],
+    ["", "empty string"],
+    ["29/13/26", "impossible month 13"],
+    ["32/06/26", "impossible day 32"],
+    ["31/04/26", "day 31 for 30-day month (April)"],
+    ["30/02/26", "Feb 30"],
+    ["29/02/25", "Feb 29 in non-leap year (2025)"],
+  ])("throws on %s (%s)", (input) => {
+    expect(() => parseBanreservasEmpresasDate(input)).toThrow("Invalid Banreservas Empresas date format");
+  });
+
+  it("accepts Feb 29 in leap year 2024", () => {
+    expect(parseBanreservasEmpresasDate("29/02/24")).toBe("2024-02-29T00:00:00-04:00");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseBanreservasEmpresasAmount — positive-only, column-based direction
+// ---------------------------------------------------------------------------
+
+describe("parseBanreservasEmpresasAmount", () => {
+  it("parses positive credit amount", () => {
+    const r = parseBanreservasEmpresasAmount("25,000.00");
+    expect(r.value).toBe(25000);
+    expect(r.direction).toBe("credit");
+  });
+
+  it("parses zero amount as credit", () => {
+    const r = parseBanreservasEmpresasAmount("0.00");
+    expect(r.value).toBe(0);
+    expect(r.direction).toBe("credit");
+  });
+
+  it("parses amount without thousands separator", () => {
+    const r = parseBanreservasEmpresasAmount("1234.56");
+    expect(r.value).toBeCloseTo(1234.56);
+    expect(r.direction).toBe("credit");
+  });
+
+  it("parses large grouped amount (1,234,567.89)", () => {
+    const r = parseBanreservasEmpresasAmount("1,234,567.89");
+    expect(r.value).toBe(1234567.89);
+    expect(r.direction).toBe("credit");
+  });
+
+  it.each([
+    ["44,00.00", "malformed grouping (2-digit group)"],
+    ["4,4,000.00", "malformed grouping (extra comma)"],
+    [",100.00", "leading comma"],
+    ["100,.00", "trailing comma before decimal"],
+    ["1,23.456", "non-standard group size"],
+  ])("rejects malformed comma grouping: %s (%s)", (input) => {
+    expect(() => parseBanreservasEmpresasAmount(input)).toThrow("Invalid Banreservas Empresas amount format");
+  });
+
+  it.each([
+    ["abc", "non-numeric"],
+    ["", "empty string"],
+    ["--5000", "double negative"],
+    ["-5,000.00", "negative amount (sign not expected in Empresas)"],
+    ["123.456", "more than 2 decimal places"],
+  ])("throws on %s (%s)", (input) => {
+    expect(() => parseBanreservasEmpresasAmount(input)).toThrow("Invalid Banreservas Empresas amount format");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseBanreservasEmpresasTransactionRows — fixture round-trip → BankMovement[]
+// ---------------------------------------------------------------------------
+
+describe("parseBanreservasEmpresasTransactionRows", () => {
+  it("parses fixture transactions into BankMovement objects", () => {
+    const movements = parseBanreservasEmpresasTransactionRows(banreservasEmpresasTransactions);
+    expect(movements).toHaveLength(2);
+
+    expect(movements[0]).toMatchObject({
+      bankId: "banreservas_empresas",
+      accountFingerprint: "banreservas-empresas-XXXXXXXXXX",
+      postedAt: "2026-06-29T00:00:00-04:00",
+      amount: "25000.00",
+      currency: "DOP",
+      direction: "credit",
+      concept: "DEPOSITO EN EFECTIVO",
+      originator: null,
+      metadata: null,
+    });
+    expect(movements[0].reference).toBe("942632990001");
+
+    expect(movements[1]).toMatchObject({
+      bankId: "banreservas_empresas",
+      accountFingerprint: "banreservas-empresas-XXXXXXXXXX",
+      postedAt: "2026-06-28T00:00:00-04:00",
+      amount: "193.15",
+      currency: "DOP",
+      direction: "debit",
+      concept: "COBRO IMP DGII 0.15%_TRANS TUB",
+      originator: null,
+      metadata: null,
+    });
+    expect(movements[1].reference).toBe("942632990002");
+
+    // Amounts are absolute strings with exactly 2 decimal places.
+    for (const m of movements) {
+      expect(m.amount).toMatch(/^\d+\.\d{2}$/);
+    }
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(parseBanreservasEmpresasTransactionRows([])).toEqual([]);
+  });
+
+  it("accepts custom bankId and accountFingerprint overrides", () => {
+    const movements = parseBanreservasEmpresasTransactionRows(banreservasEmpresasTransactions, {
+      bankId: "banreservas-custom",
+      accountFingerprint: "banreservas-custom-fp",
+    });
+    expect(movements[0].bankId).toBe("banreservas-custom");
+    expect(movements[0].accountFingerprint).toBe("banreservas-custom-fp");
+  });
+
+  it("rejects malformed dates in transaction rows", () => {
+    expect(() =>
+      parseBanreservasEmpresasTransactionRows([{ ...banreservasEmpresasTransactions[0], date: "2026-06-29" }]),
+    ).toThrow("Invalid Banreservas Empresas date format");
+  });
+
+  it("rejects malformed amounts in transaction rows", () => {
+    expect(() =>
+      parseBanreservasEmpresasTransactionRows([
+        { ...banreservasEmpresasTransactions[0], debit: "abc", credit: "0.00" },
+      ]),
+    ).toThrow("Invalid Banreservas Empresas amount format");
+  });
+
+  it("rejects malformed comma grouping in transaction rows", () => {
+    expect(() =>
+      parseBanreservasEmpresasTransactionRows([
+        { ...banreservasEmpresasTransactions[0], debit: "0.00", credit: "44,00.00" },
+      ]),
+    ).toThrow("Invalid Banreservas Empresas amount format");
+  });
+
+  it("rejects row where both debit and credit are non-zero", () => {
+    expect(() =>
+      parseBanreservasEmpresasTransactionRows([
+        { ...banreservasEmpresasTransactions[0], debit: "193.15", credit: "25,000.00" },
+      ]),
+    ).toThrow("ambiguous");
+  });
+
+  it("rejects row where both debit and credit are zero", () => {
+    expect(() =>
+      parseBanreservasEmpresasTransactionRows([
+        { ...banreservasEmpresasTransactions[0], debit: "0.00", credit: "0.00" },
+      ]),
+    ).toThrow("missing");
+  });
+
+  it.each([
+    ["-5,000.00", "0.00", "debit column"],
+    ["0.00", "-1,000.00", "credit column"],
+  ])("rejects negative amount in %s (%s) — %s sign/column mismatch", (debit, credit) => {
+    expect(() =>
+      parseBanreservasEmpresasTransactionRows([
+        { ...banreservasEmpresasTransactions[0], debit, credit },
+      ]),
+    ).toThrow("sign/column mismatch");
+  });
+
+  it("rejects malformed zero in inactive debit column", () => {
+    expect(() =>
+      parseBanreservasEmpresasTransactionRows([
+        { ...banreservasEmpresasTransactions[0], debit: "0,00.00", credit: "25,000.00" },
+      ]),
+    ).toThrow("Invalid Banreservas Empresas amount format");
+  });
+
+  it("rejects malformed zero in inactive credit column", () => {
+    expect(() =>
+      parseBanreservasEmpresasTransactionRows([
+        { ...banreservasEmpresasTransactions[0], debit: "193.15", credit: "0,00.00" },
+      ]),
+    ).toThrow("Invalid Banreservas Empresas amount format");
+  });
+
+  it("normalizes whitespace-only transactionNumber to null and trims valid reference", () => {
+    const nullRef = parseBanreservasEmpresasTransactionRows([
+      { ...banreservasEmpresasTransactions[0], transactionNumber: "   " },
+    ]);
+    expect(nullRef[0].reference).toBeNull();
+    const validRef = parseBanreservasEmpresasTransactionRows([
+      { ...banreservasEmpresasTransactions[0], transactionNumber: "942632990001" },
+    ]);
+    expect(validRef[0].reference).toBe("942632990001");
+  });
+
+  it("balance is NOT leaked into metadata or any output field", () => {
+    const movements = parseBanreservasEmpresasTransactionRows(banreservasEmpresasTransactions);
+    for (const m of movements) {
+      expect(m.metadata).toBeNull();
+      expect(m.concept).not.toContain("DOP");
+      expect(m.concept).not.toContain("29,472.55");
+      expect(m.concept).not.toContain("4,472.55");
+    }
+  });
+
+  it("normalizes description whitespace", () => {
+    const movements = parseBanreservasEmpresasTransactionRows([
+      { ...banreservasEmpresasTransactions[0], description: "  DEPOSITO  EN   EFECTIVO  " },
+    ]);
+    expect(movements[0].concept).toBe("DEPOSITO EN EFECTIVO");
   });
 });

--- a/src/modules/bank-adapters/banreservas.ts
+++ b/src/modules/bank-adapters/banreservas.ts
@@ -1,11 +1,12 @@
 /** Banreservas Personas + Empresas — read-only adapter skeletons (PR5B2/PR5B3)
- *  + Personas DOM extraction parser (PR5D/PR5F). */
+ *  + Personas DOM extraction parser (PR5D/PR5F)
+ *  + Empresas DOM extraction parser (PR5E). */
 
 import type { BankMovement, TransactionDirection } from "../../modules/transactions";
 import type { IngestionScraper } from "../../worker/queues";
 import type { CdpSessionChecker } from "../../modules/bank-sessions";
 import type { BankAdapter, BankAutoLoginStrategy } from "./registry";
-import type { BanreservasPersonasTransaction } from "./fixtures/types";
+import type { BanreservasPersonasTransaction, BanreservasEmpresasTransaction } from "./fixtures/types";
 
 /**
  * Portal-specific bank codes for Banreservas Personas and Empresas.
@@ -79,6 +80,7 @@ export const banreservasPersonasPortalConfig = {
 export const banreservasEmpresasScraperProfile = {
   bankId: banreservasEmpresasBankCode,
   portalVariant: banreservasEmpresasPortalVariant,
+  accountFingerprint: "banreservas-empresas-XXXXXXXXXX",
   loginUrl: "https://www.banreservas.com.do/TuBancoEmpresas/Login.aspx",
   landingUrl: "https://www.banreservas.com.do/TuBancoEmpresas/Default.aspx",
   framework: "aspnet-webforms+devexpress" as const,
@@ -269,6 +271,141 @@ export function parseBanreservasPersonasTransactionRows(
       metadata: null,
     };
   });
+}
+
+// ---------------------------------------------------------------------------
+// Transaction parser — Banreservas Empresas DD/MM/YY + column-based amounts → BankMovement
+// ---------------------------------------------------------------------------
+
+export interface BanreservasEmpresasParseOptions {
+  accountFingerprint?: string;
+  bankId?: string;
+  currency?: string;
+}
+
+/**
+ * Parse Banreservas Empresas DD/MM/YY (2-digit year) dates.
+ * Assumes 2000+ for the 2-digit year (e.g., "26" → 2026).
+ */
+export function parseBanreservasEmpresasDate(value: string): string {
+  const match = /^(\d{2})\/(\d{2})\/(\d{2})$/.exec(value.trim());
+  if (!match) throw new Error("Invalid Banreservas Empresas date format");
+
+  const [, dayStr, monthStr, yearStr] = match;
+  const day = Number(dayStr);
+  const month = Number(monthStr);
+  const year = 2000 + Number(yearStr);
+
+  // Validate month range.
+  if (month < 1 || month > 12) throw new Error("Invalid Banreservas Empresas date format");
+
+  // Validate day range for the given month (including leap-year check for Feb).
+  const daysInMonth = new Date(year, month, 0).getDate();
+  if (day < 1 || day > daysInMonth) throw new Error("Invalid Banreservas Empresas date format");
+
+  const fullYearStr = String(year);
+  return `${fullYearStr}-${monthStr}-${dayStr}T00:00:00${SANTO_DOMINGO_OFFSET}`;
+}
+
+/**
+ * Parse Banreservas Empresas amounts. Amounts are always positive in the
+ * Empresas format; direction is determined by which column (debit/credit)
+ * contains the non-zero value. Rejects negative amounts (sign not expected).
+ */
+export function parseBanreservasEmpresasAmount(value: string): { value: number; direction: TransactionDirection } {
+  const trimmed = value.trim();
+  if (trimmed === "") throw new Error("Invalid Banreservas Empresas amount format");
+
+  // Reject negative amounts — Empresas format uses separate columns, not signs.
+  if (trimmed.startsWith("-")) throw new Error("Invalid Banreservas Empresas amount format");
+
+  // Validate comma grouping BEFORE stripping: commas must follow standard
+  // thousands grouping (exactly 3 digits after each comma).
+  const hasCommas = trimmed.includes(",");
+  if (hasCommas && !/^\d{1,3}(,\d{3})+(\.\d+)?$/.test(trimmed)) {
+    throw new Error("Invalid Banreservas Empresas amount format");
+  }
+
+  const normalized = trimmed.replace(/,/g, "");
+  // Reject malformed patterns: leading/trailing dots, etc.
+  if (!/^\d+(\.\d+)?$/.test(normalized)) {
+    throw new Error("Invalid Banreservas Empresas amount format");
+  }
+
+  // Reject >2 decimal places — toFixed(2) must not silently round.
+  if (/\.\d{3,}$/.test(normalized)) {
+    throw new Error("Invalid Banreservas Empresas amount format");
+  }
+
+  const amount = Number(normalized);
+  if (!Number.isFinite(amount)) throw new Error("Invalid Banreservas Empresas amount format");
+
+  return {
+    value: amount,
+    direction: "credit",
+  };
+}
+
+export function parseBanreservasEmpresasTransactionRows(
+  rows: readonly BanreservasEmpresasTransaction[],
+  options: BanreservasEmpresasParseOptions = {},
+): BankMovement[] {
+  return rows.map((row) => {
+    const postedAt = parseBanreservasEmpresasDate(row.date);
+
+    const debitText = row.debit.trim();
+    const creditText = row.credit.trim();
+
+    // Sign/column mismatch: Empresas amounts are always positive.
+    if (debitText.startsWith("-")) {
+      throw new Error(
+        `Banreservas Empresas parser: sign/column mismatch — debit column contains negative amount "${debitText}"`,
+      );
+    }
+    if (creditText.startsWith("-")) {
+      throw new Error(
+        `Banreservas Empresas parser: sign/column mismatch — credit column contains negative amount "${creditText}"`,
+      );
+    }
+
+    // Validate BOTH columns' format before deciding direction.
+    // Catches malformed inactive-zero cells like "0,00.00" that a blind
+    // Number() conversion would silently coerce to 0.
+    const debitParsed = parseBanreservasEmpresasAmount(debitText);
+    const creditParsed = parseBanreservasEmpresasAmount(creditText);
+
+    if (debitParsed.value !== 0 && creditParsed.value !== 0) {
+      throw new Error(
+        `Banreservas Empresas parser: ambiguous amount — both debit ("${debitText}") and credit ("${creditText}") are non-zero`,
+      );
+    }
+
+    if (debitParsed.value === 0 && creditParsed.value === 0) {
+      throw new Error(
+        "Banreservas Empresas parser: missing amount — both debit and credit columns are zero",
+      );
+    }
+
+    const isDebit = debitParsed.value !== 0;
+
+    return {
+      bankId: options.bankId ?? banreservasEmpresasBankCode,
+      accountFingerprint: options.accountFingerprint ?? banreservasEmpresasScraperProfile.accountFingerprint,
+      postedAt,
+      amount: Math.abs(isDebit ? debitParsed.value : creditParsed.value).toFixed(2),
+      currency: options.currency ?? "DOP",
+      direction: (isDebit ? "debit" : "credit") as TransactionDirection,
+      reference: normalizeOptionalField(row.transactionNumber),
+      concept: normalizeText(row.description),
+      originator: null,
+      metadata: null,
+    };
+  });
+}
+
+function normalizeOptionalField(value: string): string | null {
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
 }
 
 // ── Adapter factories + stubs ────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds Banreservas Empresas read-only transaction parsing helpers for DD/MM/YY dates, Empresas amount cells, and transaction-number references.
- Fails closed on malformed inactive columns, unsupported decimal precision, impossible dates, ambiguous/missing debit-credit states, and sign/column mismatches.
- Updates PR5 task metadata to record the Empresas extraction sub-slice while leaving PR4-dependent work blocked.

## Changes
| File | Change |
|------|--------|
| `src/modules/bank-adapters/banreservas.ts` | Adds Banreservas Empresas parser helpers and account fingerprint metadata. |
| `src/modules/bank-adapters/banreservas.test.ts` | Adds behavior-focused Empresas parser tests, including review-remediated financial fail-closed cases. |
| `openspec/changes/multi-bank-auto-login/tasks.md` | Adds PR5E Banreservas Empresas parser slice status. |

## Test Plan
- [x] Targeted Banreservas adapter tests
- [x] Relevant fixture tests
- [x] `pnpm test`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `git diff --check`

## Review Notes
- Changed lines: 398 insertions, 2 deletions across 3 files — exactly 400 changed lines.
- Fresh review initially requested malformed inactive-column validation, decimal precision rejection, and budget correction.
- Remediation completed; final fresh re-review found no findings.
- No credential submission, no auto-login enablement, no MFA/CAPTCHA/OneSpan automation, and no export hot path.
- This repository currently has no GitHub issues or `type:*` labels, so this PR follows the existing RD-Sync PR practice.