### PR TITLE
feat(auto-login): add lock contract foundation

### DIFF
--- a/openspec/changes/multi-bank-auto-login/tasks.md
+++ b/openspec/changes/multi-bank-auto-login/tasks.md
@@ -89,7 +89,9 @@ Gate: full gates + FRESH 4R review + Judgment Day before merge; PR3B1 <=400 line
 
 ## PR4: Auto-login orchestration + Redis lock/fencing + breaker + Popular auto-login [HIGH RISK]
 
-- [ ] 4.1 Create `src/modules/bank-auto-login-lock/index.ts`: Redis-backed `AutoLoginLock` — `acquire(bankCode,expiredEventId)`->`{leaseToken,fencingToken,expiresAt}|null`; owner-only `release`/`renew`; key `autologin:lock:{bankCode}:{expiredEventId}`; bounded TTL; CAS-guarded state writes carry fencingToken (stale lease cannot unlock/overwrite).
+- [x] 4.1a Create `src/modules/bank-auto-login-lock/index.ts`: lock contract + `AutoLoginLock` interface + `LockStore` abstraction + `createAutoLoginLock` factory with bounded TTL, CAS-guarded fencing tokens, input validation, and comprehensive unit tests (no Redis adapter yet — see 4.1b).
+- [ ] 4.1b Redis-backed `LockStore` adapter: atomic Lua scripts for `acquireSlot`/`releaseIfOwner`/`renewIfOwner` with TTL-bound CAS, fencing-token increment, and expired-key semantics matching Redis native expiry.
+- [ ] 4.1c Wire `LockStore` Redis adapter into production `createAutoLoginLock` calls via DI/config.
 - [ ] 4.2 `prisma/schema.prisma`: add `BankAutoLoginConfig` (`autoLoginEnabled` default false; breaker `closed|open` only, NO half_open) + `BankAdapterConfig` (`scrapingEnabled` default true); migration.
 - [ ] 4.3 Create `src/modules/bank-auto-login-config/` + `src/modules/bank-adapter-config/`: repos + conservative breaker policy (3 failures/30min->open, NO half-open, manual admin reset only clears window, alert on open + <=every 30min).
 - [ ] 4.4 Create `src/worker/scraper/auto-login.ts`: `BankAutoLoginStrategy` state machine + `LoginMutationGuard` (HTTPS + exact origin + login-path allowlist, re-check before fill AND submit, `assertCompatiblePreSubmit`).

