### PR TITLE
feat(bank-auto-login-config): add config repository (PR4.3c)

### DIFF
--- a/openspec/changes/multi-bank-auto-login/tasks.md
+++ b/openspec/changes/multi-bank-auto-login/tasks.md
@@ -93,7 +93,7 @@ Gate: full gates + FRESH 4R review + Judgment Day before merge; PR3B1 <=400 line
 - [x] 4.1b Redis-backed `LockStore` adapter: atomic Lua scripts for `acquireSlot`/`releaseIfOwner`/`renewIfOwner` with TTL-bound CAS, fencing-token increment, and expired-key semantics matching Redis native expiry.
 - [x] 4.1c Wire `LockStore` Redis adapter into production `createAutoLoginLock` calls via DI/config.
 - [x] 4.2 `prisma/schema.prisma`: add `BankAutoLoginConfig` (`autoLoginEnabled` default false; breaker `closed|open` only, NO half_open) + `BankAdapterConfig` (`scrapingEnabled` default true); migration.
-- [ ] 4.3 Create `src/modules/bank-auto-login-config/` + `src/modules/bank-adapter-config/`: repos + conservative breaker policy (3 failures/30min->open, NO half-open, manual admin reset only clears window, alert on open + <=every 30min).
+- [x] 4.3 Create `src/modules/bank-auto-login-config/` + `src/modules/bank-adapter-config/`: repos + conservative breaker policy (3 failures/30min->open, NO half-open, manual admin reset only clears window, alert on open + <=every 30min).
 - [ ] 4.4 Create `src/worker/scraper/auto-login.ts`: `BankAutoLoginStrategy` state machine + `LoginMutationGuard` (HTTPS + exact origin + login-path allowlist, re-check before fill AND submit, `assertCompatiblePreSubmit`).
 - [ ] 4.5 Wire scrape-time canonical trigger: expired->assert `adapter.bankCode===credential.bankCode`->`assertCdpLoopback`->acquire lock (or skip->manual)->ensureBrowser (or throttled)->login->detect(dashboard|mfa|unknown|redirect|incompatible)->success|needs_admin_action->owner release.
 - [ ] 4.6 Modify `src/modules/bank-sessions/index.ts`: `expired` assigns/retains `expiredEventId` (UUID until restore), records/alerts/schedules only (NO credential submission).

