### PR TITLE
feat(scraper): add LoginMutationGuard (PR4.4a)

### DIFF
--- a/src/worker/scraper/login-mutation-guard.test.ts
+++ b/src/worker/scraper/login-mutation-guard.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  LoginMutationGuard,
+  LoginMutationGuardError,
+  LOGIN_MUTATION_GUARD_ERROR_SUMMARIES,
+  type BankPortalConfig,
+  type LoginMutationPage,
+} from "./login-mutation-guard";
+
+const portalConfig: BankPortalConfig = {
+  bankCode: "popular",
+  baseUrl: "https://ib.bpd.com.do",
+  loginPathAllowlist: ["/login"],
+  usernameSelector: "#username",
+  passwordSelector: "#password",
+  submitSelector: "button[type='submit']",
+  mfaIndicatorSelector: "[data-mfa]",
+  incompatibleFlowSelector: "[data-corporate-token]",
+  dashboardPathIndicator: "/dashboard",
+};
+
+const credentialControlSelectors = [portalConfig.usernameSelector, portalConfig.passwordSelector] as const;
+const allLoginControlSelectors = [...credentialControlSelectors, portalConfig.submitSelector] as const;
+
+function makePage(url: string, visibleSelectors: readonly string[] = []): LoginMutationPage {
+  return {
+    async currentUrl() {
+      return url;
+    },
+    async hasVisibleSelector(selector) {
+      return visibleSelectors.includes(selector);
+    },
+  };
+}
+
+async function guardedSubmit(
+  guard: LoginMutationGuard,
+  page: LoginMutationPage,
+  fill: () => void,
+  submit: () => void,
+): Promise<void> {
+  await guard.beforeFill(page);
+  fill();
+  await guard.beforeSubmit(page);
+  submit();
+}
+
+describe("LoginMutationGuard", () => {
+  it.each([
+    ["rejects http portal URLs", "http://ib.bpd.com.do/login"],
+    ["rejects subdomain lookalikes", "https://ib.bpd.com.do.evil.com/login"],
+    ["rejects userinfo tricks", "https://ib.bpd.com.do@evil.com/login"],
+    ["rejects port mismatches", "https://ib.bpd.com.do:8443/login"],
+    ["rejects paths outside the allowlist", "https://ib.bpd.com.do/dashboard"],
+  ])("%s", async (_caseName, url) => {
+    const guard = new LoginMutationGuard(portalConfig);
+
+    await expect(guard.assertLoginPage(makePage(url))).rejects.toMatchObject({
+      outcome: "needs_admin_action",
+      safeSummary: LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.UNAUTHORIZED_LOGIN_PAGE,
+    });
+  });
+
+  it("rejects malformed URLs with a fixed safe summary", async () => {
+    const guard = new LoginMutationGuard(portalConfig);
+
+    await expect(guard.assertLoginPage(makePage("not a url with secret=password"))).rejects.toMatchObject({
+      safeSummary: LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.MALFORMED_PORTAL_URL,
+    });
+  });
+
+  it("runs fill and submit when the login URL and controls are authorized", async () => {
+    const page = makePage("https://ib.bpd.com.do/login", allLoginControlSelectors);
+    const guard = new LoginMutationGuard(portalConfig);
+    const fill = vi.fn();
+    const submit = vi.fn();
+
+    await expect(guardedSubmit(guard, page, fill, submit)).resolves.toBeUndefined();
+
+    expect(fill).toHaveBeenCalledOnce();
+    expect(submit).toHaveBeenCalledOnce();
+  });
+
+  it("re-checks before submit and catches redirect/navigation after fill", async () => {
+    let currentUrl = "https://ib.bpd.com.do/login";
+    const visibleSelectors = new Set<string>(allLoginControlSelectors);
+    const page: LoginMutationPage = {
+      async currentUrl() { return currentUrl; },
+      async hasVisibleSelector(selector) { return visibleSelectors.has(selector); },
+    };
+    const guard = new LoginMutationGuard(portalConfig);
+    const fill = vi.fn(() => {
+      currentUrl = "https://evil.com/login";
+    });
+    const submit = vi.fn();
+
+    await expect(guardedSubmit(guard, page, fill, submit)).rejects.toMatchObject({
+      safeSummary: LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.UNAUTHORIZED_LOGIN_PAGE,
+    });
+
+    expect(fill).toHaveBeenCalledOnce();
+    expect(submit).not.toHaveBeenCalled();
+  });
+
+  it("blocks incompatible pre-submit flows before caller mutations run", async () => {
+    const page = makePage("https://ib.bpd.com.do/login", ["[data-corporate-token]"]);
+    const guard = new LoginMutationGuard(portalConfig);
+    const fill = vi.fn();
+    const submit = vi.fn();
+
+    await expect(guardedSubmit(guard, page, fill, submit)).rejects.toMatchObject({
+      outcome: "needs_admin_action",
+      safeSummary: LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.INCOMPATIBLE_FLOW,
+    });
+
+    expect(fill).not.toHaveBeenCalled();
+    expect(submit).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["username", [portalConfig.passwordSelector, portalConfig.submitSelector], 0],
+    ["password", [portalConfig.usernameSelector, portalConfig.submitSelector], 0],
+    ["submit", credentialControlSelectors, 0],
+  ] as const)("blocks guarded submission when the required %s control is missing", async (_controlName, selectors, fillCalls) => {
+    const page = makePage("https://ib.bpd.com.do/login", selectors);
+    const guard = new LoginMutationGuard(portalConfig);
+    const fill = vi.fn();
+    const submit = vi.fn();
+
+    await expect(guardedSubmit(guard, page, fill, submit)).rejects.toMatchObject({
+      outcome: "needs_admin_action",
+      reason: "missing_required_login_control",
+      safeSummary: LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.MISSING_REQUIRED_LOGIN_CONTROL,
+    });
+
+    expect(fill).toHaveBeenCalledTimes(fillCalls);
+    expect(submit).not.toHaveBeenCalled();
+  });
+
+  it("blocks MFA-protected pages before caller mutations run", async () => {
+    const page = makePage("https://ib.bpd.com.do/login", ["[data-mfa]"]);
+    const guard = new LoginMutationGuard(portalConfig);
+    const fill = vi.fn();
+    const submit = vi.fn();
+
+    await expect(guardedSubmit(guard, page, fill, submit)).rejects.toMatchObject({
+      outcome: "needs_admin_action",
+      reason: "protected_flow",
+      safeSummary: LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.PROTECTED_FLOW,
+    });
+
+    expect(fill).not.toHaveBeenCalled();
+    expect(submit).not.toHaveBeenCalled();
+  });
+
+  it("does not authorize submit when an MFA indicator appears after fill", async () => {
+    const visibleSelectors = new Set<string>(allLoginControlSelectors);
+    const page: LoginMutationPage = {
+      async currentUrl() { return "https://ib.bpd.com.do/login"; },
+      async hasVisibleSelector(selector) { return visibleSelectors.has(selector); },
+    };
+    const guard = new LoginMutationGuard(portalConfig);
+    const fill = vi.fn(() => {
+      visibleSelectors.add("[data-mfa]");
+    });
+    const submit = vi.fn();
+
+    await expect(guardedSubmit(guard, page, fill, submit)).rejects.toMatchObject({
+      reason: "protected_flow",
+      safeSummary: LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.PROTECTED_FLOW,
+    });
+
+    expect(fill).toHaveBeenCalledOnce();
+    expect(submit).not.toHaveBeenCalled();
+  });
+
+  it("validates the login page when assertCompatiblePreSubmit is called directly", async () => {
+    const guard = new LoginMutationGuard(portalConfig);
+
+    await expect(guard.assertCompatiblePreSubmit(makePage("https://evil.com/login"))).rejects.toMatchObject({
+      safeSummary: LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.UNAUTHORIZED_LOGIN_PAGE,
+    });
+  });
+
+  it("validates required pre-submit controls when assertCompatiblePreSubmit is called directly", async () => {
+    const page = makePage("https://ib.bpd.com.do/login", credentialControlSelectors);
+    const guard = new LoginMutationGuard(portalConfig);
+
+    await expect(guard.assertCompatiblePreSubmit(page)).rejects.toMatchObject({
+      safeSummary: LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.MISSING_REQUIRED_LOGIN_CONTROL,
+    });
+  });
+
+  it("uses typed errors with fixed safe summaries", async () => {
+    const guard = new LoginMutationGuard(portalConfig);
+    const rejection = guard.beforeSubmit(makePage("https://evil.com/login"));
+
+    await expect(rejection).rejects.toBeInstanceOf(LoginMutationGuardError);
+    await expect(rejection).rejects.toMatchObject({
+      safeSummary: LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.UNAUTHORIZED_LOGIN_PAGE,
+    });
+  });
+
+  it.each([
+    ["currentUrl", {
+      async currentUrl(): Promise<string> { throw new Error("browser leaked https://evil.example/login?password=secret"); },
+      async hasVisibleSelector(): Promise<boolean> { return true; },
+    }],
+    ["hasVisibleSelector", {
+      async currentUrl(): Promise<string> { return "https://ib.bpd.com.do/login"; },
+      async hasVisibleSelector(selector: string): Promise<boolean> { throw new Error(`selector leaked ${selector} with internal diagnostics`); },
+    }],
+  ] as const)("translates %s failures to a fixed safe guard error", async (_operation, page) => {
+    const guard = new LoginMutationGuard(portalConfig);
+    const rejection = guard.beforeFill(page);
+
+    await expect(rejection).rejects.toBeInstanceOf(LoginMutationGuardError);
+    await expect(rejection).rejects.toMatchObject({
+      outcome: "needs_admin_action",
+      reason: "portal_state_unavailable",
+      safeSummary: LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.PORTAL_STATE_UNAVAILABLE,
+    });
+    await expect(rejection).rejects.toThrow(LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.PORTAL_STATE_UNAVAILABLE);
+  });
+});