--- a/src/modules/bank-auto-login-lock/index.ts
+++ b/src/modules/bank-auto-login-lock/index.ts
@@ -1,8 +1,3 @@
-/**
- * AutoLoginLock with fencing tokens. Prevents concurrent scrape runs from
- * double-submitting credentials for the SAME expired session event.
- * Scoped to bankCode + expiredEventId.
- */
 import { randomBytes } from "node:crypto";
 
 export interface AcquiredLock {
@@ -17,21 +12,22 @@ export interface AutoLoginLock {
   renew(bankCode: string, expiredEventId: string, leaseToken: string, ttlMs?: number): Promise<boolean>;
 }
 
-/** Store abstraction for distributed locking. Production wraps ioredis via atomic Lua scripts. */
-export interface LockStore {
-  acquireSlot(key: string, leaseToken: string, ttlMs: number, nowMs: number): Promise<number | null>;
-  releaseIfOwner(key: string, expectedLeaseToken: string): Promise<boolean>;
-  renewIfOwner(key: string, expectedLeaseToken: string, newTtlMs: number, nowMs: number): Promise<boolean>;
+export interface AcquireSlotParams {
+  key: string;
+  leaseToken: string;
+  ttlMs: number;
+  nowMs: number;
 }
-
-
-
-export interface CreateAutoLoginLockOptions {
-  store: LockStore;
-  defaultTtlMs?: number;
-  maxTtlMs?: number;
-  generateLeaseToken?: () => string;
-  now?: () => number;
+export interface RenewIfOwnerParams {
+  key: string;
+  expectedLeaseToken: string;
+  newTtlMs: number;
+  nowMs: number;
+}
+export interface LockStore {
+  acquireSlot(params: AcquireSlotParams): Promise<number | null>;
+  releaseIfOwner(key: string, expectedLeaseToken: string): Promise<boolean>;
+  renewIfOwner(params: RenewIfOwnerParams): Promise<boolean>;
 }
 
 export const DEFAULT_LOCK_TTL_MS = 5 * 60 * 1000;
@@ -44,25 +40,24 @@ export class LockValidationError extends Error {
     this.name = "LockValidationError";
   }
 }
-
 const BANK_CODE_RE = /^[a-z][a-z0-9_-]{0,31}$/;
 const EVENT_ID_RE = /^[a-zA-Z0-9-]{1,64}$/;
 
-function validate(field: string, value: unknown, tests: [boolean, string][]): void {
+function validate(field: string, tests: [boolean, string][]): void {
   for (const [ok, msg] of tests) {
     if (!ok) throw new LockValidationError(field, msg);
   }
 }
 
 function validateBankCode(bankCode: string): void {
-  validate("bankCode", bankCode, [
+  validate("bankCode", [
     [typeof bankCode === "string" && bankCode.length > 0, "must be a non-empty string"],
     [BANK_CODE_RE.test(bankCode), "must be 1-32 chars, lowercase alphanumeric/underscore/hyphen, starting with a letter"],
   ]);
 }
 
 function validateEventId(eventId: string): void {
-  validate("expiredEventId", eventId, [
+  validate("expiredEventId", [
     [typeof eventId === "string" && eventId.length > 0, "must be a non-empty string"],
     [eventId.length <= 64, "must be at most 64 characters"],
     [EVENT_ID_RE.test(eventId), "must contain only alphanumeric characters and hyphens"],
@@ -70,26 +65,29 @@ function validateEventId(eventId: string): void {
 }
 
 function validateLeaseToken(leaseToken: string): void {
-  validate("leaseToken", leaseToken, [
+  validate("leaseToken", [
     [typeof leaseToken === "string" && leaseToken.length > 0, "must be a non-empty string"],
   ]);
 }
 
 function validateTtlMs(ttlMs: number, maxTtlMs?: number): void {
-  validate("ttlMs", ttlMs, [
+  validate("ttlMs", [
     [typeof ttlMs === "number" && Number.isFinite(ttlMs) && ttlMs > 0, "must be a positive number"],
     ...(maxTtlMs != null ? [[ttlMs <= maxTtlMs, `must not exceed ${maxTtlMs}ms`] as [boolean, string]] : []),
   ]);
 }
 
-export function buildLockKey(bankCode: string, expiredEventId: string): string {
-  return `${LOCK_KEY_PREFIX}:${bankCode}:${expiredEventId}`;
-}
-function defaultGenerateLeaseToken(): string {
-  return randomBytes(16).toString("hex");
-}
+export const buildLockKey = (bankCode: string, expiredEventId: string): string =>
+  `${LOCK_KEY_PREFIX}:${bankCode}:${expiredEventId}`;
 
-export function createAutoLoginLock(options: CreateAutoLoginLockOptions): AutoLoginLock {
+const defaultGenerateLeaseToken = (): string => randomBytes(16).toString("hex");
+export function createAutoLoginLock(options: {
+  store: LockStore;
+  defaultTtlMs?: number;
+  maxTtlMs?: number;
+  generateLeaseToken?: () => string;
+  now?: () => number;
+}): AutoLoginLock {
   const { store, defaultTtlMs = DEFAULT_LOCK_TTL_MS, maxTtlMs = MAX_LOCK_TTL_MS, generateLeaseToken = defaultGenerateLeaseToken, now = () => Date.now() } = options;
 
   if (!store) throw new Error("LockStore is required");
@@ -103,7 +101,7 @@ export function createAutoLoginLock(options: CreateAutoLoginLockOptions): AutoLo
       const key = buildLockKey(bankCode, expiredEventId);
       const leaseToken = generateLeaseToken();
       const currentTime = now();
-      const fencingToken = await store.acquireSlot(key, leaseToken, effectiveTtlMs, currentTime);
+      const fencingToken = await store.acquireSlot({ key, leaseToken, ttlMs: effectiveTtlMs, nowMs: currentTime });
       if (fencingToken === null) return null;
       return { leaseToken, fencingToken, expiresAt: currentTime + effectiveTtlMs };
     },
@@ -119,7 +117,7 @@ export function createAutoLoginLock(options: CreateAutoLoginLockOptions): AutoLo
       validateLeaseToken(leaseToken);
       const effectiveTtlMs = ttlMs ?? defaultTtlMs;
       validateTtlMs(effectiveTtlMs, maxTtlMs);
-      return store.renewIfOwner(buildLockKey(bankCode, expiredEventId), leaseToken, effectiveTtlMs, now());
+      return store.renewIfOwner({ key: buildLockKey(bankCode, expiredEventId), expectedLeaseToken: leaseToken, newTtlMs: effectiveTtlMs, nowMs: now() });
     },
   };
 }

--- a/src/modules/bank-auto-login-lock/index.ts
+++ b/src/modules/bank-auto-login-lock/index.ts
@@ -1,0 +1,125 @@
+/**
+ * AutoLoginLock with fencing tokens. Prevents concurrent scrape runs from
+ * double-submitting credentials for the SAME expired session event.
+ * Scoped to bankCode + expiredEventId.
+ */
+import { randomBytes } from "node:crypto";
+
+export interface AcquiredLock {
+  leaseToken: string;
+  fencingToken: number;
+  expiresAt: number;
+}
+
+export interface AutoLoginLock {
+  acquire(bankCode: string, expiredEventId: string, ttlMs?: number): Promise<AcquiredLock | null>;
+  release(bankCode: string, expiredEventId: string, leaseToken: string): Promise<boolean>;
+  renew(bankCode: string, expiredEventId: string, leaseToken: string, ttlMs?: number): Promise<boolean>;
+}
+
+/** Store abstraction for distributed locking. Production wraps ioredis via atomic Lua scripts. */
+export interface LockStore {
+  acquireSlot(key: string, leaseToken: string, ttlMs: number, nowMs: number): Promise<number | null>;
+  releaseIfOwner(key: string, expectedLeaseToken: string): Promise<boolean>;
+  renewIfOwner(key: string, expectedLeaseToken: string, newTtlMs: number, nowMs: number): Promise<boolean>;
+}
+
+
+
+export interface CreateAutoLoginLockOptions {
+  store: LockStore;
+  defaultTtlMs?: number;
+  maxTtlMs?: number;
+  generateLeaseToken?: () => string;
+  now?: () => number;
+}
+
+export const DEFAULT_LOCK_TTL_MS = 5 * 60 * 1000;
+export const MAX_LOCK_TTL_MS = 15 * 60 * 1000;
+export const LOCK_KEY_PREFIX = "autologin:lock";
+
+export class LockValidationError extends Error {
+  constructor(field: string, message: string) {
+    super(`Invalid ${field}: ${message}`);
+    this.name = "LockValidationError";
+  }
+}
+
+const BANK_CODE_RE = /^[a-z][a-z0-9_-]{0,31}$/;
+const EVENT_ID_RE = /^[a-zA-Z0-9-]{1,64}$/;
+
+function validate(field: string, value: unknown, tests: [boolean, string][]): void {
+  for (const [ok, msg] of tests) {
+    if (!ok) throw new LockValidationError(field, msg);
+  }
+}
+
+function validateBankCode(bankCode: string): void {
+  validate("bankCode", bankCode, [
+    [typeof bankCode === "string" && bankCode.length > 0, "must be a non-empty string"],
+    [BANK_CODE_RE.test(bankCode), "must be 1-32 chars, lowercase alphanumeric/underscore/hyphen, starting with a letter"],
+  ]);
+}
+
+function validateEventId(eventId: string): void {
+  validate("expiredEventId", eventId, [
+    [typeof eventId === "string" && eventId.length > 0, "must be a non-empty string"],
+    [eventId.length <= 64, "must be at most 64 characters"],
+    [EVENT_ID_RE.test(eventId), "must contain only alphanumeric characters and hyphens"],
+  ]);
+}
+
+function validateLeaseToken(leaseToken: string): void {
+  validate("leaseToken", leaseToken, [
+    [typeof leaseToken === "string" && leaseToken.length > 0, "must be a non-empty string"],
+  ]);
+}
+
+function validateTtlMs(ttlMs: number, maxTtlMs?: number): void {
+  validate("ttlMs", ttlMs, [
+    [typeof ttlMs === "number" && Number.isFinite(ttlMs) && ttlMs > 0, "must be a positive number"],
+    ...(maxTtlMs != null ? [[ttlMs <= maxTtlMs, `must not exceed ${maxTtlMs}ms`] as [boolean, string]] : []),
+  ]);
+}
+
+export function buildLockKey(bankCode: string, expiredEventId: string): string {
+  return `${LOCK_KEY_PREFIX}:${bankCode}:${expiredEventId}`;
+}
+function defaultGenerateLeaseToken(): string {
+  return randomBytes(16).toString("hex");
+}
+
+export function createAutoLoginLock(options: CreateAutoLoginLockOptions): AutoLoginLock {
+  const { store, defaultTtlMs = DEFAULT_LOCK_TTL_MS, maxTtlMs = MAX_LOCK_TTL_MS, generateLeaseToken = defaultGenerateLeaseToken, now = () => Date.now() } = options;
+
+  if (!store) throw new Error("LockStore is required");
+
+  return {
+    async acquire(bankCode, expiredEventId, ttlMs?) {
+      validateBankCode(bankCode);
+      validateEventId(expiredEventId);
+      const effectiveTtlMs = ttlMs ?? defaultTtlMs;
+      validateTtlMs(effectiveTtlMs, maxTtlMs);
+      const key = buildLockKey(bankCode, expiredEventId);
+      const leaseToken = generateLeaseToken();
+      const currentTime = now();
+      const fencingToken = await store.acquireSlot(key, leaseToken, effectiveTtlMs, currentTime);
+      if (fencingToken === null) return null;
+      return { leaseToken, fencingToken, expiresAt: currentTime + effectiveTtlMs };
+    },
+    async release(bankCode, expiredEventId, leaseToken) {
+      validateBankCode(bankCode);
+      validateEventId(expiredEventId);
+      validateLeaseToken(leaseToken);
+      return store.releaseIfOwner(buildLockKey(bankCode, expiredEventId), leaseToken);
+    },
+    async renew(bankCode, expiredEventId, leaseToken, ttlMs?) {
+      validateBankCode(bankCode);
+      validateEventId(expiredEventId);
+      validateLeaseToken(leaseToken);
+      const effectiveTtlMs = ttlMs ?? defaultTtlMs;
+      validateTtlMs(effectiveTtlMs, maxTtlMs);
+      return store.renewIfOwner(buildLockKey(bankCode, expiredEventId), leaseToken, effectiveTtlMs, now());
+    },
+  };
+}

--- a/src/modules/bank-auto-login-lock/lock.test.ts
+++ b/src/modules/bank-auto-login-lock/lock.test.ts
@@ -12,7 +12,7 @@ class InMemoryLockStore {
   private store = new Map<string, string>();
   private counters = new Map<string, number>();
   constructor(private readonly now?: () => number) {}
-  async acquireSlot(key: string, leaseToken: string, ttlMs: number, nowMs: number): Promise<number | null> {
+  async acquireSlot({ key, leaseToken, ttlMs, nowMs }: { key: string; leaseToken: string; ttlMs: number; nowMs: number }): Promise<number | null> {
     const raw = this.store.get(key);
     if (raw) {
       const d = JSON.parse(raw) as { expiresAt: number; fencingToken: number };
@@ -34,7 +34,7 @@ class InMemoryLockStore {
     this.store.delete(key);
     return true;
   }
-  async renewIfOwner(key: string, expected: string, newTtlMs: number, nowMs: number): Promise<boolean> {
+  async renewIfOwner({ key, expectedLeaseToken: expected, newTtlMs, nowMs }: { key: string; expectedLeaseToken: string; newTtlMs: number; nowMs: number }): Promise<boolean> {
     const raw = this.store.get(key);
     if (!raw) return false;
     const d = JSON.parse(raw) as { leaseToken: string; fencingToken: number; expiresAt: number };
@@ -56,7 +56,6 @@ function setup(opts?: { defaultTtlMs?: number; maxTtlMs?: number; now?: () => nu
   });
   return { store, lock, startTimeMs };
 }
-
 describe("AutoLoginLock", () => {
   describe("acquire", () => {
     it("returns lease with leaseToken, fencingToken=1, and expiresAt", async () => {
@@ -264,6 +263,10 @@ describe("AutoLoginLock", () => {
       expect(buildLockKey("popular", "evt-001")).toBe("autologin:lock:popular:evt-001");
       expect(LOCK_KEY_PREFIX).toBe("autologin:lock");
       expect(DEFAULT_LOCK_TTL_MS).toBe(5 * 60 * 1000);
+    });
+    it("throws when store is missing (fail-fast)", () => {
+      // Force an undefined store to exercise the runtime guard (TS would catch this normally).
+      expect(() => createAutoLoginLock({ store: undefined as unknown as import("./index").LockStore })).toThrow("LockStore is required");
     });
   });
 });

--- a/src/modules/bank-auto-login-lock/lock.test.ts
+++ b/src/modules/bank-auto-login-lock/lock.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect } from "vitest";
+import {
+  createAutoLoginLock,
+  buildLockKey,
+  LockValidationError,
+  DEFAULT_LOCK_TTL_MS,
+  MAX_LOCK_TTL_MS,
+  LOCK_KEY_PREFIX,
+} from "./index";
+
+class InMemoryLockStore {
+  private store = new Map<string, string>();
+  private counters = new Map<string, number>();
+  constructor(private readonly now?: () => number) {}
+  async acquireSlot(key: string, leaseToken: string, ttlMs: number, nowMs: number): Promise<number | null> {
+    const raw = this.store.get(key);
+    if (raw) {
+      const d = JSON.parse(raw) as { expiresAt: number; fencingToken: number };
+      if (d.expiresAt > nowMs) return null;
+      this.counters.set(key, d.fencingToken + 1);
+    } else {
+      this.counters.set(key, (this.counters.get(key) ?? 0) + 1);
+    }
+    const ft = this.counters.get(key)!;
+    this.store.set(key, JSON.stringify({ leaseToken, fencingToken: ft, expiresAt: nowMs + ttlMs }));
+    return ft;
+  }
+  async releaseIfOwner(key: string, expected: string): Promise<boolean> {
+    const raw = this.store.get(key);
+    if (!raw) return false;
+    const d = JSON.parse(raw) as { leaseToken: string; expiresAt: number };
+    if (d.leaseToken !== expected) return false;
+    if (d.expiresAt <= (this.now?.() ?? Infinity)) { this.store.delete(key); return false; }
+    this.store.delete(key);
+    return true;
+  }
+  async renewIfOwner(key: string, expected: string, newTtlMs: number, nowMs: number): Promise<boolean> {
+    const raw = this.store.get(key);
+    if (!raw) return false;
+    const d = JSON.parse(raw) as { leaseToken: string; fencingToken: number; expiresAt: number };
+    if (d.leaseToken !== expected || d.expiresAt <= nowMs) return false;
+    this.store.set(key, JSON.stringify({ ...d, expiresAt: nowMs + newTtlMs }));
+    return true;
+  }
+}
+
+function setup(opts?: { defaultTtlMs?: number; maxTtlMs?: number; now?: () => number }) {
+  const startTimeMs = 1_000_000;
+  const now = opts?.now ?? (() => startTimeMs);
+  const store = new InMemoryLockStore(now);
+  const lock = createAutoLoginLock({
+    store,
+    defaultTtlMs: opts?.defaultTtlMs ?? DEFAULT_LOCK_TTL_MS,
+    maxTtlMs: opts?.maxTtlMs ?? MAX_LOCK_TTL_MS,
+    now,
+  });
+  return { store, lock, startTimeMs };
+}
+
+describe("AutoLoginLock", () => {
+  describe("acquire", () => {
+    it("returns lease with leaseToken, fencingToken=1, and expiresAt", async () => {
+      const { lock, startTimeMs } = setup();
+      const r = await lock.acquire("popular", "evt-001");
+      expect(r).not.toBeNull();
+      expect(r!.leaseToken).toBeTypeOf("string");
+      expect(r!.leaseToken.length).toBeGreaterThan(0);
+      expect(r!.fencingToken).toBe(1);
+      expect(r!.expiresAt).toBe(startTimeMs + DEFAULT_LOCK_TTL_MS);
+    });
+    it("returns null when lock is already held", async () => {
+      const { lock } = setup();
+      expect(await lock.acquire("popular", "evt-001")).not.toBeNull();
+      expect(await lock.acquire("popular", "evt-001")).toBeNull();
+    });
+    it("returns null when held by a different owner instance", async () => {
+      let counter = 0;
+      const now = () => 1_000_000;
+      const store = new InMemoryLockStore(now);
+      const mk = () => createAutoLoginLock({
+        store, defaultTtlMs: 60_000, now,
+        generateLeaseToken: () => `lease-${++counter}`,
+      });
+      expect(await mk().acquire("popular", "evt-001")).not.toBeNull();
+      expect(await mk().acquire("popular", "evt-001")).toBeNull();
+    });
+  });
+
+  describe("release", () => {
+    it("succeeds for matching leaseToken", async () => {
+      const { lock } = setup();
+      const acquired = await lock.acquire("popular", "evt-001");
+      expect(await lock.release("popular", "evt-001", acquired!.leaseToken)).toBe(true);
+    });
+    it("fails for wrong leaseToken (stale owner)", async () => {
+      const { lock } = setup();
+      await lock.acquire("popular", "evt-001");
+      expect(await lock.release("popular", "evt-001", "wrong-token")).toBe(false);
+    });
+    it("fails for stale leaseToken after new acquire", async () => {
+      let timeMs = 1_000_000;
+      const now = () => timeMs;
+      const lock = createAutoLoginLock({ store: new InMemoryLockStore(now), defaultTtlMs: 1000, now });
+      const first = await lock.acquire("popular", "evt-001");
+      timeMs += 2000;
+      const second = await lock.acquire("popular", "evt-001");
+      expect(await lock.release("popular", "evt-001", first!.leaseToken)).toBe(false);
+      expect(await lock.release("popular", "evt-001", second!.leaseToken)).toBe(true);
+    });
+  });
+
+  describe("renew", () => {
+    it("succeeds for matching leaseToken", async () => {
+      const { lock } = setup();
+      const acquired = await lock.acquire("popular", "evt-001");
+      expect(await lock.renew("popular", "evt-001", acquired!.leaseToken, 60_000)).toBe(true);
+    });
+    it("extends TTL from current time, not original", async () => {
+      let timeMs = 1_000_000;
+      const now = () => timeMs;
+      const lock = createAutoLoginLock({ store: new InMemoryLockStore(now), defaultTtlMs: 5_000, maxTtlMs: 60_000, now });
+      const ac = await lock.acquire("popular", "evt-001");
+      expect(ac!.expiresAt).toBe(1_005_000);
+      timeMs = 1_002_000;
+      expect(await lock.renew("popular", "evt-001", ac!.leaseToken, 10_000)).toBe(true);
+      timeMs = 1_008_000;
+      expect(await lock.acquire("popular", "evt-001")).toBeNull();
+      timeMs = 1_012_001;
+      expect((await lock.acquire("popular", "evt-001"))!.fencingToken).toBe(2);
+    });
+    it("fails for expired lease after new owner acquired", async () => {
+      let timeMs = 1_000_000;
+      const now = () => timeMs;
+      const lock = createAutoLoginLock({ store: new InMemoryLockStore(now), defaultTtlMs: 1000, now });
+      const first = await lock.acquire("popular", "evt-001");
+      timeMs += 2000;
+      const second = await lock.acquire("popular", "evt-001");
+      expect(await lock.renew("popular", "evt-001", first!.leaseToken)).toBe(false);
+      expect(await lock.renew("popular", "evt-001", second!.leaseToken)).toBe(true);
+    });
+  });
+
+  describe("max TTL enforcement", () => {
+    it.each([
+      ["acquire", (l: ReturnType<typeof createAutoLoginLock>) => l.acquire("popular", "evt-001", 60_001)],
+      ["renew", async (l: ReturnType<typeof createAutoLoginLock>) => {
+        const a = await l.acquire("popular", "evt-001");
+        return l.renew("popular", "evt-001", a!.leaseToken, 60_001);
+      }],
+    ])("rejects %s TTL exceeding maxTtlMs", async (_, op) => {
+      const { lock } = setup({ defaultTtlMs: 30_000, maxTtlMs: 60_000 });
+      await expect(op(lock)).rejects.toThrow(LockValidationError);
+    });
+    it("accepts TTL at and below maxTtlMs", async () => {
+      const { lock } = setup({ maxTtlMs: 60_000 });
+      expect(await lock.acquire("popular", "evt-001", 60_000)).not.toBeNull();
+      expect(await lock.acquire("popular", "evt-002", 5_000)).not.toBeNull();
+    });
+    it("defaults maxTtlMs to 15 minutes", async () => {
+      expect(MAX_LOCK_TTL_MS).toBe(15 * 60 * 1000);
+      const { lock } = setup();
+      await expect(lock.acquire("popular", "evt-001", MAX_LOCK_TTL_MS + 1)).rejects.toThrow(LockValidationError);
+    });
+  });
+
+  describe("expired-token release semantics", () => {
+    it("release before re-acquire on expired lock returns false and cleans up (matching Redis expiry)", async () => {
+      let timeMs = 1_000_000;
+      const now = () => timeMs;
+      const lock = createAutoLoginLock({ store: new InMemoryLockStore(now), defaultTtlMs: 1000, now });
+      const first = await lock.acquire("popular", "evt-001");
+      timeMs += 2000;
+      expect(await lock.release("popular", "evt-001", first!.leaseToken)).toBe(false);
+      const second = await lock.acquire("popular", "evt-001");
+      expect(second).not.toBeNull();
+      expect(second!.fencingToken).toBe(2);
+    });
+    it("release after owner expiry fails like Redis (lease mismatch after re-acquire)", async () => {
+      let timeMs = 1_000_000;
+      const now = () => timeMs;
+      const lock = createAutoLoginLock({ store: new InMemoryLockStore(now), defaultTtlMs: 1000, now });
+      const first = await lock.acquire("popular", "evt-001");
+      timeMs += 2000;
+      const second = await lock.acquire("popular", "evt-001");
+      expect(second).not.toBeNull();
+      expect(await lock.release("popular", "evt-001", first!.leaseToken)).toBe(false);
+      expect(await lock.release("popular", "evt-001", second!.leaseToken)).toBe(true);
+    });
+  });
+
+  describe("fencing tokens", () => {
+    it("increase on each re-acquire after release", async () => {
+      const { lock } = setup();
+      const a1 = await lock.acquire("popular", "evt-001");
+      expect(a1!.fencingToken).toBe(1);
+      await lock.release("popular", "evt-001", a1!.leaseToken);
+      const a2 = await lock.acquire("popular", "evt-001");
+      expect(a2!.fencingToken).toBe(2);
+      await lock.release("popular", "evt-001", a2!.leaseToken);
+      const a3 = await lock.acquire("popular", "evt-001");
+      expect(a3!.fencingToken).toBe(3);
+    });
+    it("increase on re-acquire after expiry", async () => {
+      let timeMs = 1_000_000;
+      const now = () => timeMs;
+      const lock = createAutoLoginLock({ store: new InMemoryLockStore(now), defaultTtlMs: 1000, now });
+      expect((await lock.acquire("popular", "evt-001"))!.fencingToken).toBe(1);
+      timeMs += 2000;
+      expect((await lock.acquire("popular", "evt-001"))!.fencingToken).toBe(2);
+    });
+    it("are independent per key and bank", async () => {
+      const { lock } = setup();
+      const a1 = await lock.acquire("popular", "evt-001");
+      const a2 = await lock.acquire("popular", "evt-002");
+      const a3 = await lock.acquire("banreservas", "evt-001");
+      expect(a1!.fencingToken).toBe(1);
+      expect(a2!.fencingToken).toBe(1);
+      expect(a3!.fencingToken).toBe(1);
+      await lock.release("popular", "evt-001", a1!.leaseToken);
+      expect((await lock.acquire("popular", "evt-001"))!.fencingToken).toBe(2);
+      expect(await lock.acquire("popular", "evt-002")).toBeNull();
+    });
+  });
+
+  describe("input validation", () => {
+    it.each([
+      ["", "empty bankCode"], ["POPULAR", "uppercase"], ["popular-bank!", "special chars"],
+      ["1invalid", "starts with digit"], ["a".repeat(33), "exceeds 32 chars"],
+    ])("rejects invalid bankCode %j (%s)", async (bankCode) => {
+      const { lock } = setup();
+      await expect(lock.acquire(bankCode, "evt-001")).rejects.toThrow(LockValidationError);
+    });
+    it.each([
+      ["", "empty"], ["evt with spaces", "spaces"], ["evt!@#", "special chars"],
+      ["a".repeat(65), "exceeds 64 chars"],
+    ])("rejects invalid expiredEventId %j (%s)", async (eventId) => {
+      const { lock } = setup();
+      await expect(lock.acquire("popular", eventId)).rejects.toThrow(LockValidationError);
+    });
+    it("accepts valid bank codes and UUID-style eventIds", async () => {
+      const { lock } = setup();
+      for (const code of ["popular", "banreservas", "my_bank-2"]) {
+        expect(await lock.acquire(code, "evt-001")).not.toBeNull();
+      }
+      expect(await lock.acquire("popular", "550e8400-e29b-41d4-a716-446655440000")).not.toBeNull();
+    });
+    it.each([
+      ["release", (l: ReturnType<typeof createAutoLoginLock>) => l.release("popular", "evt-001", "")],
+      ["renew", (l: ReturnType<typeof createAutoLoginLock>) => l.renew("popular", "evt-001", "")],
+    ])("rejects empty leaseToken in %s", async (_, op) => {
+      await expect(op(setup().lock)).rejects.toThrow(LockValidationError);
+    });
+    it.each([
+      ["acquire", (l: ReturnType<typeof createAutoLoginLock>) => l.acquire("popular", "evt-001", 0)],
+      ["acquire", (l: ReturnType<typeof createAutoLoginLock>) => l.acquire("popular", "evt-001", -1000)],
+      ["renew", async (l: ReturnType<typeof createAutoLoginLock>) => {
+        const a = await l.acquire("popular", "evt-001");
+        return l.renew("popular", "evt-001", a!.leaseToken, 0);
+      }],
+    ])("rejects non-positive TTL in %s", async (_, op) => {
+      await expect(op(setup().lock)).rejects.toThrow(LockValidationError);
+    });
+    it("uses correct key prefix and defaults", () => {
+      expect(buildLockKey("popular", "evt-001")).toBe("autologin:lock:popular:evt-001");
+      expect(LOCK_KEY_PREFIX).toBe("autologin:lock");
+      expect(DEFAULT_LOCK_TTL_MS).toBe(5 * 60 * 1000);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds the PR4A1 AutoLoginLock foundation contract: lock factory, store interface, key validation, TTL bounds, owner-only release/renew, and fencing tokens.
- Keeps this slice honest: Redis-backed adapter and production wiring remain pending subtasks (`4.1b`, `4.1c`).
- Adds behavior-focused tests for acquire, concurrent denial, stale/wrong token safety, renew, distinct expired events, fencing monotonicity, TTL bounds, expiry semantics, validation, and fail-fast missing-store construction.

## Changes
| File | Change |
|------|--------|
| `src/modules/bank-auto-login-lock/index.ts` | Adds AutoLoginLock foundation contract/factory and bounded TTL/key validation. |
| `src/modules/bank-auto-login-lock/lock.test.ts` | Adds compact behavior-focused tests with an in-memory store fake modeling Redis expiry semantics. |
| `openspec/changes/multi-bank-auto-login/tasks.md` | Splits 4.1 into 4.1a complete and pending Redis adapter/wiring subtasks. |

## Test Plan
- [x] `pnpm test -- src/modules/bank-auto-login-lock/lock.test.ts`
- [x] `pnpm test`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `git diff --check`

## Review Notes
- Changed lines: 398 insertions, 1 deletion across 3 files.
- Fresh 4R review found blockers around TTL bounds, Redis-backed task honesty, fake expiry semantics, test-only API surface, and missing store fail-fast behavior.
- Fixes completed; final focused reliability/readability checks passed locally before push.
- No credential submission/decryption, no browser/CDP use, no Redis connection creation, and no production wiring in this slice.
- This is PR4 high-risk foundation work. Do not merge without Judgment Day approval.
- This repository currently has no GitHub issues or `type:*` labels, so this PR follows the existing RD-Sync PR practice.