--- a/src/modules/bank-auto-login-config/repository.test.ts
+++ b/src/modules/bank-auto-login-config/repository.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it, vi } from "vitest";
+import { BankAutoLoginConfigRepository } from "./repository";
+import type { PrismaClient } from "../../generated/prisma/client";
+
+/** Mirrors the raw Prisma row shape (breakerState is a plain `string` column). */
+interface RawRow {
+  bankCode: string;
+  autoLoginEnabled: boolean;
+  breakerState: string;
+  breakerFailureCount: number;
+  breakerFailureWindowStart: Date | null;
+  breakerOpenedAt: Date | null;
+  breakerLastResetAt: Date | null;
+  updatedAt: Date;
+  updatedBy: string | null;
+}
+
+function defaultRow(overrides: Partial<RawRow> = {}): RawRow {
+  return {
+    bankCode: "popular",
+    autoLoginEnabled: false,
+    breakerState: "closed",
+    breakerFailureCount: 0,
+    breakerFailureWindowStart: null,
+    breakerOpenedAt: null,
+    breakerLastResetAt: null,
+    updatedAt: new Date("2026-07-02T00:00:00.000Z"),
+    updatedBy: null,
+    ...overrides,
+  };
+}
+
+function makePrisma(overrides: { findUnique?: unknown; upsert?: unknown; update?: unknown } = {}) {
+  const bankAutoLoginConfig = {
+    findUnique: vi.fn().mockResolvedValue(overrides.findUnique ?? null),
+    upsert: vi.fn().mockResolvedValue(overrides.upsert ?? defaultRow()),
+    update: vi.fn().mockResolvedValue(overrides.update ?? defaultRow()),
+  };
+  return { prisma: { bankAutoLoginConfig } as unknown as PrismaClient, bankAutoLoginConfig };
+}
+
+describe("BankAutoLoginConfigRepository.getByBankCode", () => {
+  it("returns null for an unknown bankCode (fail closed, no fallback)", async () => {
+    const { prisma } = makePrisma({ findUnique: null });
+    const repo = new BankAutoLoginConfigRepository(prisma);
+    await expect(repo.getByBankCode("unknown")).resolves.toBeNull();
+  });
+
+  it("maps a known row", async () => {
+    const { prisma } = makePrisma({ findUnique: defaultRow({ autoLoginEnabled: true }) });
+    const repo = new BankAutoLoginConfigRepository(prisma);
+    const record = await repo.getByBankCode("popular");
+    expect(record).toMatchObject({ bankCode: "popular", autoLoginEnabled: true, breakerState: "closed" });
+  });
+
+  it("rejects a persisted breaker state outside the closed|open union", async () => {
+    const { prisma } = makePrisma({ findUnique: defaultRow({ breakerState: "half_open" }) });
+    const repo = new BankAutoLoginConfigRepository(prisma);
+    await expect(repo.getByBankCode("popular")).rejects.toThrow(/Invalid breaker state/);
+  });
+});
+
+describe("BankAutoLoginConfigRepository.upsertDefaults", () => {
+  it("auto-provisions the default row for a known bank", async () => {
+    const { prisma, bankAutoLoginConfig } = makePrisma();
+    const repo = new BankAutoLoginConfigRepository(prisma);
+    const record = await repo.upsertDefaults("popular");
+    expect(record).toMatchObject({ bankCode: "popular", autoLoginEnabled: false, breakerState: "closed" });
+    expect(bankAutoLoginConfig.upsert).toHaveBeenCalledOnce();
+  });
+
+  it("fails closed (returns null, no auto-provisioned Bank row) when the parent Bank does not exist", async () => {
+    const { prisma, bankAutoLoginConfig } = makePrisma();
+    bankAutoLoginConfig.upsert.mockRejectedValue({ code: "P2003" });
+    const repo = new BankAutoLoginConfigRepository(prisma);
+    await expect(repo.upsertDefaults("unknown")).resolves.toBeNull();
+  });
+});
+
+describe("BankAutoLoginConfigRepository.recordFailure", () => {
+  it("is a no-op for an unknown bankCode", async () => {
+    const { prisma, bankAutoLoginConfig } = makePrisma({ findUnique: null });
+    const repo = new BankAutoLoginConfigRepository(prisma);
+    await expect(repo.recordFailure("unknown", new Date())).resolves.toBeNull();
+    expect(bankAutoLoginConfig.update).not.toHaveBeenCalled();
+  });
+
+  it("increments the failure count and persists the window on the first failure", async () => {
+    const now = new Date("2026-07-02T12:00:00.000Z");
+    const { prisma, bankAutoLoginConfig } = makePrisma({
+      findUnique: defaultRow(),
+      update: defaultRow({ breakerFailureCount: 1, breakerFailureWindowStart: now }),
+    });
+    const repo = new BankAutoLoginConfigRepository(prisma);
+    const record = await repo.recordFailure("popular", now);
+    expect(record).toMatchObject({ breakerFailureCount: 1, breakerState: "closed" });
+    const updateArgs = bankAutoLoginConfig.update.mock.calls[0][0];
+    expect(updateArgs.data.breakerOpenedAt).toBeUndefined(); // untouched — did not just open
+  });
+
+  it("opens the breaker on the 3rd failure inside the window and stamps breakerOpenedAt", async () => {
+    const t0 = new Date("2026-07-02T12:00:00.000Z");
+    const t2 = new Date("2026-07-02T12:10:00.000Z");
+    const { prisma, bankAutoLoginConfig } = makePrisma({
+      findUnique: defaultRow({ breakerFailureCount: 2, breakerFailureWindowStart: t0 }),
+      update: defaultRow({ breakerState: "open", breakerFailureCount: 3, breakerFailureWindowStart: t0, breakerOpenedAt: t2 }),
+    });
+    const repo = new BankAutoLoginConfigRepository(prisma);
+    const record = await repo.recordFailure("popular", t2);
+    expect(record?.breakerState).toBe("open");
+    const updateArgs = bankAutoLoginConfig.update.mock.calls[0][0];
+    expect(updateArgs.data.breakerOpenedAt).toEqual(t2);
+  });
+});
+
+describe("BankAutoLoginConfigRepository.openBreaker", () => {
+  it("is a no-op for an unknown bankCode", async () => {
+    const { prisma, bankAutoLoginConfig } = makePrisma({ findUnique: null });
+    const repo = new BankAutoLoginConfigRepository(prisma);
+    await expect(repo.openBreaker("unknown", new Date())).resolves.toBeNull();
+    expect(bankAutoLoginConfig.update).not.toHaveBeenCalled();
+  });
+
+  it("is idempotent when already open — does not re-write", async () => {
+    const { prisma, bankAutoLoginConfig } = makePrisma({ findUnique: defaultRow({ breakerState: "open" }) });
+    const repo = new BankAutoLoginConfigRepository(prisma);
+    const record = await repo.openBreaker("popular", new Date());
+    expect(record?.breakerState).toBe("open");
+    expect(bankAutoLoginConfig.update).not.toHaveBeenCalled();
+  });
+
+  it("force-opens a closed breaker", async () => {
+    const now = new Date("2026-07-02T12:00:00.000Z");
+    const { prisma, bankAutoLoginConfig } = makePrisma({
+      findUnique: defaultRow(),
+      update: defaultRow({ breakerState: "open", breakerOpenedAt: now }),
+    });
+    const repo = new BankAutoLoginConfigRepository(prisma);
+    const record = await repo.openBreaker("popular", now);
+    expect(record?.breakerState).toBe("open");
+    expect(bankAutoLoginConfig.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { breakerState: "open", breakerOpenedAt: now } }),
+    );
+  });
+});
+
+describe("BankAutoLoginConfigRepository.resetBreaker", () => {
+  it("requires a non-empty updatedBy actor id", async () => {
+    const { prisma } = makePrisma();
+    const repo = new BankAutoLoginConfigRepository(prisma);
+    await expect(repo.resetBreaker("popular", "")).rejects.toThrow(/updatedBy/);
+  });
+
+  it("is a no-op for an unknown bankCode", async () => {
+    const { prisma, bankAutoLoginConfig } = makePrisma({ findUnique: null });
+    const repo = new BankAutoLoginConfigRepository(prisma);
+    await expect(repo.resetBreaker("unknown", "admin-1")).resolves.toBeNull();
+    expect(bankAutoLoginConfig.update).not.toHaveBeenCalled();
+  });
+
+  it("clears state, count, and window and stamps breakerLastResetAt + updatedBy — the ONLY open->closed path", async () => {
+    const now = new Date("2026-07-02T13:00:00.000Z");
+    const { prisma, bankAutoLoginConfig } = makePrisma({
+      findUnique: defaultRow({ bankCode: "popular" }),
+      update: defaultRow({ breakerState: "closed", breakerLastResetAt: now, updatedBy: "admin-1" }),
+    });
+    const repo = new BankAutoLoginConfigRepository(prisma);
+    const record = await repo.resetBreaker("popular", "admin-1", now);
+    expect(record).toMatchObject({ breakerState: "closed", updatedBy: "admin-1" });
+    expect(bankAutoLoginConfig.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: {
+          breakerState: "closed",
+          breakerFailureCount: 0,
+          breakerFailureWindowStart: null,
+          breakerLastResetAt: now,
+          updatedBy: "admin-1",
+        },
+      }),
+    );
+  });
+});
+
+describe("BankAutoLoginConfigRepository.setAutoLoginEnabled", () => {
+  it("is a no-op for an unknown bankCode", async () => {
+    const { prisma, bankAutoLoginConfig } = makePrisma({ findUnique: null });
+    const repo = new BankAutoLoginConfigRepository(prisma);
+    await expect(repo.setAutoLoginEnabled("unknown", true, "admin-1")).resolves.toBeNull();
+    expect(bankAutoLoginConfig.update).not.toHaveBeenCalled();
+  });
+
+  it("flips the flag and stamps updatedBy", async () => {
+    const { prisma, bankAutoLoginConfig } = makePrisma({
+      findUnique: defaultRow(),
+      update: defaultRow({ autoLoginEnabled: true, updatedBy: "admin-1" }),
+    });
+    const repo = new BankAutoLoginConfigRepository(prisma);
+    const record = await repo.setAutoLoginEnabled("popular", true, "admin-1");
+    expect(record).toMatchObject({ autoLoginEnabled: true, updatedBy: "admin-1" });
+    expect(bankAutoLoginConfig.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { autoLoginEnabled: true, updatedBy: "admin-1" } }),
+    );
+  });
+});

