### PR TITLE
feat(scraper): add auto-login state machine (PR4.4b)

### DIFF
--- a/openspec/changes/multi-bank-auto-login/tasks.md
+++ b/openspec/changes/multi-bank-auto-login/tasks.md
@@ -94,7 +94,7 @@ Gate: full gates + FRESH 4R review + Judgment Day before merge; PR3B1 <=400 line
 - [x] 4.1c Wire `LockStore` Redis adapter into production `createAutoLoginLock` calls via DI/config.
 - [x] 4.2 `prisma/schema.prisma`: add `BankAutoLoginConfig` (`autoLoginEnabled` default false; breaker `closed|open` only, NO half_open) + `BankAdapterConfig` (`scrapingEnabled` default true); migration.
 - [x] 4.3 Create `src/modules/bank-auto-login-config/` + `src/modules/bank-adapter-config/`: repos + conservative breaker policy (3 failures/30min->open, NO half-open, manual admin reset only clears window, alert on open + <=every 30min).
-- [ ] 4.4 Create `src/worker/scraper/auto-login.ts`: `BankAutoLoginStrategy` state machine + `LoginMutationGuard` (HTTPS + exact origin + login-path allowlist, re-check before fill AND submit, `assertCompatiblePreSubmit`).
+- [x] 4.4 Create `src/worker/scraper/auto-login.ts`: `BankAutoLoginStrategy` state machine + `LoginMutationGuard` (HTTPS + exact origin + login-path allowlist, re-check before fill AND submit, `assertCompatiblePreSubmit`).
 - [ ] 4.5 Wire scrape-time canonical trigger: expired->assert `adapter.bankCode===credential.bankCode`->`assertCdpLoopback`->acquire lock (or skip->manual)->ensureBrowser (or throttled)->login->detect(dashboard|mfa|unknown|redirect|incompatible)->success|needs_admin_action->owner release.
 - [ ] 4.6 Modify `src/modules/bank-sessions/index.ts`: `expired` assigns/retains `expiredEventId` (UUID until restore), records/alerts/schedules only (NO credential submission).
 - [ ] 4.7 Enable Popular: register `createAutoLoginStrategy`, set `autoLoginEnabled=true` (gated); Popular portal-drift fixture (incompatible pre-submit asserts NO fill/submit + post-submit unknown).

