### PR TITLE
feat(auto-login): add Redis lock store adapter

### DIFF
--- a/openspec/changes/multi-bank-auto-login/tasks.md
+++ b/openspec/changes/multi-bank-auto-login/tasks.md
@@ -90,7 +90,7 @@ Gate: full gates + FRESH 4R review + Judgment Day before merge; PR3B1 <=400 line
 ## PR4: Auto-login orchestration + Redis lock/fencing + breaker + Popular auto-login [HIGH RISK]
 
 - [x] 4.1a Create `src/modules/bank-auto-login-lock/index.ts`: lock contract + `AutoLoginLock` interface + `LockStore` abstraction + `createAutoLoginLock` factory with bounded TTL, CAS-guarded fencing tokens, input validation, and comprehensive unit tests (no Redis adapter yet — see 4.1b).
-- [ ] 4.1b Redis-backed `LockStore` adapter: atomic Lua scripts for `acquireSlot`/`releaseIfOwner`/`renewIfOwner` with TTL-bound CAS, fencing-token increment, and expired-key semantics matching Redis native expiry.
+- [x] 4.1b Redis-backed `LockStore` adapter: atomic Lua scripts for `acquireSlot`/`releaseIfOwner`/`renewIfOwner` with TTL-bound CAS, fencing-token increment, and expired-key semantics matching Redis native expiry.
 - [ ] 4.1c Wire `LockStore` Redis adapter into production `createAutoLoginLock` calls via DI/config.
 - [ ] 4.2 `prisma/schema.prisma`: add `BankAutoLoginConfig` (`autoLoginEnabled` default false; breaker `closed|open` only, NO half_open) + `BankAdapterConfig` (`scrapingEnabled` default true); migration.
 - [ ] 4.3 Create `src/modules/bank-auto-login-config/` + `src/modules/bank-adapter-config/`: repos + conservative breaker policy (3 failures/30min->open, NO half-open, manual admin reset only clears window, alert on open + <=every 30min).