--- a/src/modules/bank-auto-login-config/repository.test.ts
+++ b/src/modules/bank-auto-login-config/repository.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it, vi } from "vitest";
 import { BankAutoLoginConfigRepository } from "./repository";
 import type { PrismaClient } from "../../generated/prisma/client";
 
-/** Mirrors the raw Prisma row shape (breakerState is a plain `string` column). */
 interface RawRow {
   bankCode: string;
   autoLoginEnabled: boolean;
@@ -15,7 +14,22 @@ interface RawRow {
   updatedBy: string | null;
 }
 
-function defaultRow(overrides: Partial<RawRow> = {}): RawRow {
+const RECORD_SELECT = {
+  bankCode: true,
+  autoLoginEnabled: true,
+  breakerState: true,
+  breakerFailureCount: true,
+  breakerFailureWindowStart: true,
+  breakerOpenedAt: true,
+  breakerLastResetAt: true,
+  updatedAt: true,
+  updatedBy: true,
+} as const;
+const BANK_CODE_SELECT = { bankCode: true } as const;
+const SERIALIZABLE_OPTIONS = { isolationLevel: "Serializable" };
+const NOW = new Date("2026-07-02T12:00:00.000Z");
+
+function row(overrides: Partial<RawRow> = {}): RawRow {
   return {
     bankCode: "popular",
     autoLoginEnabled: false,
@@ -33,172 +47,196 @@ function defaultRow(overrides: Partial<RawRow> = {}): RawRow {
 function makePrisma(overrides: { findUnique?: unknown; upsert?: unknown; update?: unknown } = {}) {
   const bankAutoLoginConfig = {
     findUnique: vi.fn().mockResolvedValue(overrides.findUnique ?? null),
-    upsert: vi.fn().mockResolvedValue(overrides.upsert ?? defaultRow()),
-    update: vi.fn().mockResolvedValue(overrides.update ?? defaultRow()),
+    upsert: vi.fn().mockResolvedValue(overrides.upsert ?? row()),
+    update: vi.fn().mockResolvedValue(overrides.update ?? row()),
   };
-  return { prisma: { bankAutoLoginConfig } as unknown as PrismaClient, bankAutoLoginConfig };
+  const prisma = {
+    bankAutoLoginConfig,
+    $transaction: vi.fn(async (operation: (tx: { bankAutoLoginConfig: typeof bankAutoLoginConfig }) => unknown) =>
+      operation({ bankAutoLoginConfig }),
+    ),
+  };
+  return { prisma: prisma as unknown as PrismaClient, bankAutoLoginConfig, transaction: prisma.$transaction };
 }
 
-describe("BankAutoLoginConfigRepository.getByBankCode", () => {
-  it("returns null for an unknown bankCode (fail closed, no fallback)", async () => {
-    const { prisma } = makePrisma({ findUnique: null });
-    const repo = new BankAutoLoginConfigRepository(prisma);
-    await expect(repo.getByBankCode("unknown")).resolves.toBeNull();
-  });
+function expectFindUnique(mock: ReturnType<typeof vi.fn>, bankCode: string, select: unknown = RECORD_SELECT) {
+  expect(mock).toHaveBeenCalledWith({ where: { bankCode }, select });
+}
 
-  it("maps a known row", async () => {
-    const { prisma } = makePrisma({ findUnique: defaultRow({ autoLoginEnabled: true }) });
-    const repo = new BankAutoLoginConfigRepository(prisma);
-    const record = await repo.getByBankCode("popular");
-    expect(record).toMatchObject({ bankCode: "popular", autoLoginEnabled: true, breakerState: "closed" });
-  });
+function expectUpdate(mock: ReturnType<typeof vi.fn>, bankCode: string, data: unknown) {
+  expect(mock).toHaveBeenCalledWith({ where: { bankCode }, data, select: RECORD_SELECT });
+}
 
-  it("rejects a persisted breaker state outside the closed|open union", async () => {
-    const { prisma } = makePrisma({ findUnique: defaultRow({ breakerState: "half_open" }) });
-    const repo = new BankAutoLoginConfigRepository(prisma);
-    await expect(repo.getByBankCode("popular")).rejects.toThrow(/Invalid breaker state/);
-  });
-});
-
-describe("BankAutoLoginConfigRepository.upsertDefaults", () => {
-  it("auto-provisions the default row for a known bank", async () => {
-    const { prisma, bankAutoLoginConfig } = makePrisma();
-    const repo = new BankAutoLoginConfigRepository(prisma);
-    const record = await repo.upsertDefaults("popular");
-    expect(record).toMatchObject({ bankCode: "popular", autoLoginEnabled: false, breakerState: "closed" });
-    expect(bankAutoLoginConfig.upsert).toHaveBeenCalledOnce();
-  });
-
-  it("fails closed (returns null, no auto-provisioned Bank row) when the parent Bank does not exist", async () => {
-    const { prisma, bankAutoLoginConfig } = makePrisma();
-    bankAutoLoginConfig.upsert.mockRejectedValue({ code: "P2003" });
-    const repo = new BankAutoLoginConfigRepository(prisma);
-    await expect(repo.upsertDefaults("unknown")).resolves.toBeNull();
-  });
-});
-
-describe("BankAutoLoginConfigRepository.recordFailure", () => {
-  it("is a no-op for an unknown bankCode", async () => {
-    const { prisma, bankAutoLoginConfig } = makePrisma({ findUnique: null });
-    const repo = new BankAutoLoginConfigRepository(prisma);
-    await expect(repo.recordFailure("unknown", new Date())).resolves.toBeNull();
-    expect(bankAutoLoginConfig.update).not.toHaveBeenCalled();
-  });
-
-  it("increments the failure count and persists the window on the first failure", async () => {
-    const now = new Date("2026-07-02T12:00:00.000Z");
-    const { prisma, bankAutoLoginConfig } = makePrisma({
-      findUnique: defaultRow(),
-      update: defaultRow({ breakerFailureCount: 1, breakerFailureWindowStart: now }),
+describe("BankAutoLoginConfigRepository", () => {
+  describe("getByBankCode", () => {
+    it("returns null for an unknown bankCode with exact isolation", async () => {
+      const { repo, bankAutoLoginConfig } = makeRepo({ findUnique: null });
+      await expect(repo.getByBankCode("unknown")).resolves.toBeNull();
+      expectFindUnique(bankAutoLoginConfig.findUnique, "unknown");
     });
-    const repo = new BankAutoLoginConfigRepository(prisma);
-    const record = await repo.recordFailure("popular", now);
-    expect(record).toMatchObject({ breakerFailureCount: 1, breakerState: "closed" });
-    const updateArgs = bankAutoLoginConfig.update.mock.calls[0][0];
-    expect(updateArgs.data.breakerOpenedAt).toBeUndefined(); // untouched — did not just open
+
+    it("maps known rows and rejects invalid persisted breaker states", async () => {
+      await expect(makeRepo({ findUnique: row({ autoLoginEnabled: true }) }).repo.getByBankCode("popular")).resolves.toMatchObject({
+        bankCode: "popular",
+        autoLoginEnabled: true,
+        breakerState: "closed",
+      });
+      await expect(makeRepo({ findUnique: row({ breakerState: "half_open" }) }).repo.getByBankCode("popular")).rejects.toThrow(
+        /Invalid breaker state/,
+      );
+    });
   });
 
-  it("opens the breaker on the 3rd failure inside the window and stamps breakerOpenedAt", async () => {
-    const t0 = new Date("2026-07-02T12:00:00.000Z");
-    const t2 = new Date("2026-07-02T12:10:00.000Z");
-    const { prisma, bankAutoLoginConfig } = makePrisma({
-      findUnique: defaultRow({ breakerFailureCount: 2, breakerFailureWindowStart: t0 }),
-      update: defaultRow({ breakerState: "open", breakerFailureCount: 3, breakerFailureWindowStart: t0, breakerOpenedAt: t2 }),
+  describe("upsertDefaults", () => {
+    it("auto-provisions only the requested bankCode", async () => {
+      const bankCode = "banreservas";
+      const { repo, bankAutoLoginConfig } = makeRepo({ upsert: row({ bankCode }) });
+
+      await expect(repo.upsertDefaults(bankCode)).resolves.toMatchObject({ bankCode, autoLoginEnabled: false, breakerState: "closed" });
+      expect(bankAutoLoginConfig.upsert).toHaveBeenCalledWith({ where: { bankCode }, update: {}, create: { bankCode }, select: RECORD_SELECT });
     });
-    const repo = new BankAutoLoginConfigRepository(prisma);
-    const record = await repo.recordFailure("popular", t2);
-    expect(record?.breakerState).toBe("open");
-    const updateArgs = bankAutoLoginConfig.update.mock.calls[0][0];
-    expect(updateArgs.data.breakerOpenedAt).toEqual(t2);
+
+    it("fails closed when the parent Bank does not exist", async () => {
+      const { repo, bankAutoLoginConfig } = makeRepo();
+      bankAutoLoginConfig.upsert.mockRejectedValue({ code: "P2003" });
+
+      await expect(repo.upsertDefaults("unknown")).resolves.toBeNull();
+      expect(bankAutoLoginConfig.upsert).toHaveBeenCalledWith({
+        where: { bankCode: "unknown" },
+        update: {},
+        create: { bankCode: "unknown" },
+        select: RECORD_SELECT,
+      });
+    });
+  });
+
+  describe("recordFailure", () => {
+    it("is a serializable no-op for an unknown bankCode", async () => {
+      const { repo, bankAutoLoginConfig, transaction } = makeRepo({ findUnique: null });
+
+      await expect(repo.recordFailure("unknown", NOW)).resolves.toBeNull();
+
+      expect(transaction).toHaveBeenCalledWith(expect.any(Function), SERIALIZABLE_OPTIONS);
+      expectFindUnique(bankAutoLoginConfig.findUnique, "unknown");
+      expect(bankAutoLoginConfig.update).not.toHaveBeenCalled();
+    });
+
+    it("persists the full closed-state transition on the first failure", async () => {
+      const bankCode = "bhd";
+      const { repo, bankAutoLoginConfig, transaction } = makeRepo({
+        findUnique: row({ bankCode }),
+        update: row({ bankCode, breakerFailureCount: 1, breakerFailureWindowStart: NOW }),
+      });
+
+      await expect(repo.recordFailure(bankCode, NOW)).resolves.toMatchObject({ bankCode, breakerFailureCount: 1, breakerState: "closed" });
+
+      expect(transaction).toHaveBeenCalledWith(expect.any(Function), SERIALIZABLE_OPTIONS);
+      expectUpdate(bankAutoLoginConfig.update, bankCode, failureData("closed", 1, NOW, null));
+    });
+
+    it("opens the breaker on the 3rd failure inside the window", async () => {
+      const t0 = new Date("2026-07-02T12:00:00.000Z");
+      const openedAt = new Date("2026-07-02T12:10:00.000Z");
+      const { repo, bankAutoLoginConfig } = makeRepo({
+        findUnique: row({ breakerFailureCount: 2, breakerFailureWindowStart: t0 }),
+        update: row({ breakerState: "open", breakerFailureCount: 3, breakerFailureWindowStart: t0, breakerOpenedAt: openedAt }),
+      });
+
+      await expect(repo.recordFailure("popular", openedAt)).resolves.toMatchObject({ breakerState: "open", breakerFailureCount: 3 });
+      expectUpdate(bankAutoLoginConfig.update, "popular", failureData("open", 3, t0, openedAt));
+    });
+
+    it("does not update an already-open breaker", async () => {
+      const openedAt = new Date("2026-07-02T11:00:00.000Z");
+      const { repo, bankAutoLoginConfig } = makeRepo({ findUnique: row({ breakerState: "open", breakerFailureCount: 3, breakerOpenedAt: openedAt }) });
+
+      await expect(repo.recordFailure("popular", NOW)).resolves.toMatchObject({ breakerState: "open", breakerFailureCount: 3, breakerOpenedAt: openedAt });
+      expect(bankAutoLoginConfig.update).not.toHaveBeenCalled();
+    });
+
+    it("retries serializable write conflicts and recomputes from the latest row", async () => {
+      const t0 = new Date("2026-07-02T12:00:00.000Z");
+      const openedAt = new Date("2026-07-02T12:10:00.000Z");
+      const { repo, bankAutoLoginConfig, transaction } = makeRepo();
+      bankAutoLoginConfig.findUnique
+        .mockResolvedValueOnce(row({ breakerFailureCount: 1, breakerFailureWindowStart: t0 }))
+        .mockResolvedValueOnce(row({ breakerFailureCount: 2, breakerFailureWindowStart: t0 }));
+      bankAutoLoginConfig.update
+        .mockResolvedValueOnce(row({ breakerFailureCount: 2, breakerFailureWindowStart: t0 }))
+        .mockResolvedValueOnce(row({ breakerState: "open", breakerFailureCount: 3, breakerFailureWindowStart: t0, breakerOpenedAt: openedAt }));
+      transaction
+        .mockImplementationOnce(async (operation: (tx: { bankAutoLoginConfig: typeof bankAutoLoginConfig }) => unknown) => {
+          await operation({ bankAutoLoginConfig });
+          throw { code: "P2034" };
+        })
+        .mockImplementationOnce(async (operation: (tx: { bankAutoLoginConfig: typeof bankAutoLoginConfig }) => unknown) => operation({ bankAutoLoginConfig }));
+
+      await expect(repo.recordFailure("popular", openedAt)).resolves.toMatchObject({ breakerState: "open", breakerFailureCount: 3, breakerOpenedAt: openedAt });
+      expect(transaction).toHaveBeenCalledTimes(2);
+      expect(transaction).toHaveBeenNthCalledWith(1, expect.any(Function), SERIALIZABLE_OPTIONS);
+      expect(transaction).toHaveBeenNthCalledWith(2, expect.any(Function), SERIALIZABLE_OPTIONS);
+      expect(bankAutoLoginConfig.update).toHaveBeenNthCalledWith(2, { where: { bankCode: "popular" }, data: failureData("open", 3, t0, openedAt), select: RECORD_SELECT });
+    });
+  });
+
+  describe("openBreaker", () => {
+    it("is a no-op for unknown or already-open rows", async () => {
+      const unknown = makeRepo({ findUnique: null });
+      await expect(unknown.repo.openBreaker("unknown", NOW)).resolves.toBeNull();
+      expectFindUnique(unknown.bankAutoLoginConfig.findUnique, "unknown");
+      expect(unknown.bankAutoLoginConfig.update).not.toHaveBeenCalled();
+
+      const opened = makeRepo({ findUnique: row({ breakerState: "open" }) });
+      await expect(opened.repo.openBreaker("popular", NOW)).resolves.toMatchObject({ breakerState: "open" });
+      expect(opened.bankAutoLoginConfig.update).not.toHaveBeenCalled();
+    });
+
+    it("force-opens a closed breaker", async () => {
+      const { repo, bankAutoLoginConfig } = makeRepo({ findUnique: row(), update: row({ breakerState: "open", breakerOpenedAt: NOW }) });
+      await expect(repo.openBreaker("popular", NOW)).resolves.toMatchObject({ breakerState: "open" });
+      expectUpdate(bankAutoLoginConfig.update, "popular", { breakerState: "open", breakerOpenedAt: NOW });
+    });
+  });
+
+  describe("resetBreaker", () => {
+    it("requires updatedBy and is a no-op for unknown bankCode", async () => {
+      await expect(makeRepo().repo.resetBreaker("popular", "")).rejects.toThrow(/updatedBy/);
+
+      const { repo, bankAutoLoginConfig } = makeRepo({ findUnique: null });
+      await expect(repo.resetBreaker("unknown", "admin-1")).resolves.toBeNull();
+      expectFindUnique(bankAutoLoginConfig.findUnique, "unknown", BANK_CODE_SELECT);
+      expect(bankAutoLoginConfig.update).not.toHaveBeenCalled();
+    });
+
+    it("clears breakerOpenedAt and persists reset metadata", async () => {
+      const resetAt = new Date("2026-07-02T13:00:00.000Z");
+      const data = { breakerState: "closed", breakerFailureCount: 0, breakerFailureWindowStart: null, breakerOpenedAt: null, breakerLastResetAt: resetAt, updatedBy: "admin-1" };
+      const { repo, bankAutoLoginConfig } = makeRepo({ findUnique: row(), update: row({ ...data }) });
+
+      await expect(repo.resetBreaker("popular", "admin-1", resetAt)).resolves.toMatchObject({ breakerState: "closed", breakerOpenedAt: null, updatedBy: "admin-1" });
+      expectUpdate(bankAutoLoginConfig.update, "popular", data);
+    });
+  });
+
+  describe("setAutoLoginEnabled", () => {
+    it("is a no-op for unknown bankCode and updates only known rows", async () => {
+      const unknown = makeRepo({ findUnique: null });
+      await expect(unknown.repo.setAutoLoginEnabled("unknown", true, "admin-1")).resolves.toBeNull();
+      expectFindUnique(unknown.bankAutoLoginConfig.findUnique, "unknown", BANK_CODE_SELECT);
+      expect(unknown.bankAutoLoginConfig.update).not.toHaveBeenCalled();
+
+      const known = makeRepo({ findUnique: row(), update: row({ autoLoginEnabled: true, updatedBy: "admin-1" }) });
+      await expect(known.repo.setAutoLoginEnabled("popular", true, "admin-1")).resolves.toMatchObject({ autoLoginEnabled: true, updatedBy: "admin-1" });
+      expectUpdate(known.bankAutoLoginConfig.update, "popular", { autoLoginEnabled: true, updatedBy: "admin-1" });
+    });
   });
 });
 
-describe("BankAutoLoginConfigRepository.openBreaker", () => {
-  it("is a no-op for an unknown bankCode", async () => {
-    const { prisma, bankAutoLoginConfig } = makePrisma({ findUnique: null });
-    const repo = new BankAutoLoginConfigRepository(prisma);
-    await expect(repo.openBreaker("unknown", new Date())).resolves.toBeNull();
-    expect(bankAutoLoginConfig.update).not.toHaveBeenCalled();
-  });
+function makeRepo(overrides?: Parameters<typeof makePrisma>[0]) {
+  const ctx = makePrisma(overrides);
+  return { ...ctx, repo: new BankAutoLoginConfigRepository(ctx.prisma) };
+}
 
-  it("is idempotent when already open — does not re-write", async () => {
-    const { prisma, bankAutoLoginConfig } = makePrisma({ findUnique: defaultRow({ breakerState: "open" }) });
-    const repo = new BankAutoLoginConfigRepository(prisma);
-    const record = await repo.openBreaker("popular", new Date());
-    expect(record?.breakerState).toBe("open");
-    expect(bankAutoLoginConfig.update).not.toHaveBeenCalled();
-  });
-
-  it("force-opens a closed breaker", async () => {
-    const now = new Date("2026-07-02T12:00:00.000Z");
-    const { prisma, bankAutoLoginConfig } = makePrisma({
-      findUnique: defaultRow(),
-      update: defaultRow({ breakerState: "open", breakerOpenedAt: now }),
-    });
-    const repo = new BankAutoLoginConfigRepository(prisma);
-    const record = await repo.openBreaker("popular", now);
-    expect(record?.breakerState).toBe("open");
-    expect(bankAutoLoginConfig.update).toHaveBeenCalledWith(
-      expect.objectContaining({ data: { breakerState: "open", breakerOpenedAt: now } }),
-    );
-  });
-});
-
-describe("BankAutoLoginConfigRepository.resetBreaker", () => {
-  it("requires a non-empty updatedBy actor id", async () => {
-    const { prisma } = makePrisma();
-    const repo = new BankAutoLoginConfigRepository(prisma);
-    await expect(repo.resetBreaker("popular", "")).rejects.toThrow(/updatedBy/);
-  });
-
-  it("is a no-op for an unknown bankCode", async () => {
-    const { prisma, bankAutoLoginConfig } = makePrisma({ findUnique: null });
-    const repo = new BankAutoLoginConfigRepository(prisma);
-    await expect(repo.resetBreaker("unknown", "admin-1")).resolves.toBeNull();
-    expect(bankAutoLoginConfig.update).not.toHaveBeenCalled();
-  });
-
-  it("clears state, count, and window and stamps breakerLastResetAt + updatedBy — the ONLY open->closed path", async () => {
-    const now = new Date("2026-07-02T13:00:00.000Z");
-    const { prisma, bankAutoLoginConfig } = makePrisma({
-      findUnique: defaultRow({ bankCode: "popular" }),
-      update: defaultRow({ breakerState: "closed", breakerLastResetAt: now, updatedBy: "admin-1" }),
-    });
-    const repo = new BankAutoLoginConfigRepository(prisma);
-    const record = await repo.resetBreaker("popular", "admin-1", now);
-    expect(record).toMatchObject({ breakerState: "closed", updatedBy: "admin-1" });
-    expect(bankAutoLoginConfig.update).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: {
-          breakerState: "closed",
-          breakerFailureCount: 0,
-          breakerFailureWindowStart: null,
-          breakerLastResetAt: now,
-          updatedBy: "admin-1",
-        },
-      }),
-    );
-  });
-});
-
-describe("BankAutoLoginConfigRepository.setAutoLoginEnabled", () => {
-  it("is a no-op for an unknown bankCode", async () => {
-    const { prisma, bankAutoLoginConfig } = makePrisma({ findUnique: null });
-    const repo = new BankAutoLoginConfigRepository(prisma);
-    await expect(repo.setAutoLoginEnabled("unknown", true, "admin-1")).resolves.toBeNull();
-    expect(bankAutoLoginConfig.update).not.toHaveBeenCalled();
-  });
-
-  it("flips the flag and stamps updatedBy", async () => {
-    const { prisma, bankAutoLoginConfig } = makePrisma({
-      findUnique: defaultRow(),
-      update: defaultRow({ autoLoginEnabled: true, updatedBy: "admin-1" }),
-    });
-    const repo = new BankAutoLoginConfigRepository(prisma);
-    const record = await repo.setAutoLoginEnabled("popular", true, "admin-1");
-    expect(record).toMatchObject({ autoLoginEnabled: true, updatedBy: "admin-1" });
-    expect(bankAutoLoginConfig.update).toHaveBeenCalledWith(
-      expect.objectContaining({ data: { autoLoginEnabled: true, updatedBy: "admin-1" } }),
-    );
-  });
-});
+function failureData(breakerState: "closed" | "open", breakerFailureCount: number, breakerFailureWindowStart: Date, breakerOpenedAt: Date | null) {
+  return { breakerState, breakerFailureCount, breakerFailureWindowStart, breakerOpenedAt };
+}

--- a/src/modules/bank-auto-login-config/repository.ts
+++ b/src/modules/bank-auto-login-config/repository.ts
@@ -1,0 +1,169 @@
+/**
+ * Prisma repository for `BankAutoLoginConfig` — per-bank auto-login kill
+ * switch + circuit-breaker state. Speaks domain `bankCode` (`Bank.code`)
+ * everywhere, never Prisma's internal `Bank.id`. Unknown bankCode always
+ * fails closed (null / no-op, never falls back to another bank). Unused
+ * in production yet — the state machine (PR4.4/4.5) is the first caller.
+ */
+
+import type { PrismaClient } from "../../generated/prisma/client";
+import { nextStateOnFailure, type BreakerState } from "./breaker-policy";
+
+export interface BankAutoLoginConfigRecord {
+  bankCode: string;
+  autoLoginEnabled: boolean;
+  breakerState: BreakerState;
+  breakerFailureCount: number;
+  breakerFailureWindowStart: Date | null;
+  breakerOpenedAt: Date | null;
+  breakerLastResetAt: Date | null;
+  updatedAt: Date;
+  updatedBy: string | null;
+}
+
+type Row = {
+  bankCode: string;
+  autoLoginEnabled: boolean;
+  breakerState: string;
+  breakerFailureCount: number;
+  breakerFailureWindowStart: Date | null;
+  breakerOpenedAt: Date | null;
+  breakerLastResetAt: Date | null;
+  updatedAt: Date;
+  updatedBy: string | null;
+};
+
+const RECORD_SELECT = {
+  bankCode: true,
+  autoLoginEnabled: true,
+  breakerState: true,
+  breakerFailureCount: true,
+  breakerFailureWindowStart: true,
+  breakerOpenedAt: true,
+  breakerLastResetAt: true,
+  updatedAt: true,
+  updatedBy: true,
+} as const;
+
+/** Validates the persisted breaker state against the closed|open union — rejects any other value. */
+function toBreakerState(value: string): BreakerState {
+  if (value !== "closed" && value !== "open") {
+    throw new Error(`Invalid breaker state persisted for BankAutoLoginConfig: ${value}`);
+  }
+  return value;
+}
+
+function mapRow(row: Row): BankAutoLoginConfigRecord {
+  return { ...row, breakerState: toBreakerState(row.breakerState) };
+}
+
+export class BankAutoLoginConfigRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  /** Returns `null` for an unknown bankCode — never falls back to another bank. */
+  async getByBankCode(bankCode: string): Promise<BankAutoLoginConfigRecord | null> {
+    const row = await this.prisma.bankAutoLoginConfig.findUnique({
+      where: { bankCode },
+      select: RECORD_SELECT,
+    });
+    return row ? mapRow(row) : null;
+  }
+
+  /** Auto-provisions the default row (mirrors `upsertBankByCode`). Fails closed (null) if the parent Bank row is missing. */
+  async upsertDefaults(bankCode: string): Promise<BankAutoLoginConfigRecord | null> {
+    try {
+      const row = await this.prisma.bankAutoLoginConfig.upsert({
+        where: { bankCode },
+        update: {},
+        create: { bankCode },
+        select: RECORD_SELECT,
+      });
+      return mapRow(row);
+    } catch (error: unknown) {
+      if (isForeignKeyViolation(error)) return null;
+      throw error;
+    }
+  }
+
+  /** Applies the pure `nextStateOnFailure` transition for one failure at `now`. Fail-closed no-op for an unknown bankCode. */
+  async recordFailure(bankCode: string, now: Date): Promise<BankAutoLoginConfigRecord | null> {
+    const existing = await this.prisma.bankAutoLoginConfig.findUnique({
+      where: { bankCode },
+      select: RECORD_SELECT,
+    });
+    if (!existing) return null;
+
+    const next = nextStateOnFailure(mapRow(existing), now);
+    const row = await this.prisma.bankAutoLoginConfig.update({
+      where: { bankCode },
+      data: {
+        breakerState: next.breakerState,
+        breakerFailureCount: next.breakerFailureCount,
+        breakerFailureWindowStart: next.breakerFailureWindowStart,
+        ...(next.breakerOpenedAt ? { breakerOpenedAt: next.breakerOpenedAt } : {}),
+      },
+      select: RECORD_SELECT,
+    });
+    return mapRow(row);
+  }
+
+  /** Explicit force-open, independent of failure counting. Idempotent while already open; no-op for unknown bankCode. */
+  async openBreaker(bankCode: string, now: Date): Promise<BankAutoLoginConfigRecord | null> {
+    const existing = await this.prisma.bankAutoLoginConfig.findUnique({
+      where: { bankCode },
+      select: RECORD_SELECT,
+    });
+    if (!existing) return null;
+    if (existing.breakerState === "open") return mapRow(existing);
+
+    const row = await this.prisma.bankAutoLoginConfig.update({
+      where: { bankCode },
+      data: { breakerState: "open", breakerOpenedAt: now },
+      select: RECORD_SELECT,
+    });
+    return mapRow(row);
+  }
+
+  /** The ONLY open->closed transition. Clears count/window, stamps `breakerLastResetAt`; requires `updatedBy`. */
+  async resetBreaker(bankCode: string, updatedBy: string, now: Date = new Date()): Promise<BankAutoLoginConfigRecord | null> {
+    if (!updatedBy) throw new Error("resetBreaker requires an updatedBy actor id");
+
+    const existing = await this.prisma.bankAutoLoginConfig.findUnique({ where: { bankCode }, select: { bankCode: true } });
+    if (!existing) return null;
+
+    const row = await this.prisma.bankAutoLoginConfig.update({
+      where: { bankCode },
+      data: {
+        breakerState: "closed",
+        breakerFailureCount: 0,
+        breakerFailureWindowStart: null,
+        breakerLastResetAt: now,
+        updatedBy,
+      },
+      select: RECORD_SELECT,
+    });
+    return mapRow(row);
+  }
+
+  /** Flips the manual auto-login kill switch. Fail-closed no-op for an unknown bankCode. */
+  async setAutoLoginEnabled(bankCode: string, enabled: boolean, updatedBy: string): Promise<BankAutoLoginConfigRecord | null> {
+    const existing = await this.prisma.bankAutoLoginConfig.findUnique({ where: { bankCode }, select: { bankCode: true } });
+    if (!existing) return null;
+
+    const row = await this.prisma.bankAutoLoginConfig.update({
+      where: { bankCode },
+      data: { autoLoginEnabled: enabled, updatedBy },
+      select: RECORD_SELECT,
+    });
+    return mapRow(row);
+  }
+}
+
+function isForeignKeyViolation(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code: unknown }).code === "P2003"
+  );
+}

--- a/src/modules/bank-auto-login-config/repository.ts
+++ b/src/modules/bank-auto-login-config/repository.ts
@@ -1,12 +1,4 @@
-/**
- * Prisma repository for `BankAutoLoginConfig` — per-bank auto-login kill
- * switch + circuit-breaker state. Speaks domain `bankCode` (`Bank.code`)
- * everywhere, never Prisma's internal `Bank.id`. Unknown bankCode always
- * fails closed (null / no-op, never falls back to another bank). Unused
- * in production yet — the state machine (PR4.4/4.5) is the first caller.
- */
-
-import type { PrismaClient } from "../../generated/prisma/client";
+import { Prisma, type PrismaClient } from "../../generated/prisma/client";
 import { nextStateOnFailure, type BreakerState } from "./breaker-policy";
 
 export interface BankAutoLoginConfigRecord {
@@ -21,17 +13,8 @@ export interface BankAutoLoginConfigRecord {
   updatedBy: string | null;
 }
 
-type Row = {
-  bankCode: string;
-  autoLoginEnabled: boolean;
-  breakerState: string;
-  breakerFailureCount: number;
-  breakerFailureWindowStart: Date | null;
-  breakerOpenedAt: Date | null;
-  breakerLastResetAt: Date | null;
-  updatedAt: Date;
-  updatedBy: string | null;
-};
+type Row = Omit<BankAutoLoginConfigRecord, "breakerState"> & { breakerState: string };
+type BankAutoLoginConfigTx = Pick<PrismaClient, "bankAutoLoginConfig">;
 
 const RECORD_SELECT = {
   bankCode: true,
@@ -45,7 +28,8 @@ const RECORD_SELECT = {
   updatedBy: true,
 } as const;
 
-/** Validates the persisted breaker state against the closed|open union — rejects any other value. */
+const SERIALIZABLE_RETRY_ATTEMPTS = 3;
+
 function toBreakerState(value: string): BreakerState {
   if (value !== "closed" && value !== "open") {
     throw new Error(`Invalid breaker state persisted for BankAutoLoginConfig: ${value}`);
@@ -57,19 +41,18 @@ function mapRow(row: Row): BankAutoLoginConfigRecord {
   return { ...row, breakerState: toBreakerState(row.breakerState) };
 }
 
+function hasPrismaCode(error: unknown, code: string): boolean {
+  return typeof error === "object" && error !== null && "code" in error && (error as { code: unknown }).code === code;
+}
+
 export class BankAutoLoginConfigRepository {
   constructor(private readonly prisma: PrismaClient) {}
 
-  /** Returns `null` for an unknown bankCode — never falls back to another bank. */
   async getByBankCode(bankCode: string): Promise<BankAutoLoginConfigRecord | null> {
-    const row = await this.prisma.bankAutoLoginConfig.findUnique({
-      where: { bankCode },
-      select: RECORD_SELECT,
-    });
+    const row = await this.prisma.bankAutoLoginConfig.findUnique({ where: { bankCode }, select: RECORD_SELECT });
     return row ? mapRow(row) : null;
   }
 
-  /** Auto-provisions the default row (mirrors `upsertBankByCode`). Fails closed (null) if the parent Bank row is missing. */
   async upsertDefaults(bankCode: string): Promise<BankAutoLoginConfigRecord | null> {
     try {
       const row = await this.prisma.bankAutoLoginConfig.upsert({
@@ -80,39 +63,36 @@ export class BankAutoLoginConfigRepository {
       });
       return mapRow(row);
     } catch (error: unknown) {
-      if (isForeignKeyViolation(error)) return null;
+      if (hasPrismaCode(error, "P2003")) return null;
       throw error;
     }
   }
 
-  /** Applies the pure `nextStateOnFailure` transition for one failure at `now`. Fail-closed no-op for an unknown bankCode. */
   async recordFailure(bankCode: string, now: Date): Promise<BankAutoLoginConfigRecord | null> {
-    const existing = await this.prisma.bankAutoLoginConfig.findUnique({
-      where: { bankCode },
-      select: RECORD_SELECT,
-    });
-    if (!existing) return null;
+    return this.runSerializableWithRetry(async (tx) => {
+      const existing = await tx.bankAutoLoginConfig.findUnique({ where: { bankCode }, select: RECORD_SELECT });
+      if (!existing) return null;
 
-    const next = nextStateOnFailure(mapRow(existing), now);
-    const row = await this.prisma.bankAutoLoginConfig.update({
-      where: { bankCode },
-      data: {
-        breakerState: next.breakerState,
-        breakerFailureCount: next.breakerFailureCount,
-        breakerFailureWindowStart: next.breakerFailureWindowStart,
-        ...(next.breakerOpenedAt ? { breakerOpenedAt: next.breakerOpenedAt } : {}),
-      },
-      select: RECORD_SELECT,
+      const current = mapRow(existing);
+      if (current.breakerState === "open") return current;
+
+      const next = nextStateOnFailure(current, now);
+      const row = await tx.bankAutoLoginConfig.update({
+        where: { bankCode },
+        data: {
+          breakerState: next.breakerState,
+          breakerFailureCount: next.breakerFailureCount,
+          breakerFailureWindowStart: next.breakerFailureWindowStart,
+          breakerOpenedAt: next.breakerOpenedAt,
+        },
+        select: RECORD_SELECT,
+      });
+      return mapRow(row);
     });
-    return mapRow(row);
   }
 
-  /** Explicit force-open, independent of failure counting. Idempotent while already open; no-op for unknown bankCode. */
   async openBreaker(bankCode: string, now: Date): Promise<BankAutoLoginConfigRecord | null> {
-    const existing = await this.prisma.bankAutoLoginConfig.findUnique({
-      where: { bankCode },
-      select: RECORD_SELECT,
-    });
+    const existing = await this.prisma.bankAutoLoginConfig.findUnique({ where: { bankCode }, select: RECORD_SELECT });
     if (!existing) return null;
     if (existing.breakerState === "open") return mapRow(existing);
 
@@ -124,7 +104,6 @@ export class BankAutoLoginConfigRepository {
     return mapRow(row);
   }
 
-  /** The ONLY open->closed transition. Clears count/window, stamps `breakerLastResetAt`; requires `updatedBy`. */
   async resetBreaker(bankCode: string, updatedBy: string, now: Date = new Date()): Promise<BankAutoLoginConfigRecord | null> {
     if (!updatedBy) throw new Error("resetBreaker requires an updatedBy actor id");
 
@@ -137,6 +116,7 @@ export class BankAutoLoginConfigRepository {
         breakerState: "closed",
         breakerFailureCount: 0,
         breakerFailureWindowStart: null,
+        breakerOpenedAt: null,
         breakerLastResetAt: now,
         updatedBy,
       },
@@ -145,7 +125,6 @@ export class BankAutoLoginConfigRepository {
     return mapRow(row);
   }
 
-  /** Flips the manual auto-login kill switch. Fail-closed no-op for an unknown bankCode. */
   async setAutoLoginEnabled(bankCode: string, enabled: boolean, updatedBy: string): Promise<BankAutoLoginConfigRecord | null> {
     const existing = await this.prisma.bankAutoLoginConfig.findUnique({ where: { bankCode }, select: { bankCode: true } });
     if (!existing) return null;
@@ -157,13 +136,15 @@ export class BankAutoLoginConfigRepository {
     });
     return mapRow(row);
   }
-}
 
-function isForeignKeyViolation(error: unknown): boolean {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    "code" in error &&
-    (error as { code: unknown }).code === "P2003"
-  );
+  private async runSerializableWithRetry<T>(operation: (tx: BankAutoLoginConfigTx) => Promise<T>): Promise<T> {
+    for (let attempt = 1; attempt <= SERIALIZABLE_RETRY_ATTEMPTS; attempt += 1) {
+      try {
+        return await this.prisma.$transaction(operation, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable });
+      } catch (error: unknown) {
+        if (!hasPrismaCode(error, "P2034") || attempt === SERIALIZABLE_RETRY_ATTEMPTS) throw error;
+      }
+    }
+    throw new Error("Unreachable serializable transaction retry state");
+  }
 }


### PR DESCRIPTION
## Summary

- Adds BankAutoLoginConfigRepository for default provisioning, failure accrual, force-open, manual reset, and auto-login toggle writes.
- Hardens recordFailure with Serializable transaction retry on Prisma P2034 to avoid lost failure increments.
- Marks OpenSpec task 4.3 complete after the full config repository/breaker-policy chain has landed.

## Scope

- src/modules/bank-auto-login-config/repository.ts and tests.
- openspec/changes/multi-bank-auto-login/tasks.md checkbox for task 4.3.

## Out of scope

- LoginMutationGuard, auto-login state machine, scraper wiring, admin endpoints, metrics, or bank enablement.

## Verification

- Targeted repository + breaker policy tests passed after fixes.
- pnpm typecheck passed.
- pnpm lint passed.
- git diff --check passed.

## Review budget

- 3 files, 393 additions / 1 deletion. Under the 400-line budget.

## Chain context

- Chain strategy: feature-branch-chain.
- Base: feature/multi-bank-auto-login.
- Previous PRs merged: #23 conservative breaker policy, #25 BankAdapterConfigRepository.

## HIGH RISK note

PR4 slices require fresh 4R review + Judgment Day before merge.