--- a/src/worker/scraper/login-mutation-guard.test.ts
+++ b/src/worker/scraper/login-mutation-guard.test.ts
@@ -1,12 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import {
-  LoginMutationGuard,
-  LoginMutationGuardError,
-  LOGIN_MUTATION_GUARD_ERROR_SUMMARIES,
-  type BankPortalConfig,
-  type LoginMutationPage,
-} from "./login-mutation-guard";
+import { LOGIN_MUTATION_GUARD_ERROR_SUMMARIES, LoginMutationGuard, LoginMutationGuardError, type BankPortalConfig, type LoginMutationPage } from "./login-mutation-guard";
 
 const portalConfig: BankPortalConfig = {
   bankCode: "popular",
@@ -25,23 +19,14 @@ const allLoginControlSelectors = [...credentialControlSelectors, portalConfig.su
 
 function makePage(url: string, visibleSelectors: readonly string[] = []): LoginMutationPage {
   return {
-    async currentUrl() {
-      return url;
-    },
-    async hasVisibleSelector(selector) {
-      return visibleSelectors.includes(selector);
-    },
+    async currentUrl() { return url; },
+    async hasVisibleSelector(selector) { return visibleSelectors.includes(selector); },
   };
 }
 
-async function guardedSubmit(
-  guard: LoginMutationGuard,
-  page: LoginMutationPage,
-  fill: () => void,
-  submit: () => void,
-): Promise<void> {
+async function guardedSubmit(guard: LoginMutationGuard, page: LoginMutationPage, fill: () => void | Promise<void>, submit: () => void): Promise<void> {
   await guard.beforeFill(page);
-  fill();
+  await fill();
   await guard.beforeSubmit(page);
   submit();
 }
@@ -51,23 +36,44 @@ describe("LoginMutationGuard", () => {
     ["rejects http portal URLs", "http://ib.bpd.com.do/login"],
     ["rejects subdomain lookalikes", "https://ib.bpd.com.do.evil.com/login"],
     ["rejects userinfo tricks", "https://ib.bpd.com.do@evil.com/login"],
+    ["rejects userinfo on the allowed origin", "https://evil.example@ib.bpd.com.do/login"],
     ["rejects port mismatches", "https://ib.bpd.com.do:8443/login"],
     ["rejects paths outside the allowlist", "https://ib.bpd.com.do/dashboard"],
   ])("%s", async (_caseName, url) => {
     const guard = new LoginMutationGuard(portalConfig);
 
-    await expect(guard.assertLoginPage(makePage(url))).rejects.toMatchObject({
+    await expect(guard.beforeFill(makePage(url, allLoginControlSelectors))).rejects.toMatchObject({
       outcome: "needs_admin_action",
       safeSummary: LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.UNAUTHORIZED_LOGIN_PAGE,
     });
   });
 
-  it("rejects malformed URLs with a fixed safe summary", async () => {
+  it("rejects malformed URLs with a typed fixed safe error", async () => {
     const guard = new LoginMutationGuard(portalConfig);
+    const rejection = guard.beforeFill(makePage("not a url with secret=password", allLoginControlSelectors));
 
-    await expect(guard.assertLoginPage(makePage("not a url with secret=password"))).rejects.toMatchObject({
-      safeSummary: LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.MALFORMED_PORTAL_URL,
-    });
+    await expect(rejection).rejects.toBeInstanceOf(LoginMutationGuardError);
+    await expect(rejection).rejects.toMatchObject({ message: LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.MALFORMED_PORTAL_URL, reason: "malformed_url", safeSummary: LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.MALFORMED_PORTAL_URL });
+  });
+
+  it.each([
+    ["baseUrl userinfo", { ...portalConfig, baseUrl: "https://evil.example@ib.bpd.com.do/login" }, LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.MALFORMED_PORTAL_URL],
+    ["missing username selector", { ...portalConfig, usernameSelector: undefined }, LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.PORTAL_STATE_UNAVAILABLE],
+    ["missing password selector", { ...portalConfig, passwordSelector: undefined }, LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.PORTAL_STATE_UNAVAILABLE],
+    ["missing submit selector", { ...portalConfig, submitSelector: undefined }, LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.PORTAL_STATE_UNAVAILABLE],
+    ["blank username selector", { ...portalConfig, usernameSelector: " \t " }, LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.PORTAL_STATE_UNAVAILABLE],
+    ["blank password selector", { ...portalConfig, passwordSelector: "\n" }, LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.PORTAL_STATE_UNAVAILABLE],
+    ["blank submit selector", { ...portalConfig, submitSelector: "" }, LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.PORTAL_STATE_UNAVAILABLE],
+    ["missing MFA detector", { ...portalConfig, mfaIndicatorSelector: undefined }, LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.PORTAL_STATE_UNAVAILABLE],
+    ["missing incompatible-flow detector", { ...portalConfig, incompatibleFlowSelector: undefined }, LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.PORTAL_STATE_UNAVAILABLE],
+    ["blank MFA detector", { ...portalConfig, mfaIndicatorSelector: " \t " }, LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.PORTAL_STATE_UNAVAILABLE],
+    ["blank incompatible-flow detector", { ...portalConfig, incompatibleFlowSelector: "\n" }, LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.PORTAL_STATE_UNAVAILABLE],
+    ["missing login path allowlist", { ...portalConfig, loginPathAllowlist: undefined }, LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.PORTAL_STATE_UNAVAILABLE],
+    ["empty login path allowlist", { ...portalConfig, loginPathAllowlist: [] }, LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.PORTAL_STATE_UNAVAILABLE],
+    ["blank login path allowlist entry", { ...portalConfig, loginPathAllowlist: [""] }, LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.PORTAL_STATE_UNAVAILABLE],
+    ["whitespace login path allowlist entry", { ...portalConfig, loginPathAllowlist: [" \t "] }, LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.PORTAL_STATE_UNAVAILABLE],
+  ] as const)("fails closed when config has %s", (_caseName, config, safeSummary) => {
+    expect(() => new LoginMutationGuard(config as unknown as BankPortalConfig)).toThrow(safeSummary);
   });
 
   it("runs fill and submit when the login URL and controls are authorized", async () => {
@@ -82,16 +88,20 @@ describe("LoginMutationGuard", () => {
     expect(submit).toHaveBeenCalledOnce();
   });
 
-  it("re-checks before submit and catches redirect/navigation after fill", async () => {
+  it("awaits async fill before submit re-checks and catches navigation drift", async () => {
     let currentUrl = "https://ib.bpd.com.do/login";
+    const events: string[] = [];
     const visibleSelectors = new Set<string>(allLoginControlSelectors);
     const page: LoginMutationPage = {
-      async currentUrl() { return currentUrl; },
+      async currentUrl() { events.push(`url:${currentUrl}`); return currentUrl; },
       async hasVisibleSelector(selector) { return visibleSelectors.has(selector); },
     };
     const guard = new LoginMutationGuard(portalConfig);
-    const fill = vi.fn(() => {
+    const fill = vi.fn(async () => {
+      events.push("fill:start");
+      await Promise.resolve();
       currentUrl = "https://evil.com/login";
+      events.push("fill:end");
     });
     const submit = vi.fn();
 
@@ -101,17 +111,22 @@ describe("LoginMutationGuard", () => {
 
     expect(fill).toHaveBeenCalledOnce();
     expect(submit).not.toHaveBeenCalled();
+    expect(events).toEqual(["url:https://ib.bpd.com.do/login", "fill:start", "fill:end", "url:https://evil.com/login"]);
   });
 
-  it("blocks incompatible pre-submit flows before caller mutations run", async () => {
-    const page = makePage("https://ib.bpd.com.do/login", ["[data-corporate-token]"]);
+  it.each([
+    ["incompatible pre-submit flows", ["[data-corporate-token]"], "incompatible_flow", LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.INCOMPATIBLE_FLOW],
+    ["MFA-protected pages", ["[data-mfa]"], "protected_flow", LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.PROTECTED_FLOW],
+  ] as const)("blocks %s before caller mutations run", async (_caseName, selectors, reason, safeSummary) => {
+    const page = makePage("https://ib.bpd.com.do/login", selectors);
     const guard = new LoginMutationGuard(portalConfig);
     const fill = vi.fn();
     const submit = vi.fn();
 
     await expect(guardedSubmit(guard, page, fill, submit)).rejects.toMatchObject({
       outcome: "needs_admin_action",
-      safeSummary: LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.INCOMPATIBLE_FLOW,
+      reason,
+      safeSummary,
     });
 
     expect(fill).not.toHaveBeenCalled();
@@ -119,10 +134,10 @@ describe("LoginMutationGuard", () => {
   });
 
   it.each([
-    ["username", [portalConfig.passwordSelector, portalConfig.submitSelector], 0],
-    ["password", [portalConfig.usernameSelector, portalConfig.submitSelector], 0],
-    ["submit", credentialControlSelectors, 0],
-  ] as const)("blocks guarded submission when the required %s control is missing", async (_controlName, selectors, fillCalls) => {
+    ["username", [portalConfig.passwordSelector, portalConfig.submitSelector]],
+    ["password", [portalConfig.usernameSelector, portalConfig.submitSelector]],
+    ["submit", credentialControlSelectors],
+  ] as const)("blocks guarded submission when the required %s control is missing", async (_controlName, selectors) => {
     const page = makePage("https://ib.bpd.com.do/login", selectors);
     const guard = new LoginMutationGuard(portalConfig);
     const fill = vi.fn();
@@ -134,41 +149,29 @@ describe("LoginMutationGuard", () => {
       safeSummary: LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.MISSING_REQUIRED_LOGIN_CONTROL,
     });
 
-    expect(fill).toHaveBeenCalledTimes(fillCalls);
-    expect(submit).not.toHaveBeenCalled();
-  });
-
-  it("blocks MFA-protected pages before caller mutations run", async () => {
-    const page = makePage("https://ib.bpd.com.do/login", ["[data-mfa]"]);
-    const guard = new LoginMutationGuard(portalConfig);
-    const fill = vi.fn();
-    const submit = vi.fn();
-
-    await expect(guardedSubmit(guard, page, fill, submit)).rejects.toMatchObject({
-      outcome: "needs_admin_action",
-      reason: "protected_flow",
-      safeSummary: LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.PROTECTED_FLOW,
-    });
-
     expect(fill).not.toHaveBeenCalled();
     expect(submit).not.toHaveBeenCalled();
   });
 
-  it("does not authorize submit when an MFA indicator appears after fill", async () => {
+  it.each([
+    ["MFA indicator", "[data-mfa]", "protected_flow", LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.PROTECTED_FLOW],
+    ["incompatible flow", "[data-corporate-token]", "incompatible_flow", LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.INCOMPATIBLE_FLOW],
+  ] as const)("does not authorize submit when %s appears after async fill", async (_caseName, selector, reason, safeSummary) => {
     const visibleSelectors = new Set<string>(allLoginControlSelectors);
     const page: LoginMutationPage = {
       async currentUrl() { return "https://ib.bpd.com.do/login"; },
       async hasVisibleSelector(selector) { return visibleSelectors.has(selector); },
     };
     const guard = new LoginMutationGuard(portalConfig);
-    const fill = vi.fn(() => {
-      visibleSelectors.add("[data-mfa]");
+    const fill = vi.fn(async () => {
+      await Promise.resolve();
+      visibleSelectors.add(selector);
     });
     const submit = vi.fn();
 
     await expect(guardedSubmit(guard, page, fill, submit)).rejects.toMatchObject({
-      reason: "protected_flow",
-      safeSummary: LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.PROTECTED_FLOW,
+      reason,
+      safeSummary,
     });
 
     expect(fill).toHaveBeenCalledOnce();

--- a/src/worker/scraper/login-mutation-guard.ts
+++ b/src/worker/scraper/login-mutation-guard.ts
@@ -1,0 +1,173 @@
+export interface BankPortalConfig {
+  // Foundation only: no production scraper caller yet; reserved metadata is non-authorizing.
+  bankCode?: string;
+  baseUrl: string;
+  loginPathAllowlist: readonly string[];
+  usernameSelector: string;
+  passwordSelector: string;
+  submitSelector: string;
+  mfaIndicatorSelector?: string;
+  incompatibleFlowSelector?: string;
+  dashboardPathIndicator?: string;
+}
+
+export interface LoginMutationPage {
+  currentUrl(): string | Promise<string>;
+  hasVisibleSelector(selector: string): boolean | Promise<boolean>;
+}
+
+export const LOGIN_MUTATION_GUARD_ERROR_SUMMARIES = {
+  MALFORMED_PORTAL_URL: "Bank portal URL is malformed",
+  UNAUTHORIZED_LOGIN_PAGE: "Bank login page is not authorized for credential mutation",
+  INCOMPATIBLE_FLOW: "Bank portal requires admin action before credential submission",
+  PROTECTED_FLOW: "Bank portal requires admin action before credential submission",
+  MISSING_REQUIRED_LOGIN_CONTROL: "Bank login page is missing required login controls",
+  PORTAL_STATE_UNAVAILABLE: "Bank portal state could not be verified",
+} as const;
+
+export type LoginMutationGuardSafeSummary =
+  (typeof LOGIN_MUTATION_GUARD_ERROR_SUMMARIES)[keyof typeof LOGIN_MUTATION_GUARD_ERROR_SUMMARIES];
+
+export type LoginMutationGuardReason =
+  | "malformed_url"
+  | "unauthorized_login_page"
+  | "incompatible_flow"
+  | "protected_flow"
+  | "missing_required_login_control"
+  | "portal_state_unavailable";
+
+export class LoginMutationGuardError extends Error {
+  readonly outcome = "needs_admin_action" as const;
+
+  constructor(
+    readonly reason: LoginMutationGuardReason,
+    readonly safeSummary: LoginMutationGuardSafeSummary,
+  ) {
+    super(safeSummary);
+    this.name = "LoginMutationGuardError";
+  }
+}
+
+export class LoginMutationGuard {
+  private readonly allowedOrigin: string;
+  private readonly allowedLoginPaths: ReadonlySet<string>;
+
+  constructor(private readonly config: BankPortalConfig) {
+    const baseUrl = parseSafeUrl(config.baseUrl);
+    if (!baseUrl || baseUrl.protocol !== "https:") {
+      throw new LoginMutationGuardError(
+        "malformed_url",
+        LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.MALFORMED_PORTAL_URL,
+      );
+    }
+
+    this.allowedOrigin = baseUrl.origin;
+    this.allowedLoginPaths = new Set(config.loginPathAllowlist.map(normalizeAllowedPath));
+  }
+
+  async assertLoginPage(page: LoginMutationPage): Promise<void> {
+    const currentUrl = parseSafeUrl(await this.currentUrl(page));
+    if (!currentUrl) {
+      throw new LoginMutationGuardError(
+        "malformed_url",
+        LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.MALFORMED_PORTAL_URL,
+      );
+    }
+
+    if (
+      currentUrl.protocol !== "https:" ||
+      currentUrl.origin !== this.allowedOrigin ||
+      !this.allowedLoginPaths.has(currentUrl.pathname)
+    ) {
+      throw new LoginMutationGuardError(
+        "unauthorized_login_page",
+        LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.UNAUTHORIZED_LOGIN_PAGE,
+      );
+    }
+  }
+
+  async beforeFill(page: LoginMutationPage): Promise<void> {
+    await this.assertSafeLoginState(page);
+    await this.assertRequiredControls(page, [this.config.usernameSelector, this.config.passwordSelector, this.config.submitSelector]);
+  }
+
+  async beforeSubmit(page: LoginMutationPage): Promise<void> {
+    await this.assertCompatiblePreSubmit(page);
+  }
+
+  async assertCompatiblePreSubmit(page: LoginMutationPage): Promise<void> {
+    await this.assertSafeLoginState(page);
+    await this.assertRequiredControls(page, [
+      this.config.usernameSelector,
+      this.config.passwordSelector,
+      this.config.submitSelector,
+    ]);
+  }
+
+  private async assertSafeLoginState(page: LoginMutationPage): Promise<void> {
+    await this.assertLoginPage(page);
+
+    if (this.config.mfaIndicatorSelector && (await this.hasVisibleSelector(page, this.config.mfaIndicatorSelector))) {
+      throw new LoginMutationGuardError(
+        "protected_flow",
+        LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.PROTECTED_FLOW,
+      );
+    }
+
+    if (!this.config.incompatibleFlowSelector) return;
+
+    if (await this.hasVisibleSelector(page, this.config.incompatibleFlowSelector)) {
+      throw new LoginMutationGuardError(
+        "incompatible_flow",
+        LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.INCOMPATIBLE_FLOW,
+      );
+    }
+  }
+
+  private async assertRequiredControls(page: LoginMutationPage, selectors: readonly string[]): Promise<void> {
+    for (const selector of selectors) {
+      if (await this.hasVisibleSelector(page, selector)) continue;
+
+      throw new LoginMutationGuardError(
+        "missing_required_login_control",
+        LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.MISSING_REQUIRED_LOGIN_CONTROL,
+      );
+    }
+  }
+
+  private async currentUrl(page: LoginMutationPage): Promise<string> {
+    try {
+      return await page.currentUrl();
+    } catch {
+      throw createPortalStateUnavailableError();
+    }
+  }
+
+  private async hasVisibleSelector(page: LoginMutationPage, selector: string): Promise<boolean> {
+    try {
+      return await page.hasVisibleSelector(selector);
+    } catch {
+      throw createPortalStateUnavailableError();
+    }
+  }
+}
+
+function createPortalStateUnavailableError(): LoginMutationGuardError {
+  return new LoginMutationGuardError(
+    "portal_state_unavailable",
+    LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.PORTAL_STATE_UNAVAILABLE,
+  );
+}
+
+function parseSafeUrl(rawUrl: string): URL | null {
+  try {
+    return new URL(rawUrl);
+  } catch {
+    return null;
+  }
+}
+
+function normalizeAllowedPath(path: string): string {
+  if (!path.startsWith("/")) return `/${path}`;
+  return path;
+}

--- a/src/worker/scraper/login-mutation-guard.ts
+++ b/src/worker/scraper/login-mutation-guard.ts
@@ -6,8 +6,8 @@ export interface BankPortalConfig {
   usernameSelector: string;
   passwordSelector: string;
   submitSelector: string;
-  mfaIndicatorSelector?: string;
-  incompatibleFlowSelector?: string;
+  mfaIndicatorSelector: string;
+  incompatibleFlowSelector: string;
   dashboardPathIndicator?: string;
 }
 
@@ -54,18 +54,25 @@ export class LoginMutationGuard {
 
   constructor(private readonly config: BankPortalConfig) {
     const baseUrl = parseSafeUrl(config.baseUrl);
-    if (!baseUrl || baseUrl.protocol !== "https:") {
+    if (!baseUrl || baseUrl.protocol !== "https:" || hasUserInfo(baseUrl)) {
       throw new LoginMutationGuardError(
         "malformed_url",
         LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.MALFORMED_PORTAL_URL,
       );
     }
 
+    const requiredSelectors = [config.usernameSelector, config.passwordSelector, config.submitSelector, config.mfaIndicatorSelector, config.incompatibleFlowSelector];
+    if (!requiredSelectors.every(hasNonBlankString)) {
+      throw createPortalStateUnavailableError();
+    }
+
+    const loginPathAllowlist = config.loginPathAllowlist;
+    if (!Array.isArray(loginPathAllowlist) || loginPathAllowlist.length === 0 || !loginPathAllowlist.every(hasNonBlankString)) throw createPortalStateUnavailableError();
     this.allowedOrigin = baseUrl.origin;
-    this.allowedLoginPaths = new Set(config.loginPathAllowlist.map(normalizeAllowedPath));
+    this.allowedLoginPaths = new Set(loginPathAllowlist.map(normalizeAllowedPath));
   }
 
-  async assertLoginPage(page: LoginMutationPage): Promise<void> {
+  private async assertAuthorizedLoginUrl(page: LoginMutationPage): Promise<void> {
     const currentUrl = parseSafeUrl(await this.currentUrl(page));
     if (!currentUrl) {
       throw new LoginMutationGuardError(
@@ -77,6 +84,7 @@ export class LoginMutationGuard {
     if (
       currentUrl.protocol !== "https:" ||
       currentUrl.origin !== this.allowedOrigin ||
+      hasUserInfo(currentUrl) ||
       !this.allowedLoginPaths.has(currentUrl.pathname)
     ) {
       throw new LoginMutationGuardError(
@@ -97,24 +105,18 @@ export class LoginMutationGuard {
 
   async assertCompatiblePreSubmit(page: LoginMutationPage): Promise<void> {
     await this.assertSafeLoginState(page);
-    await this.assertRequiredControls(page, [
-      this.config.usernameSelector,
-      this.config.passwordSelector,
-      this.config.submitSelector,
-    ]);
+    await this.assertRequiredControls(page, [this.config.usernameSelector, this.config.passwordSelector, this.config.submitSelector]);
   }
 
   private async assertSafeLoginState(page: LoginMutationPage): Promise<void> {
-    await this.assertLoginPage(page);
+    await this.assertAuthorizedLoginUrl(page);
 
-    if (this.config.mfaIndicatorSelector && (await this.hasVisibleSelector(page, this.config.mfaIndicatorSelector))) {
+    if (await this.hasVisibleSelector(page, this.config.mfaIndicatorSelector)) {
       throw new LoginMutationGuardError(
         "protected_flow",
         LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.PROTECTED_FLOW,
       );
     }
-
-    if (!this.config.incompatibleFlowSelector) return;
 
     if (await this.hasVisibleSelector(page, this.config.incompatibleFlowSelector)) {
       throw new LoginMutationGuardError(
@@ -153,10 +155,7 @@ export class LoginMutationGuard {
 }
 
 function createPortalStateUnavailableError(): LoginMutationGuardError {
-  return new LoginMutationGuardError(
-    "portal_state_unavailable",
-    LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.PORTAL_STATE_UNAVAILABLE,
-  );
+  return new LoginMutationGuardError("portal_state_unavailable", LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.PORTAL_STATE_UNAVAILABLE);
 }
 
 function parseSafeUrl(rawUrl: string): URL | null {
@@ -167,7 +166,6 @@ function parseSafeUrl(rawUrl: string): URL | null {
   }
 }
 
-function normalizeAllowedPath(path: string): string {
-  if (!path.startsWith("/")) return `/${path}`;
-  return path;
-}
+function hasUserInfo(url: URL): boolean { return url.username.length > 0 || url.password.length > 0; }
+function hasNonBlankString(value: unknown): value is string { return typeof value === "string" && value.trim().length > 0; }
+function normalizeAllowedPath(path: string): string { return path.startsWith("/") ? path : `/${path}`; }


### PR DESCRIPTION
## Summary

- Adds a foundation-only LoginMutationGuard for future auto-login state-machine use.
- Fails closed for invalid/moved/protected/incompatible/missing-control/page-operation-failure portal states.
- Adds behavior tests proving guarded success and guarded rejection boundaries; no production wiring added.

## Scope

- src/worker/scraper/login-mutation-guard.ts
- src/worker/scraper/login-mutation-guard.test.ts

## Out of scope

- Auto-login state machine.
- Scraper/consumer/admin/UI wiring.
- Real bank portal configs.
- Credential fill/submit/decryption.
- MFA/CAPTCHA/security-question/third-party protection automation or bypass.
- OpenSpec task 4.4 checkbox; tasks.md combines guard + state machine, so PR4.4b must complete it.

## Verification

- Targeted guard test passed: 19/19.
- pnpm test passed during apply: 947 passed, 38 skipped.
- pnpm typecheck passed.
- pnpm lint passed.
- git diff --check passed.
- Fresh 4R pre-commit final: R1/R2/R3/R4 no findings.

## Review budget

- 2 files, 399 additions. Under the 400-line budget.

## Chain context

- Base: feature/multi-bank-auto-login.
- Previous PR4.3 slices merged: #23, #25, #24.
- Next planned slice: PR4.4b auto-login state machine core.

## HIGH RISK note

PR4 slices require fresh 4R review + Judgment Day before merge. This PR has pre-commit 4R clean, but still needs PR-level review + Judgment Day before merge.