--- a/src/modules/bank-auto-login-lock/redis-store.test.ts
+++ b/src/modules/bank-auto-login-lock/redis-store.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { RedisLockStore, type RedisEvalClient } from "./redis-store";
+
+/** Fake Redis client — simulates Lua contracts with native TTL semantics. */
+class FakeRedisClient implements RedisEvalClient {
+  private store = new Map<string, string>();
+  private expiry = new Map<string, number>();
+  public evalCalls: { script: string; keys: string[]; args: (string | number)[] }[] = [];
+  public nextEvalError?: Error;
+  public now = Date.now();
+  private isExpired(key: string): boolean {
+    const exp = this.expiry.get(key);
+    if (exp == null) return false;
+    if (this.now >= exp) { this.store.delete(key); this.expiry.delete(key); return true; }
+    return false;
+  }
+
+  async eval(script: string, numKeys: number, ...args: (string | number)[]): Promise<unknown> {
+    if (this.nextEvalError) { const e = this.nextEvalError; this.nextEvalError = undefined; throw e; }
+    const keys = args.slice(0, numKeys) as string[];
+    const sa = args.slice(numKeys);
+    this.evalCalls.push({ script, keys, args: sa });
+    const isAcquire = script.includes("INCR") && script.includes("fenceKey");
+    const isRelease = script.includes("expectedToken") && script.includes("DEL") && !script.includes("INCR");
+    const isRenew = script.includes("newTtlMs") && script.includes("SET") && !script.includes("INCR");
+    if (isAcquire) {
+      const [lockKey, fenceKey, leaseToken, ttlMs] = [keys[0], keys[1], sa[0] as string, Number(sa[1])];
+      if (!this.isExpired(lockKey) && this.store.has(lockKey)) return null;
+      const next = Number(this.store.get(fenceKey) ?? 0) + 1;
+      this.store.set(fenceKey, String(next));
+      this.store.set(lockKey, JSON.stringify({ leaseToken, fencingToken: next }));
+      this.expiry.set(lockKey, this.now + ttlMs);
+      return next;
+    }
+    if (isRelease) {
+      const expected = sa[0] as string;
+      if (this.isExpired(keys[0])) return 0;
+      const raw = this.store.get(keys[0]);
+      if (!raw) return 0;
+      const d = JSON.parse(raw) as { leaseToken: string };
+      if (d.leaseToken !== expected) return 0;
+      this.store.delete(keys[0]); this.expiry.delete(keys[0]);
+      return 1;
+    }
+    if (isRenew) {
+      const [expected, ttlMs] = [sa[0] as string, Number(sa[1])];
+      if (this.isExpired(keys[0])) return 0;
+      const raw = this.store.get(keys[0]);
+      if (!raw) return 0;
+      const d = JSON.parse(raw) as { leaseToken: string };
+      if (d.leaseToken !== expected) return 0;
+      this.expiry.set(keys[0], this.now + ttlMs);
+      this.store.set(keys[0], JSON.stringify(d));
+      return 1;
+    }
+    throw new Error(`Unexpected script`);
+  }
+}
+
+describe("RedisLockStore", () => {
+  let redis: FakeRedisClient;
+  let store: RedisLockStore;
+  let t: number;
+
+  beforeEach(() => {
+    t = 1_000_000;
+    redis = new FakeRedisClient();
+    redis.now = t;
+    store = new RedisLockStore({ client: redis });
+  });
+
+  const key = "autologin:lock:popular:evt-001";
+
+  describe("acquireSlot", () => {
+    it("uses atomic eval and returns fencing token", async () => {
+      expect(await store.acquireSlot({ key, leaseToken: "t1", ttlMs: 60_000, nowMs: t })).toBe(1);
+      expect(redis.evalCalls).toHaveLength(1);
+      expect(redis.evalCalls[0].keys).toEqual([key, `${key}:fence`]);
+    });
+
+    it("returns null when lock is held", async () => {
+      await store.acquireSlot({ key, leaseToken: "t1", ttlMs: 60_000, nowMs: t });
+      expect(await store.acquireSlot({ key, leaseToken: "t2", ttlMs: 60_000, nowMs: t })).toBeNull();
+    });
+
+    it("acquires after TTL expiry (Redis-native)", async () => {
+      expect(await store.acquireSlot({ key, leaseToken: "t1", ttlMs: 5000, nowMs: t })).toBe(1);
+      redis.now = t + 6000;
+      expect(await store.acquireSlot({ key, leaseToken: "t2", ttlMs: 5000, nowMs: t + 6000 })).toBe(2);
+    });
+
+    it("fencing tokens are independent per key", async () => {
+      const k2 = "autologin:lock:popular:evt-002";
+      const k3 = "autologin:lock:banreservas:evt-001";
+      expect(await store.acquireSlot({ key, leaseToken: "a", ttlMs: 60_000, nowMs: t })).toBe(1);
+      expect(await store.acquireSlot({ key: k2, leaseToken: "b", ttlMs: 60_000, nowMs: t })).toBe(1);
+      expect(await store.acquireSlot({ key: k3, leaseToken: "c", ttlMs: 60_000, nowMs: t })).toBe(1);
+    });
+
+    it("normalizes non-integer/non-positive returns to null; positive ints to fencing token", async () => {
+      const orig = redis.eval.bind(redis);
+      for (const badReturn of [false, true, 0, "0", 1.5, "1.5"]) {
+        let called = false;
+        redis.eval = async (script, numKeys, ...rest) => {
+          if (!called) { called = true; return badReturn; }
+          return orig(script, numKeys, ...rest);
+        };
+        expect(await store.acquireSlot({ key, leaseToken: "x", ttlMs: 30_000, nowMs: t })).toBeNull();
+        called = false;
+      }
+      redis.eval = async () => { return 42; };
+      expect(await store.acquireSlot({ key, leaseToken: "x", ttlMs: 30_000, nowMs: t })).toBe(42);
+      redis.eval = orig;
+    });
+  });
+
+  describe("releaseIfOwner", () => {
+    it("deletes lock when token matches and allows re-acquire", async () => {
+      await store.acquireSlot({ key, leaseToken: "t1", ttlMs: 60_000, nowMs: t });
+      expect(await store.releaseIfOwner(key, "t1")).toBe(true);
+      expect(await store.acquireSlot({ key, leaseToken: "t2", ttlMs: 60_000, nowMs: t })).toBe(2);
+    });
+
+    it("returns false for wrong token and lock stays held", async () => {
+      await store.acquireSlot({ key, leaseToken: "t1", ttlMs: 60_000, nowMs: t });
+      expect(await store.releaseIfOwner(key, "wrong")).toBe(false);
+      expect(await store.acquireSlot({ key, leaseToken: "t2", ttlMs: 60_000, nowMs: t })).toBeNull();
+    });
+
+    it("returns false when expired (Redis-native TTL)", async () => {
+      await store.acquireSlot({ key, leaseToken: "t1", ttlMs: 5000, nowMs: t });
+      redis.now = t + 6000;
+      expect(await store.releaseIfOwner(key, "t1")).toBe(false);
+    });
+
+    it("returns false for non-existent key", async () => {
+      expect(await store.releaseIfOwner("missing", "t1")).toBe(false);
+    });
+  });
+
+  describe("renewIfOwner", () => {
+    it("extends TTL when token matches", async () => {
+      await store.acquireSlot({ key, leaseToken: "t1", ttlMs: 5000, nowMs: t });
+      redis.now = t + 2000;
+      expect(await store.renewIfOwner({ key, expectedLeaseToken: "t1", newTtlMs: 10_000, nowMs: t + 2000 })).toBe(true);
+      redis.now = t + 6000;
+      expect(await store.acquireSlot({ key, leaseToken: "t2", ttlMs: 5000, nowMs: t + 6000 })).toBeNull();
+    });
+
+    it("returns false for wrong token or expired", async () => {
+      await store.acquireSlot({ key, leaseToken: "t1", ttlMs: 60_000, nowMs: t });
+      expect(await store.renewIfOwner({ key, expectedLeaseToken: "wrong", newTtlMs: 60_000, nowMs: t + 1 })).toBe(false);
+      const r2 = new FakeRedisClient(); r2.now = t;
+      const s2 = new RedisLockStore({ client: r2 });
+      await s2.acquireSlot({ key, leaseToken: "t1", ttlMs: 5000, nowMs: t });
+      r2.now = t + 6000;
+      expect(await s2.renewIfOwner({ key, expectedLeaseToken: "t1", newTtlMs: 60_000, nowMs: t + 6000 })).toBe(false);
+    });
+  });
+
+  describe("script invocation", () => {
+    it("acquire passes correct keys and args (no nowMs)", async () => {
+      await store.acquireSlot({ key, leaseToken: "t1", ttlMs: 30_000, nowMs: 1_000_000 });
+      expect(redis.evalCalls[0].args).toEqual(["t1", 30_000]);
+      expect(redis.evalCalls[0].keys).toEqual([key, `${key}:fence`]);
+    });
+
+    it("release and renew pass correct keys (no nowMs)", async () => {
+      await store.acquireSlot({ key, leaseToken: "t1", ttlMs: 30_000, nowMs: t });
+      await store.releaseIfOwner(key, "t1");
+      expect(redis.evalCalls[1].keys).toEqual([key]);
+      expect(redis.evalCalls[1].args).toEqual(["t1"]);
+      await store.acquireSlot({ key, leaseToken: "t2", ttlMs: 30_000, nowMs: t });
+      await store.renewIfOwner({ key, expectedLeaseToken: "t2", newTtlMs: 60_000, nowMs: t + 1 });
+      expect(redis.evalCalls[3].keys).toEqual([key]);
+      expect(redis.evalCalls[3].args).toEqual(["t2", 60_000]);
+    });
+  });
+
+  describe("error handling", () => {
+    it("propagates Redis errors", async () => {
+      redis.nextEvalError = new Error("ECONNREFUSED");
+      await expect(store.acquireSlot({ key, leaseToken: "t", ttlMs: 30_000, nowMs: t })).rejects.toThrow("ECONNREFUSED");
+      await store.acquireSlot({ key, leaseToken: "t", ttlMs: 30_000, nowMs: t });
+      redis.nextEvalError = new Error("READONLY");
+      await expect(store.releaseIfOwner(key, "t")).rejects.toThrow("READONLY");
+      redis.nextEvalError = new Error("ETIMEDOUT");
+      await expect(store.renewIfOwner({ key, expectedLeaseToken: "t", newTtlMs: 60_000, nowMs: t + 1 })).rejects.toThrow("ETIMEDOUT");
+    });
+  });
+
+  describe("structural interface", () => {
+    it("accepts bare eval-only client", () => {
+      const s = new RedisLockStore({ eval: vi.fn().mockResolvedValue(null) } as RedisEvalClient);
+      expect(s).toBeInstanceOf(RedisLockStore);
+    });
+
+    it("handles string numeric responses (Redis RESP2)", async () => {
+      const orig = redis.eval.bind(redis);
+      let n = 0;
+      redis.eval = async (script, numKeys, ...rest) => { n++; const r = await orig(script, numKeys, ...rest); return n === 1 && typeof r === "number" ? String(r) : r; };
+      expect(await store.acquireSlot({ key, leaseToken: "t", ttlMs: 30_000, nowMs: t })).toBe(1);
+    });
+
+    it("handles numeric/string Redis returns for release and renew", async () => {
+      await store.acquireSlot({ key, leaseToken: "t1", ttlMs: 60_000, nowMs: t });
+      const orig = redis.eval.bind(redis);
+      redis.eval = async (s, n, ...r) => { const v = await orig(s, n, ...r); return typeof v === "number" ? String(v) : v; };
+      expect(await store.releaseIfOwner(key, "t1")).toBe(true);
+      await store.acquireSlot({ key, leaseToken: "t2", ttlMs: 60_000, nowMs: t });
+      expect(await store.renewIfOwner({ key, expectedLeaseToken: "t2", newTtlMs: 60_000, nowMs: t })).toBe(true);
+    });
+  });
+});

