### PR TITLE
feat(bank-adapter-config): add adapter config repository (PR4.3b)

### DIFF
--- a/src/modules/bank-adapter-config/repository.test.ts
+++ b/src/modules/bank-adapter-config/repository.test.ts
@@ -10,8 +10,15 @@ const RECORD_SELECT = {
 } as const;
 
 type FindUniqueArgs = { where: { bankCode: string }; select?: unknown };
-type UpdateArgs = { where: { bankCode: string }; data: { scrapingEnabled: boolean; updatedBy: string }; select?: unknown };
-type FindUniqueResult = BankAdapterConfigRecord | { bankCode: string } | null;
+type BankFindUniqueArgs = { where: { code: string }; select?: unknown };
+type UpsertArgs = {
+  where: { bankCode: string };
+  update: { scrapingEnabled: boolean; updatedBy: string };
+  create: { bankCode: string; scrapingEnabled: boolean; updatedBy: string };
+  select?: unknown;
+};
+type FindUniqueResult = BankAdapterConfigRecord | null;
+type BankFindUniqueResult = { code: string } | null;
 
 function defaultRow(overrides: Partial<BankAdapterConfigRecord> = {}): BankAdapterConfigRecord {
   return {
@@ -26,20 +33,27 @@ function defaultRow(overrides: Partial<BankAdapterConfigRecord> = {}): BankAdapt
 function makePrisma(
   overrides: {
     findUnique?: FindUniqueResult | ((args: FindUniqueArgs) => FindUniqueResult | Promise<FindUniqueResult>);
-    update?: BankAdapterConfigRecord | ((args: UpdateArgs) => BankAdapterConfigRecord | Promise<BankAdapterConfigRecord>);
+    bankFindUnique?: BankFindUniqueResult | ((args: BankFindUniqueArgs) => BankFindUniqueResult | Promise<BankFindUniqueResult>);
+    upsert?: BankAdapterConfigRecord | ((args: UpsertArgs) => BankAdapterConfigRecord | Promise<BankAdapterConfigRecord>);
   } = {},
 ) {
+  const bank = {
+    findUnique: vi.fn((args: BankFindUniqueArgs) => {
+      const result = overrides.bankFindUnique ?? null;
+      return Promise.resolve(typeof result === "function" ? result(args) : result);
+    }),
+  };
   const bankAdapterConfig = {
     findUnique: vi.fn((args: FindUniqueArgs) => {
       const result = overrides.findUnique ?? null;
       return Promise.resolve(typeof result === "function" ? result(args) : result);
     }),
-    update: vi.fn((args: UpdateArgs) => {
-      const result = overrides.update ?? defaultRow();
+    upsert: vi.fn((args: UpsertArgs) => {
+      const result = overrides.upsert ?? defaultRow();
       return Promise.resolve(typeof result === "function" ? result(args) : result);
     }),
   };
-  return { prisma: { bankAdapterConfig } as unknown as PrismaClient, bankAdapterConfig };
+  return { prisma: { bank, bankAdapterConfig } as unknown as PrismaClient, bank, bankAdapterConfig };
 }
 
 describe("BankAdapterConfigRepository.getByBankCode", () => {
@@ -65,40 +79,45 @@ describe("BankAdapterConfigRepository.getByBankCode", () => {
 
 describe("BankAdapterConfigRepository.setScrapingEnabled", () => {
   it("is a no-op for an unknown bankCode — never falls back to another bank", async () => {
-    const { prisma, bankAdapterConfig } = makePrisma({ findUnique: null });
+    const { prisma, bank, bankAdapterConfig } = makePrisma({ bankFindUnique: null });
     const repo = new BankAdapterConfigRepository(prisma);
     await expect(repo.setScrapingEnabled("unknown", false, "admin-1")).resolves.toBeNull();
-    expect(bankAdapterConfig.findUnique).toHaveBeenCalledWith({ where: { bankCode: "unknown" }, select: { bankCode: true } });
-    expect(bankAdapterConfig.update).not.toHaveBeenCalled();
+    expect(bank.findUnique).toHaveBeenCalledWith({ where: { code: "unknown" }, select: { code: true } });
+    expect(bankAdapterConfig.findUnique).not.toHaveBeenCalled();
+    expect(bankAdapterConfig.upsert).not.toHaveBeenCalled();
   });
 
-  it("disables scraping for one bank without touching auto-login state (separate kill switch)", async () => {
-    const { prisma, bankAdapterConfig } = makePrisma({
-      findUnique: defaultRow(),
-      update: defaultRow({ scrapingEnabled: false, updatedBy: "admin-1" }),
+  it("creates config for a known bank missing a config row", async () => {
+    const { prisma, bank, bankAdapterConfig } = makePrisma({
+      bankFindUnique: { code: "popular" },
+      upsert: defaultRow({ scrapingEnabled: false, updatedBy: "admin-1" }),
     });
     const repo = new BankAdapterConfigRepository(prisma);
     const record = await repo.setScrapingEnabled("popular", false, "admin-1");
     expect(record).toMatchObject({ scrapingEnabled: false, updatedBy: "admin-1" });
-    expect(bankAdapterConfig.findUnique).toHaveBeenCalledWith({ where: { bankCode: "popular" }, select: { bankCode: true } });
-    expect(bankAdapterConfig.update).toHaveBeenCalledWith({
+    expect(bank.findUnique).toHaveBeenCalledWith({ where: { code: "popular" }, select: { code: true } });
+    expect(bankAdapterConfig.findUnique).not.toHaveBeenCalled();
+    expect(bankAdapterConfig.upsert).toHaveBeenCalledWith({
       where: { bankCode: "popular" },
-      data: { scrapingEnabled: false, updatedBy: "admin-1" },
+      update: { scrapingEnabled: false, updatedBy: "admin-1" },
+      create: { bankCode: "popular", scrapingEnabled: false, updatedBy: "admin-1" },
       select: RECORD_SELECT,
     });
   });
 
   it("re-enables scraping (rollback path)", async () => {
-    const { prisma, bankAdapterConfig } = makePrisma({
-      findUnique: defaultRow({ scrapingEnabled: false }),
-      update: defaultRow({ scrapingEnabled: true, updatedBy: "admin-2" }),
+    const { prisma, bank, bankAdapterConfig } = makePrisma({
+      bankFindUnique: { code: "popular" },
+      upsert: defaultRow({ scrapingEnabled: true, updatedBy: "admin-2" }),
     });
     const repo = new BankAdapterConfigRepository(prisma);
     const record = await repo.setScrapingEnabled("popular", true, "admin-2");
     expect(record?.scrapingEnabled).toBe(true);
-    expect(bankAdapterConfig.update).toHaveBeenCalledWith({
+    expect(bank.findUnique).toHaveBeenCalledWith({ where: { code: "popular" }, select: { code: true } });
+    expect(bankAdapterConfig.upsert).toHaveBeenCalledWith({
       where: { bankCode: "popular" },
-      data: { scrapingEnabled: true, updatedBy: "admin-2" },
+      update: { scrapingEnabled: true, updatedBy: "admin-2" },
+      create: { bankCode: "popular", scrapingEnabled: true, updatedBy: "admin-2" },
       select: RECORD_SELECT,
     });
   });

--- a/src/modules/bank-adapter-config/repository.test.ts
+++ b/src/modules/bank-adapter-config/repository.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from "vitest";
+import { BankAdapterConfigRepository, type BankAdapterConfigRecord } from "./repository";
+import type { PrismaClient } from "../../generated/prisma/client";
+
+const RECORD_SELECT = {
+  bankCode: true,
+  scrapingEnabled: true,
+  updatedAt: true,
+  updatedBy: true,
+} as const;
+
+type FindUniqueArgs = { where: { bankCode: string }; select?: unknown };
+type UpdateArgs = { where: { bankCode: string }; data: { scrapingEnabled: boolean; updatedBy: string }; select?: unknown };
+type FindUniqueResult = BankAdapterConfigRecord | { bankCode: string } | null;
+
+function defaultRow(overrides: Partial<BankAdapterConfigRecord> = {}): BankAdapterConfigRecord {
+  return {
+    bankCode: "popular",
+    scrapingEnabled: true,
+    updatedAt: new Date("2026-07-02T00:00:00.000Z"),
+    updatedBy: null,
+    ...overrides,
+  };
+}
+
+function makePrisma(
+  overrides: {
+    findUnique?: FindUniqueResult | ((args: FindUniqueArgs) => FindUniqueResult | Promise<FindUniqueResult>);
+    update?: BankAdapterConfigRecord | ((args: UpdateArgs) => BankAdapterConfigRecord | Promise<BankAdapterConfigRecord>);
+  } = {},
+) {
+  const bankAdapterConfig = {
+    findUnique: vi.fn((args: FindUniqueArgs) => {
+      const result = overrides.findUnique ?? null;
+      return Promise.resolve(typeof result === "function" ? result(args) : result);
+    }),
+    update: vi.fn((args: UpdateArgs) => {
+      const result = overrides.update ?? defaultRow();
+      return Promise.resolve(typeof result === "function" ? result(args) : result);
+    }),
+  };
+  return { prisma: { bankAdapterConfig } as unknown as PrismaClient, bankAdapterConfig };
+}
+
+describe("BankAdapterConfigRepository.getByBankCode", () => {
+  it("returns null for an unknown bankCode (fail closed, no fallback)", async () => {
+    const rowsByBankCode = new Map([["popular", defaultRow()]]);
+    const { prisma, bankAdapterConfig } = makePrisma({
+      findUnique: ({ where }) => rowsByBankCode.get(where.bankCode) ?? null,
+    });
+    const repo = new BankAdapterConfigRepository(prisma);
+    await expect(repo.getByBankCode("unknown")).resolves.toBeNull();
+    expect(bankAdapterConfig.findUnique).toHaveBeenCalledWith({ where: { bankCode: "unknown" }, select: RECORD_SELECT });
+  });
+
+  it("returns the row for a known bankCode", async () => {
+    const { prisma, bankAdapterConfig } = makePrisma({
+      findUnique: ({ where }) => (where.bankCode === "popular" ? defaultRow({ scrapingEnabled: false }) : null),
+    });
+    const repo = new BankAdapterConfigRepository(prisma);
+    await expect(repo.getByBankCode("popular")).resolves.toMatchObject({ bankCode: "popular", scrapingEnabled: false });
+    expect(bankAdapterConfig.findUnique).toHaveBeenCalledWith({ where: { bankCode: "popular" }, select: RECORD_SELECT });
+  });
+});
+
+describe("BankAdapterConfigRepository.setScrapingEnabled", () => {
+  it("is a no-op for an unknown bankCode — never falls back to another bank", async () => {
+    const { prisma, bankAdapterConfig } = makePrisma({ findUnique: null });
+    const repo = new BankAdapterConfigRepository(prisma);
+    await expect(repo.setScrapingEnabled("unknown", false, "admin-1")).resolves.toBeNull();
+    expect(bankAdapterConfig.findUnique).toHaveBeenCalledWith({ where: { bankCode: "unknown" }, select: { bankCode: true } });
+    expect(bankAdapterConfig.update).not.toHaveBeenCalled();
+  });
+
+  it("disables scraping for one bank without touching auto-login state (separate kill switch)", async () => {
+    const { prisma, bankAdapterConfig } = makePrisma({
+      findUnique: defaultRow(),
+      update: defaultRow({ scrapingEnabled: false, updatedBy: "admin-1" }),
+    });
+    const repo = new BankAdapterConfigRepository(prisma);
+    const record = await repo.setScrapingEnabled("popular", false, "admin-1");
+    expect(record).toMatchObject({ scrapingEnabled: false, updatedBy: "admin-1" });
+    expect(bankAdapterConfig.findUnique).toHaveBeenCalledWith({ where: { bankCode: "popular" }, select: { bankCode: true } });
+    expect(bankAdapterConfig.update).toHaveBeenCalledWith({
+      where: { bankCode: "popular" },
+      data: { scrapingEnabled: false, updatedBy: "admin-1" },
+      select: RECORD_SELECT,
+    });
+  });
+
+  it("re-enables scraping (rollback path)", async () => {
+    const { prisma, bankAdapterConfig } = makePrisma({
+      findUnique: defaultRow({ scrapingEnabled: false }),
+      update: defaultRow({ scrapingEnabled: true, updatedBy: "admin-2" }),
+    });
+    const repo = new BankAdapterConfigRepository(prisma);
+    const record = await repo.setScrapingEnabled("popular", true, "admin-2");
+    expect(record?.scrapingEnabled).toBe(true);
+    expect(bankAdapterConfig.update).toHaveBeenCalledWith({
+      where: { bankCode: "popular" },
+      data: { scrapingEnabled: true, updatedBy: "admin-2" },
+      select: RECORD_SELECT,
+    });
+  });
+});

--- a/src/modules/bank-adapter-config/repository.ts
+++ b/src/modules/bank-adapter-config/repository.ts
@@ -1,0 +1,55 @@
+/**
+ * Prisma repository for `BankAdapterConfig` — the per-bank read-only adapter
+ * kill switch. Separate from `BankAutoLoginConfig.autoLoginEnabled`:
+ * disabling this stops ALL scraping (read-only included) for one bank
+ * without touching auto-login state or any other bank.
+ *
+ * Repos speak domain `bankCode` (`Bank.code`) everywhere, never Prisma's
+ * internal `Bank.id`. An unknown `bankCode` always fails closed: methods
+ * return `null` instead of ever falling back to another bank's row.
+ *
+ * Nothing in production wiring calls this repository yet — PR4.3 is
+ * plumbing only.
+ */
+
+import type { PrismaClient } from "../../generated/prisma/client";
+
+export interface BankAdapterConfigRecord {
+  bankCode: string;
+  scrapingEnabled: boolean;
+  updatedAt: Date;
+  updatedBy: string | null;
+}
+
+const RECORD_SELECT = {
+  bankCode: true,
+  scrapingEnabled: true,
+  updatedAt: true,
+  updatedBy: true,
+} as const;
+
+export class BankAdapterConfigRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  /** Returns `null` for an unknown bankCode — never falls back to another bank. */
+  async getByBankCode(bankCode: string): Promise<BankAdapterConfigRecord | null> {
+    const row = await this.prisma.bankAdapterConfig.findUnique({
+      where: { bankCode },
+      select: RECORD_SELECT,
+    });
+    return row ?? null;
+  }
+
+  /** Flips the adapter (read-only scraping) kill switch. Fail-closed no-op for an unknown bankCode. */
+  async setScrapingEnabled(bankCode: string, enabled: boolean, updatedBy: string): Promise<BankAdapterConfigRecord | null> {
+    const existing = await this.prisma.bankAdapterConfig.findUnique({ where: { bankCode }, select: { bankCode: true } });
+    if (!existing) return null;
+
+    const row = await this.prisma.bankAdapterConfig.update({
+      where: { bankCode },
+      data: { scrapingEnabled: enabled, updatedBy },
+      select: RECORD_SELECT,
+    });
+    return row;
+  }
+}

--- a/src/modules/bank-adapter-config/repository.ts
+++ b/src/modules/bank-adapter-config/repository.ts
@@ -1,8 +1,9 @@
 /**
  * Prisma repository for `BankAdapterConfig` — the per-bank read-only adapter
- * kill switch. Separate from `BankAutoLoginConfig.autoLoginEnabled`:
- * disabling this stops ALL scraping (read-only included) for one bank
- * without touching auto-login state or any other bank.
+ * kill-switch state. Separate from `BankAutoLoginConfig.autoLoginEnabled`:
+ * disabling this persists the intent to stop adapter scraping for one bank
+ * without touching auto-login state or any other bank. Future scrape-path wiring
+ * enforces this persisted state at runtime.
  *
  * Repos speak domain `bankCode` (`Bank.code`) everywhere, never Prisma's
  * internal `Bank.id`. An unknown `bankCode` always fails closed: methods
@@ -40,14 +41,15 @@ export class BankAdapterConfigRepository {
     return row ?? null;
   }
 
-  /** Flips the adapter (read-only scraping) kill switch. Fail-closed no-op for an unknown bankCode. */
+  /** Persists the adapter scraping kill-switch state. Fail-closed no-op for an unknown bankCode. */
   async setScrapingEnabled(bankCode: string, enabled: boolean, updatedBy: string): Promise<BankAdapterConfigRecord | null> {
-    const existing = await this.prisma.bankAdapterConfig.findUnique({ where: { bankCode }, select: { bankCode: true } });
-    if (!existing) return null;
+    const bank = await this.prisma.bank.findUnique({ where: { code: bankCode }, select: { code: true } });
+    if (!bank) return null;
 
-    const row = await this.prisma.bankAdapterConfig.update({
+    const row = await this.prisma.bankAdapterConfig.upsert({
       where: { bankCode },
-      data: { scrapingEnabled: enabled, updatedBy },
+      update: { scrapingEnabled: enabled, updatedBy },
+      create: { bankCode, scrapingEnabled: enabled, updatedBy },
       select: RECORD_SELECT,
     });
     return row;


### PR DESCRIPTION
## Summary

- Adds BankAdapterConfigRepository for per-bank scraping kill-switch reads/writes.
- Preserves fail-closed behavior for unknown bank codes: no fallback and no update.
- Provisions config rows for known banks when setting the adapter kill switch, preserving a concrete disable/re-enable recovery path.

## Scope

- src/modules/bank-adapter-config/repository.ts
- src/modules/bank-adapter-config/repository.test.ts

## Out of scope

- BankAutoLoginConfigRepository, covered by the next stacked PR.
- Runtime scraper/admin/UI wiring, metrics, alerts, or bank enablement.

## Verification

- Targeted test after fixes: repository tests passed.
- pnpm typecheck passed.
- pnpm lint passed.
- git diff --check passed.
- Slice size remains under the 400-line budget.

## Chain context

- Chain strategy: feature-branch-chain.
- Base: feature/multi-bank-auto-login.
- Previous PR: #23 merged.
- Next stacked PR: #24 BankAutoLoginConfigRepository + OpenSpec task completion.

## HIGH RISK note

PR4 slices require fresh 4R review + Judgment Day before merge.