--- a/src/worker/scraper/auto-login.test.ts
+++ b/src/worker/scraper/auto-login.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createBankAutoLoginStrategy, type BankAutoLoginPage } from "./auto-login";
+import type { BankPortalConfig } from "./login-mutation-guard";
+
+const portalConfig: BankPortalConfig = {
+  bankCode: "popular",
+  baseUrl: "https://ib.bpd.com.do",
+  loginPathAllowlist: ["/login"],
+  usernameSelector: "#username",
+  passwordSelector: "#password",
+  submitSelector: "button[type='submit']",
+  mfaIndicatorSelector: "[data-mfa]",
+  incompatibleFlowSelector: "[data-token]",
+  dashboardPathIndicator: "/dashboard",
+};
+
+const loginControls = [portalConfig.usernameSelector, portalConfig.passwordSelector, portalConfig.submitSelector] as const;
+const credential = { bankCode: "popular", username: "bank-user", password: "bank-password" };
+type TestBankAutoLoginPage = BankAutoLoginPage & { setUrl(nextUrl: string): void; show(selector: string): void };
+
+function makePage(options: { url?: string; visible?: readonly string[]; onFill?: (selector: string, value: string) => void; onClick?: () => void } = {}): TestBankAutoLoginPage {
+  let url = options.url ?? "https://ib.bpd.com.do/login";
+  const visible = new Set(options.visible ?? loginControls);
+  return {
+    async currentUrl() { return url; },
+    async hasVisibleSelector(selector) { return visible.has(selector); },
+    async fill(selector, value) { options.onFill?.(selector, value); },
+    async click() {
+      if (options.onClick) options.onClick();
+      else url = "https://ib.bpd.com.do/dashboard";
+    },
+    setUrl(nextUrl: string) { url = nextUrl; },
+    show(selector: string) { visible.add(selector); },
+  };
+}
+
+describe("createBankAutoLoginStrategy", () => {
+  it("fills and submits only after the guard authorizes both boundaries", async () => {
+    const fill = vi.fn();
+    const page = makePage({ onFill: fill });
+    const click = vi.spyOn(page, "click");
+    const strategy = createBankAutoLoginStrategy(portalConfig, { supportedBankCodes: ["popular"] });
+
+    await expect(strategy.autoLogin({ credential, page })).resolves.toEqual({ status: "succeeded" });
+    expect(fill.mock.calls).toEqual([["#username", "bank-user"], ["#password", "bank-password"]]);
+    expect(click).toHaveBeenCalledWith("button[type='submit']");
+  });
+
+  it("fails closed for an unsupported explicit bank without filling credentials", async () => {
+    const fill = vi.fn();
+    const click = vi.fn();
+    const strategy = createBankAutoLoginStrategy({ ...portalConfig, bankCode: "unknown-bank" }, { supportedBankCodes: ["popular"] });
+
+    await expect(strategy.autoLogin({ credential: { ...credential, bankCode: "unknown-bank" }, page: makePage({ onFill: fill, onClick: click }) })).resolves.toMatchObject({
+      status: "needs_admin_action",
+      reason: "unsupported_bank",
+    });
+    expect(fill).not.toHaveBeenCalled();
+    expect(click).not.toHaveBeenCalled();
+  });
+
+  it("fails closed for a credential-bank mismatch without filling credentials", async () => {
+    const fill = vi.fn();
+    const click = vi.fn();
+    const strategy = createBankAutoLoginStrategy(portalConfig);
+
+    await expect(strategy.autoLogin({ credential: { ...credential, bankCode: "bhd" }, page: makePage({ onFill: fill, onClick: click }) })).resolves.toMatchObject({
+      status: "needs_admin_action",
+      reason: "credential_bank_mismatch",
+    });
+    expect(fill).not.toHaveBeenCalled();
+    expect(click).not.toHaveBeenCalled();
+  });
+
+  it("returns safe admin-action outcomes and never submits when pre-submit state is unsafe", async () => {
+    const cases = [
+      { visible: [portalConfig.incompatibleFlowSelector, ...loginControls], reason: "incompatible_flow" },
+      { visible: [portalConfig.mfaIndicatorSelector, ...loginControls], reason: "protected_flow" },
+      { visible: [portalConfig.usernameSelector, portalConfig.submitSelector], reason: "missing_required_login_control" },
+    ] as const;
+    const strategy = createBankAutoLoginStrategy(portalConfig);
+
+    for (const unsafeCase of cases) {
+      const fill = vi.fn();
+      const click = vi.fn();
+      const result = await strategy.autoLogin({ credential, page: makePage({ visible: unsafeCase.visible, onFill: fill, onClick: click }) });
+
+      expect(result).toMatchObject({ status: "needs_admin_action", reason: unsafeCase.reason });
+      expect(fill).not.toHaveBeenCalled();
+      expect(click).not.toHaveBeenCalled();
+    }
+  });
+
+  it("re-checks the guard before password fill so redirects cannot receive passwords", async () => {
+    let setPageUrl: (nextUrl: string) => void = () => undefined;
+    const fill = vi.fn((selector: string) => {
+      if (selector === portalConfig.usernameSelector) setPageUrl("https://evil.example/login");
+    });
+    const page = makePage({ onFill: fill });
+    setPageUrl = page.setUrl;
+    const click = vi.spyOn(page, "click");
+
+    await expect(createBankAutoLoginStrategy(portalConfig).autoLogin({ credential, page })).resolves.toMatchObject({
+      status: "needs_admin_action",
+      reason: "unauthorized_login_page",
+    });
+    expect(fill.mock.calls).toEqual([["#username", "bank-user"]]);
+    expect(click).not.toHaveBeenCalled();
+  });
+
+  it("re-checks the guard before submit so redirects after password fill cannot submit credentials", async () => {
+    let setPageUrl: (nextUrl: string) => void = () => undefined;
+    const fill = vi.fn((selector: string) => {
+      if (selector === portalConfig.passwordSelector) setPageUrl("https://evil.example/login");
+    });
+    const page = makePage({ onFill: fill });
+    setPageUrl = page.setUrl;
+    const click = vi.spyOn(page, "click");
+
+    await expect(createBankAutoLoginStrategy(portalConfig).autoLogin({ credential, page })).resolves.toMatchObject({
+      status: "needs_admin_action",
+      reason: "unauthorized_login_page",
+    });
+    expect(fill.mock.calls).toEqual([["#username", "bank-user"], ["#password", "bank-password"]]);
+    expect(click).not.toHaveBeenCalled();
+  });
+
+  it("does not treat external or non-HTTPS dashboard redirects as success", async () => {
+    const cases = ["https://evil.example/dashboard", "http://ib.bpd.com.do/dashboard", "https://user@ib.bpd.com.do/dashboard"];
+
+    for (const redirectedUrl of cases) {
+      const page = makePage({ onClick: () => page.setUrl(redirectedUrl) });
+
+      await expect(createBankAutoLoginStrategy(portalConfig).autoLogin({ credential, page })).resolves.toMatchObject({
+        status: "needs_admin_action",
+        reason: "unknown_post_submit_state",
+      });
+    }
+  });
+
+  it("maps malformed portal config and browser mutation failures to safe admin action", async () => {
+    await expect(createBankAutoLoginStrategy({ ...portalConfig, baseUrl: "not-a-url" }).autoLogin({ credential, page: makePage() })).resolves.toMatchObject({
+      status: "needs_admin_action",
+      reason: "malformed_url",
+    });
+
+    const fillFailurePage = makePage();
+    vi.spyOn(fillFailurePage, "fill").mockRejectedValueOnce(new Error("browser fill failed"));
+    await expect(createBankAutoLoginStrategy(portalConfig).autoLogin({ credential, page: fillFailurePage })).resolves.toMatchObject({
+      status: "needs_admin_action",
+      reason: "portal_state_unavailable",
+    });
+
+    const clickFailurePage = makePage();
+    vi.spyOn(clickFailurePage, "click").mockRejectedValueOnce(new Error("browser click failed"));
+    await expect(createBankAutoLoginStrategy(portalConfig).autoLogin({ credential, page: clickFailurePage })).resolves.toMatchObject({
+      status: "needs_admin_action",
+      reason: "portal_state_unavailable",
+    });
+  });
+
+  it("maps post-submit protected and unknown portal states to safe admin action", async () => {
+    const mfaPage = makePage({ onClick: () => mfaPage.show(portalConfig.mfaIndicatorSelector) });
+    const unknownPage = makePage({ onClick: () => unknownPage.setUrl("https://ib.bpd.com.do/unexpected") });
+    const strategy = createBankAutoLoginStrategy(portalConfig);
+
+    await expect(strategy.autoLogin({ credential, page: mfaPage })).resolves.toMatchObject({ status: "needs_admin_action", reason: "protected_flow" });
+    await expect(strategy.autoLogin({ credential, page: unknownPage })).resolves.toMatchObject({ status: "needs_admin_action", reason: "unknown_post_submit_state" });
+  });
+});