--- a/src/modules/bank-auto-login-lock/redis-store.ts
+++ b/src/modules/bank-auto-login-lock/redis-store.ts
@@ -68,12 +68,11 @@ return nextFencing
 
 /**
  * releaseIfOwner: atomically delete the lock key only when the stored lease
- * token matches and the lease has not expired. Returns 1 on success, 0 if
- * token mismatches or the key has expired / does not exist.
+ * token matches. Redis native TTL/key existence is the expiry authority.
+ * Returns 1 on success, 0 if token mismatches or the key no longer exists.
  *
  * KEYS[1] = lock key
  * ARGV[1] = expected lease token
- * ARGV[2] = current timestamp in milliseconds
  */
 const RELEASE_SCRIPT = `
 local lockKey = KEYS[1]
@@ -92,13 +91,12 @@ return 1
 
 /**
  * renewIfOwner: atomically extend the TTL of the lock key only when the stored
- * lease token matches and the lease has not expired. Returns 1 on success,
- * 0 if token mismatches or the lease has already expired.
+ * lease token matches. Redis native TTL/key existence is the expiry authority.
+ * Returns 1 on success, 0 if token mismatches or the key no longer exists.
  *
  * KEYS[1] = lock key
  * ARGV[1] = expected lease token
  * ARGV[2] = new TTL in milliseconds
- * ARGV[3] = current timestamp in milliseconds
  */
 const RENEW_SCRIPT = `
 local lockKey = KEYS[1]

--- a/src/modules/bank-auto-login-lock/redis-store.ts
+++ b/src/modules/bank-auto-login-lock/redis-store.ts
@@ -1,0 +1,184 @@
+/**
+ * Redis-backed LockStore adapter for AutoLoginLock.
+ *
+ * Uses atomic Lua scripts via Redis `EVAL` for compare-and-set semantics.
+ * A structural `RedisEvalClient` interface decouples from any specific Redis
+ * driver — callers inject their own connection.
+ */
+
+import type {
+  AcquireSlotParams,
+  LockStore,
+  RenewIfOwnerParams,
+} from "./index";
+
+// ---------------------------------------------------------------------------
+// Structural Redis client — only EVAL is needed (no ioredis import)
+// ---------------------------------------------------------------------------
+
+/** Minimal eval-only interface matching ioredis / Redis client eval signature. */
+export interface RedisEvalClient {
+  eval(
+    script: string,
+    numKeys: number,
+    ...args: (string | number)[]
+  ): Promise<unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Lua scripts — atomic CAS operations
+// ---------------------------------------------------------------------------
+
+/**
+ * acquireSlot: atomically check-and-set a lock key.
+ *
+ * Returns the new fencing token (number) on success, or nil (null) if the key
+ * is already held and not expired. The fencing counter is incremented
+ * monotonically per lock key, ensuring stale leases cannot overwrite newer
+ * state writes via CAS.
+ *
+ * KEYS[1] = lock key
+ * KEYS[2] = fencing counter key
+ * ARGV[1] = lease token
+ * ARGV[2] = TTL in milliseconds
+ */
+const ACQUIRE_SCRIPT = `
+local lockKey = KEYS[1]
+local fenceKey = KEYS[2]
+local leaseToken = ARGV[1]
+local ttlMs = tonumber(ARGV[2])
+
+-- If the key exists, the lock is still active (Redis TTL is authoritative).
+if redis.call('EXISTS', lockKey) == 1 then
+  return nil
+end
+
+-- Increment fencing counter (monotonic, never reset).
+local nextFencing = redis.call('INCR', fenceKey)
+
+-- Store the lock entry with native Redis TTL expiry.
+local payload = cjson.encode({
+  leaseToken = leaseToken,
+  fencingToken = nextFencing,
+})
+redis.call('SET', lockKey, payload, 'PX', ttlMs)
+
+return nextFencing
+`;
+
+/**
+ * releaseIfOwner: atomically delete the lock key only when the stored lease
+ * token matches and the lease has not expired. Returns 1 on success, 0 if
+ * token mismatches or the key has expired / does not exist.
+ *
+ * KEYS[1] = lock key
+ * ARGV[1] = expected lease token
+ * ARGV[2] = current timestamp in milliseconds
+ */
+const RELEASE_SCRIPT = `
+local lockKey = KEYS[1]
+local expectedToken = ARGV[1]
+
+-- Redis TTL is authoritative: if the key exists, the lock is still active.
+local raw = redis.call('GET', lockKey)
+if not raw then return 0 end
+
+local decoded = cjson.decode(raw)
+if decoded.leaseToken ~= expectedToken then return 0 end
+
+redis.call('DEL', lockKey)
+return 1
+`;
+
+/**
+ * renewIfOwner: atomically extend the TTL of the lock key only when the stored
+ * lease token matches and the lease has not expired. Returns 1 on success,
+ * 0 if token mismatches or the lease has already expired.
+ *
+ * KEYS[1] = lock key
+ * ARGV[1] = expected lease token
+ * ARGV[2] = new TTL in milliseconds
+ * ARGV[3] = current timestamp in milliseconds
+ */
+const RENEW_SCRIPT = `
+local lockKey = KEYS[1]
+local expectedToken = ARGV[1]
+local newTtlMs = tonumber(ARGV[2])
+
+-- Redis TTL is authoritative: if the key exists, the lock is still active.
+local raw = redis.call('GET', lockKey)
+if not raw then return 0 end
+
+local decoded = cjson.decode(raw)
+if decoded.leaseToken ~= expectedToken then return 0 end
+
+-- Refresh the TTL (Redis handles expiry natively).
+redis.call('SET', lockKey, cjson.encode(decoded), 'PX', newTtlMs)
+return 1
+`;
+
+// ---------------------------------------------------------------------------
+// RedisLockStore
+// ---------------------------------------------------------------------------
+
+export interface RedisLockStoreOptions {
+  client: RedisEvalClient;
+}
+
+export class RedisLockStore implements LockStore {
+  private readonly client: RedisEvalClient;
+
+  constructor(options: RedisLockStoreOptions | RedisEvalClient) {
+    // Backward-compatible: accept a bare client or a full options object.
+    if ("eval" in options && typeof options.eval === "function") {
+      this.client = options;
+    } else {
+      const opts = options as RedisLockStoreOptions;
+      this.client = opts.client;
+    }
+  }
+
+  async acquireSlot(params: AcquireSlotParams): Promise<number | null> {
+    const { key, leaseToken, ttlMs } = params;
+    const fenceKey = `${key}:fence`;
+
+    const result = await this.client.eval(
+      ACQUIRE_SCRIPT,
+      2,         // number of KEYS
+      key,       // KEYS[1]
+      fenceKey,  // KEYS[2]
+      leaseToken,
+      ttlMs,
+    );
+
+    // ioredis returns null for nil, a number for RESP3, or a string "1" for RESP2.
+    // Acquire failure (nil) must normalize to null; fencing tokens are positive integers only.
+    if (result === null || result === undefined) return null;
+    const n = typeof result === "number" ? result : typeof result === "string" ? Number(result) : NaN;
+    return Number.isInteger(n) && n > 0 ? n : null;
+  }
+
+  async releaseIfOwner(key: string, expectedLeaseToken: string): Promise<boolean> {
+    const result = await this.client.eval(
+      RELEASE_SCRIPT,
+      1, // KEYS
+      key,
+      expectedLeaseToken,
+    );
+    // Lua returns 1/0; ioredis returns number or string.
+    return result === true || result === 1 || result === "1";
+  }
+
+  async renewIfOwner(params: RenewIfOwnerParams): Promise<boolean> {
+    const { key, expectedLeaseToken, newTtlMs } = params;
+
+    const result = await this.client.eval(
+      RENEW_SCRIPT,
+      1, // KEYS
+      key,
+      expectedLeaseToken,
+      newTtlMs,
+    );
+    return result === true || result === 1 || result === "1";
+  }
+}


### PR DESCRIPTION
## Summary
- Adds the PR4A2 Redis-backed `LockStore` adapter for the already-merged AutoLoginLock foundation.
- Uses atomic Lua `EVAL` scripts for acquire/release/renew CAS behavior, with Redis native TTL as the source of truth.
- Keeps this slice isolated: no production wiring, no Redis connection creation, no browser/CDP, no credential submission.

## Changes
| File | Change |
|------|--------|
| `src/modules/bank-auto-login-lock/redis-store.ts` | Adds `RedisLockStore`, structural `RedisEvalClient`, Lua scripts, response normalization, and fencing counter key handling. |
| `src/modules/bank-auto-login-lock/redis-store.test.ts` | Adds fake-Redis behavior tests for acquire contention, owner-only release/renew, fencing tokens, TTL semantics, return normalization, and no connection creation. |
| `openspec/changes/multi-bank-auto-login/tasks.md` | Marks 4.1b Redis-backed adapter complete; leaves 4.1c production wiring pending. |

## Test Plan
- [x] `pnpm test -- src/modules/bank-auto-login-lock/redis-store.test.ts`
- [x] `pnpm test -- src/modules/bank-auto-login-lock`
- [x] `pnpm test`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `git diff --check`

## Review Notes
- Changed lines: 397 insertions, 1 deletion across 3 files — 398 changed lines.
- Fresh 4R review found blockers around client-clock expiry and unsafe acquire return normalization.
- Fixes completed: Redis native TTL/key existence is authoritative; acquire succeeds only for positive integer fencing tokens; release/renew handle Redis numeric/string returns.
- Final 4R review after the comment-only Lua contract cleanup approved the PR.
- No production wiring in this PR. `4.1c` remains pending.
- This is PR4 high-risk work. Do not merge without Judgment Day approval.
- This repository currently has no GitHub issues or `type:*` labels, so this PR follows the existing RD-Sync PR practice.