--- a/src/worker/scraper/auto-login.test.ts
+++ b/src/worker/scraper/auto-login.test.ts
@@ -139,6 +139,21 @@ describe("createBankAutoLoginStrategy", () => {
     }
   });
 
+  it("does not treat dashboard path prefix collisions as success", async () => {
+    const page = makePage({ onClick: () => page.setUrl("https://ib.bpd.com.do/dashboardevil") });
+
+    await expect(createBankAutoLoginStrategy(portalConfig).autoLogin({ credential, page })).resolves.toMatchObject({
+      status: "needs_admin_action",
+      reason: "unknown_post_submit_state",
+    });
+  });
+
+  it("treats dashboard subpaths as success", async () => {
+    const page = makePage({ onClick: () => page.setUrl("https://ib.bpd.com.do/dashboard/accounts") });
+
+    await expect(createBankAutoLoginStrategy(portalConfig).autoLogin({ credential, page })).resolves.toEqual({ status: "succeeded" });
+  });
+
   it("maps malformed portal config and browser mutation failures to safe admin action", async () => {
     await expect(createBankAutoLoginStrategy({ ...portalConfig, baseUrl: "not-a-url" }).autoLogin({ credential, page: makePage() })).resolves.toMatchObject({
       status: "needs_admin_action",

--- a/src/worker/scraper/auto-login.ts
+++ b/src/worker/scraper/auto-login.ts
@@ -103,7 +103,7 @@ async function detectPostSubmitOutcome(page: BankAutoLoginPage, config: BankPort
       !hasUserInfo(baseUrl) &&
       !hasUserInfo(currentUrl) &&
       config.dashboardPathIndicator &&
-      currentUrl.pathname.startsWith(config.dashboardPathIndicator)
+      hasDashboardPathBoundary(currentUrl.pathname, config.dashboardPathIndicator)
     ) {
       return { status: "succeeded" };
     }
@@ -140,4 +140,5 @@ function needsAdminAction(reason: BankAutoLoginAdminActionReason, safeSummary = 
 }
 
 function hasNonBlankString(value: unknown): value is string { return typeof value === "string" && value.trim().length > 0; }
+function hasDashboardPathBoundary(pathname: string, dashboardPathIndicator: string): boolean { return pathname === dashboardPathIndicator || pathname.startsWith(`${dashboardPathIndicator}/`); }
 function hasUserInfo(url: URL): boolean { return url.username.length > 0 || url.password.length > 0; }

--- a/src/worker/scraper/auto-login.ts
+++ b/src/worker/scraper/auto-login.ts
@@ -1,0 +1,143 @@
+import { LOGIN_MUTATION_GUARD_ERROR_SUMMARIES, LoginMutationGuard, LoginMutationGuardError, type BankPortalConfig, type LoginMutationPage } from "./login-mutation-guard";
+
+export interface BankAutoLoginCredential {
+  bankCode: string;
+  username: string;
+  password: string;
+}
+
+export interface BankAutoLoginPage extends LoginMutationPage {
+  fill(selector: string, value: string): void | Promise<void>;
+  click(selector: string): void | Promise<void>;
+}
+
+export type BankAutoLoginAdminActionReason =
+  | "unsupported_bank"
+  | "credential_bank_mismatch"
+  | "incompatible_flow"
+  | "protected_flow"
+  | "missing_required_login_control"
+  | "portal_state_unavailable"
+  | "malformed_url"
+  | "unauthorized_login_page"
+  | "unknown_post_submit_state";
+
+export type BankAutoLoginOutcome =
+  | { status: "succeeded" }
+  | { status: "needs_admin_action"; reason: BankAutoLoginAdminActionReason; safeSummary: string };
+
+export interface BankAutoLoginStrategy {
+  readonly bankCode: string;
+  autoLogin(context: { credential: BankAutoLoginCredential; page: BankAutoLoginPage }): Promise<BankAutoLoginOutcome>;
+}
+
+const SAFE_ADMIN_ACTION_SUMMARY = "Bank auto-login requires admin action";
+
+export function createBankAutoLoginStrategy(
+  portalConfig: BankPortalConfig,
+  options: { supportedBankCodes?: readonly string[] } = {},
+): BankAutoLoginStrategy {
+  const bankCode = portalConfig.bankCode ?? "";
+  const supportedBankCodes = new Set(options.supportedBankCodes ?? [bankCode]);
+
+  return {
+    bankCode,
+    async autoLogin({ credential, page }) {
+      if (!bankCode || !supportedBankCodes.has(bankCode)) return needsAdminAction("unsupported_bank");
+      if (credential.bankCode !== bankCode) return needsAdminAction("credential_bank_mismatch");
+      if (!hasNonBlankString(portalConfig.dashboardPathIndicator)) return needsAdminAction("portal_state_unavailable");
+
+      const guardResult = createGuard(portalConfig);
+      if (guardResult.outcome) return guardResult.outcome;
+      const { guard } = guardResult;
+
+      const beforeUsernameFill = await runGuard(() => guard.beforeFill(page));
+      if (beforeUsernameFill) return beforeUsernameFill;
+      const usernameFill = await runBrowserMutation(() => page.fill(portalConfig.usernameSelector, credential.username));
+      if (usernameFill) return usernameFill;
+
+      const beforePasswordFill = await runGuard(() => guard.beforeFill(page));
+      if (beforePasswordFill) return beforePasswordFill;
+      const passwordFill = await runBrowserMutation(() => page.fill(portalConfig.passwordSelector, credential.password));
+      if (passwordFill) return passwordFill;
+
+      const beforeSubmit = await runGuard(() => guard.beforeSubmit(page));
+      if (beforeSubmit) return beforeSubmit;
+
+      const submit = await runBrowserMutation(() => page.click(portalConfig.submitSelector));
+      if (submit) return submit;
+      return detectPostSubmitOutcome(page, portalConfig);
+    },
+  };
+}
+
+type GuardResult = { guard: LoginMutationGuard; outcome?: never } | { guard?: never; outcome: BankAutoLoginOutcome };
+
+function createGuard(portalConfig: BankPortalConfig): GuardResult {
+  try {
+    return { guard: new LoginMutationGuard(portalConfig) };
+  } catch (error) {
+    if (error instanceof LoginMutationGuardError) return { outcome: needsAdminAction(error.reason, error.safeSummary) };
+    return { outcome: needsAdminAction("portal_state_unavailable") };
+  }
+}
+
+async function detectPostSubmitOutcome(page: BankAutoLoginPage, config: BankPortalConfig): Promise<BankAutoLoginOutcome> {
+  const guardedState = await runGuard(async () => {
+    if (await page.hasVisibleSelector(config.mfaIndicatorSelector)) {
+      throw new LoginMutationGuardError("protected_flow", LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.PROTECTED_FLOW);
+    }
+    if (await page.hasVisibleSelector(config.incompatibleFlowSelector)) {
+      throw new LoginMutationGuardError("incompatible_flow", LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.INCOMPATIBLE_FLOW);
+    }
+  });
+  if (guardedState) return guardedState;
+
+  try {
+    const baseUrl = new URL(config.baseUrl);
+    const currentUrl = new URL(await page.currentUrl());
+    if (
+      baseUrl.protocol === "https:" &&
+      currentUrl.protocol === "https:" &&
+      currentUrl.origin === baseUrl.origin &&
+      !hasUserInfo(baseUrl) &&
+      !hasUserInfo(currentUrl) &&
+      config.dashboardPathIndicator &&
+      currentUrl.pathname.startsWith(config.dashboardPathIndicator)
+    ) {
+      return { status: "succeeded" };
+    }
+  } catch {
+    return needsAdminAction("portal_state_unavailable");
+  }
+
+  return needsAdminAction("unknown_post_submit_state");
+}
+
+async function runBrowserMutation(operation: () => void | Promise<void>): Promise<BankAutoLoginOutcome | null> {
+  try {
+    await operation();
+    return null;
+  } catch {
+    return needsAdminAction("portal_state_unavailable");
+  }
+}
+
+async function runGuard(operation: () => Promise<void>): Promise<BankAutoLoginOutcome | null> {
+  try {
+    await operation();
+    return null;
+  } catch (error) {
+    if (error instanceof LoginMutationGuardError) {
+      return needsAdminAction(error.reason, error.safeSummary);
+    }
+    return needsAdminAction("portal_state_unavailable");
+  }
+}
+
+function needsAdminAction(reason: BankAutoLoginAdminActionReason, safeSummary = SAFE_ADMIN_ACTION_SUMMARY): BankAutoLoginOutcome {
+  return { status: "needs_admin_action", reason, safeSummary };
+}
+
+function hasNonBlankString(value: unknown): value is string { return typeof value === "string" && value.trim().length > 0; }
+function hasUserInfo(url: URL): boolean { return url.username.length > 0 || url.password.length > 0; }


### PR DESCRIPTION
## Summary

- Adds isolated createBankAutoLoginStrategy state-machine core for guarded credential mutation.
- Revalidates LoginMutationGuard before username fill, password fill, and submit.
- Marks OpenSpec task 4.4 complete now that PR4.4a guard and PR4.4b state machine are both present.

## Scope

- src/worker/scraper/auto-login.ts`n- src/worker/scraper/auto-login.test.ts`n- openspec/changes/multi-bank-auto-login/tasks.md`n
## Safety boundaries

- No production scraper/browser/runtime/admin/UI wiring.
- No real bank portal config or credentials.
- No MFA/CAPTCHA/security-question/anti-bot bypass.
- Fails closed for unsupported bank, credential-bank mismatch, malformed config, browser mutation failure, protected/incompatible flows, login drift, missing controls, and unknown post-submit state.
- Success requires HTTPS, expected origin, no userinfo, and configured dashboard path.

## Verification

- pnpm test — 95 files passed, 1 skipped; 973 tests passed, 38 skipped.
- pnpm lint — passed.
- pnpm typecheck — passed.
- git diff --check — passed with CRLF normalization warnings only.
- Fresh 4R pre-commit final — R1/R2/R3/R4 passed; only non-blocking suggestions.

## Review budget

- 3 files, 315 insertions / 1 deletion. Under the 400-line budget.

## Chain context

- Base: eature/multi-bank-auto-login.
- PR4.4a LoginMutationGuard merged in #26.
- Next planned slice: PR4.5 scrape-time trigger wiring.

## HIGH RISK note

PR4 slices require PR-level fresh 4R + Judgment Day before merge. This PR has pre-commit 4R clean but still needs PR-level review + Judgment Day before merge.