### PR TITLE
feat(scraper): add scrape-time auto-login trigger helper (PR4.5a)

### DIFF
--- a/src/worker/scraper/auto-login.test.ts
+++ b/src/worker/scraper/auto-login.test.ts
@@ -186,14 +186,30 @@ describe("createBankAutoLoginStrategy", () => {
 });
 
 describe("executeScrapeTimeAutoLoginTrigger", () => {
-  it("acquires the expired-event lock, runs browser login, and owner-releases on success", async () => {
+  it("acquires the expired-event lock, runs browser login, and awaits owner release after success", async () => {
     const page = makePage();
+    const events: string[] = [];
+    let releaseStartedResolve: () => void = () => undefined;
+    let releaseSettledResolve: (value: boolean) => void = () => undefined;
+    const releaseStarted = new Promise<void>((resolve) => { releaseStartedResolve = resolve; });
+    const releaseSettled = new Promise<boolean>((resolve) => { releaseSettledResolve = resolve; });
     const acquire = vi.fn().mockResolvedValue({ leaseToken: "lease-1", fencingToken: 7, expiresAt: 12345 });
-    const release = vi.fn().mockResolvedValue(true);
-    const autoLogin = vi.fn().mockResolvedValue({ status: "succeeded" });
-    const ensureBrowser = vi.fn().mockResolvedValue({ status: "ready", page });
+    const release = vi.fn(() => {
+      events.push("release started");
+      releaseStartedResolve();
+      return releaseSettled;
+    });
+    const autoLogin = vi.fn(() => Promise.resolve({ status: "succeeded" as const }).then((outcome) => {
+      events.push("autoLogin settled");
+      return outcome;
+    }));
+    const ensureBrowser = vi.fn(() => Promise.resolve({ status: "ready" as const, page }).then((browser) => {
+      events.push("ensureBrowser settled");
+      return browser;
+    }));
 
-    await expect(executeScrapeTimeAutoLoginTrigger({
+    let helperResolved = false;
+    const result = executeScrapeTimeAutoLoginTrigger({
       bankCode: "popular",
       expiredEventId: "E1",
       adapter: { bankCode: "popular", createAutoLoginStrategy: () => ({ bankCode: "popular", autoLogin }) },
@@ -201,12 +217,25 @@ describe("executeScrapeTimeAutoLoginTrigger", () => {
       cdpUrl: "http://127.0.0.1:9222",
       lock: { acquire, release },
       ensureBrowser,
-    })).resolves.toEqual({ status: "succeeded" });
+    }).then((outcome) => {
+      helperResolved = true;
+      events.push("helper resolved");
+      return outcome;
+    });
+
+    await releaseStarted;
+    await Promise.resolve();
+    expect(helperResolved).toBe(false);
+    expect(events).toEqual(["ensureBrowser settled", "autoLogin settled", "release started"]);
+
+    releaseSettledResolve(true);
+    await expect(result).resolves.toEqual({ status: "succeeded" });
 
     expect(acquire).toHaveBeenCalledWith("popular", "E1");
     expect(ensureBrowser).toHaveBeenCalledWith("http://127.0.0.1:9222");
     expect(autoLogin).toHaveBeenCalledWith({ credential, page });
     expect(release).toHaveBeenCalledWith("popular", "E1", "lease-1");
+    expect(events).toEqual(["ensureBrowser settled", "autoLogin settled", "release started", "helper resolved"]);
   });
 
   it("requires manual scraping when the same expired event lock is already held", async () => {
@@ -391,8 +420,9 @@ describe("executeScrapeTimeAutoLoginTrigger", () => {
     expect(release).toHaveBeenCalledWith("popular", "E1", "lease-1");
   });
 
-  it("does not let release failures leak raw infrastructure errors", async () => {
+  it("records safe release failure metadata without changing a successful outcome", async () => {
     const release = vi.fn().mockRejectedValue(new Error("Redis token=secret failed"));
+    const recordLockReleaseFailure = vi.fn().mockResolvedValue(undefined);
 
     await expect(executeScrapeTimeAutoLoginTrigger({
       bankCode: "popular",
@@ -402,6 +432,45 @@ describe("executeScrapeTimeAutoLoginTrigger", () => {
       cdpUrl: "http://127.0.0.1:9222",
       lock: { acquire: vi.fn().mockResolvedValue({ leaseToken: "lease-1", fencingToken: 7, expiresAt: 12345 }), release },
       ensureBrowser: vi.fn().mockResolvedValue({ status: "ready", page: makePage() }),
+      recordLockReleaseFailure,
     })).resolves.toEqual({ status: "succeeded" });
+
+    expect(recordLockReleaseFailure.mock.calls).toEqual([[{ bankCode: "popular", expiredEventId: "E1" }]]);
+  });
+
+  it("records safe release failure metadata when release resolves false", async () => {
+    const release = vi.fn().mockResolvedValue(false);
+    const recordLockReleaseFailure = vi.fn().mockResolvedValue(undefined);
+
+    await expect(executeScrapeTimeAutoLoginTrigger({
+      bankCode: "popular",
+      expiredEventId: "E1",
+      adapter: { bankCode: "popular", createAutoLoginStrategy: () => ({ bankCode: "popular", autoLogin: vi.fn().mockResolvedValue({ status: "succeeded" }) }) },
+      credential,
+      cdpUrl: "http://127.0.0.1:9222",
+      lock: { acquire: vi.fn().mockResolvedValue({ leaseToken: "lease-1", fencingToken: 7, expiresAt: 12345 }), release },
+      ensureBrowser: vi.fn().mockResolvedValue({ status: "ready", page: makePage() }),
+      recordLockReleaseFailure,
+    })).resolves.toEqual({ status: "succeeded" });
+
+    expect(recordLockReleaseFailure.mock.calls).toEqual([[{ bankCode: "popular", expiredEventId: "E1" }]]);
+  });
+
+  it("swallows release failure hook rejections without changing admin outcomes", async () => {
+    const release = vi.fn().mockRejectedValue(new Error("Redis token=secret failed"));
+    const recordLockReleaseFailure = vi.fn().mockRejectedValue(new Error("metrics token=secret failed"));
+
+    await expect(executeScrapeTimeAutoLoginTrigger({
+      bankCode: "popular",
+      expiredEventId: "E1",
+      adapter: { bankCode: "popular", createAutoLoginStrategy: () => ({ bankCode: "popular", autoLogin: vi.fn().mockResolvedValue({ status: "needs_admin_action", reason: "protected_flow", safeSummary: "MFA is required" }) }) },
+      credential,
+      cdpUrl: "http://127.0.0.1:9222",
+      lock: { acquire: vi.fn().mockResolvedValue({ leaseToken: "lease-1", fencingToken: 7, expiresAt: 12345 }), release },
+      ensureBrowser: vi.fn().mockResolvedValue({ status: "ready", page: makePage() }),
+      recordLockReleaseFailure,
+    })).resolves.toEqual({ status: "needs_admin_action", reason: "protected_flow", safeSummary: "MFA is required" });
+
+    expect(recordLockReleaseFailure.mock.calls).toEqual([[{ bankCode: "popular", expiredEventId: "E1" }]]);
   });
 });

--- a/src/worker/scraper/auto-login.test.ts
+++ b/src/worker/scraper/auto-login.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { createBankAutoLoginStrategy, type BankAutoLoginPage } from "./auto-login";
+import { createBankAutoLoginStrategy, executeScrapeTimeAutoLoginTrigger, type BankAutoLoginPage } from "./auto-login";
 import type { BankPortalConfig } from "./login-mutation-guard";
 
 const portalConfig: BankPortalConfig = {
@@ -182,5 +182,226 @@ describe("createBankAutoLoginStrategy", () => {
 
     await expect(strategy.autoLogin({ credential, page: mfaPage })).resolves.toMatchObject({ status: "needs_admin_action", reason: "protected_flow" });
     await expect(strategy.autoLogin({ credential, page: unknownPage })).resolves.toMatchObject({ status: "needs_admin_action", reason: "unknown_post_submit_state" });
+  });
+});
+
+describe("executeScrapeTimeAutoLoginTrigger", () => {
+  it("acquires the expired-event lock, runs browser login, and owner-releases on success", async () => {
+    const page = makePage();
+    const acquire = vi.fn().mockResolvedValue({ leaseToken: "lease-1", fencingToken: 7, expiresAt: 12345 });
+    const release = vi.fn().mockResolvedValue(true);
+    const autoLogin = vi.fn().mockResolvedValue({ status: "succeeded" });
+    const ensureBrowser = vi.fn().mockResolvedValue({ status: "ready", page });
+
+    await expect(executeScrapeTimeAutoLoginTrigger({
+      bankCode: "popular",
+      expiredEventId: "E1",
+      adapter: { bankCode: "popular", createAutoLoginStrategy: () => ({ bankCode: "popular", autoLogin }) },
+      credential,
+      cdpUrl: "http://127.0.0.1:9222",
+      lock: { acquire, release },
+      ensureBrowser,
+    })).resolves.toEqual({ status: "succeeded" });
+
+    expect(acquire).toHaveBeenCalledWith("popular", "E1");
+    expect(ensureBrowser).toHaveBeenCalledWith("http://127.0.0.1:9222");
+    expect(autoLogin).toHaveBeenCalledWith({ credential, page });
+    expect(release).toHaveBeenCalledWith("popular", "E1", "lease-1");
+  });
+
+  it("requires manual scraping when the same expired event lock is already held", async () => {
+    const acquire = vi.fn().mockResolvedValue(null);
+    const ensureBrowser = vi.fn();
+    const release = vi.fn();
+
+    await expect(executeScrapeTimeAutoLoginTrigger({
+      bankCode: "popular",
+      expiredEventId: "E1",
+      adapter: { bankCode: "popular", createAutoLoginStrategy: () => createBankAutoLoginStrategy(portalConfig) },
+      credential,
+      cdpUrl: "http://127.0.0.1:9222",
+      lock: { acquire, release },
+      ensureBrowser,
+    })).resolves.toEqual({
+      status: "manual_required",
+      reason: "lock_busy",
+      safeSummary: "Manual scrape required before retrying bank auto-login",
+    });
+
+    expect(ensureBrowser).not.toHaveBeenCalled();
+    expect(release).not.toHaveBeenCalled();
+  });
+
+  it("requires manual scraping without leaking raw errors when lock acquire fails", async () => {
+    const acquire = vi.fn().mockRejectedValue(new Error("redis token=secret unavailable"));
+    const ensureBrowser = vi.fn();
+    const release = vi.fn();
+
+    await expect(executeScrapeTimeAutoLoginTrigger({
+      bankCode: "popular",
+      expiredEventId: "E1",
+      adapter: { bankCode: "popular", createAutoLoginStrategy: () => createBankAutoLoginStrategy(portalConfig) },
+      credential,
+      cdpUrl: "http://127.0.0.1:9222",
+      lock: { acquire, release },
+      ensureBrowser,
+    })).resolves.toEqual({
+      status: "manual_required",
+      reason: "lock_unavailable",
+      safeSummary: "Manual scrape required before retrying bank auto-login",
+    });
+
+    expect(ensureBrowser).not.toHaveBeenCalled();
+    expect(release).not.toHaveBeenCalled();
+  });
+
+  it("fails closed before credential use on adapter mismatch or unsafe CDP URL", async () => {
+    const createAutoLoginStrategy = vi.fn();
+    const acquire = vi.fn();
+    const release = vi.fn();
+    const base = {
+      bankCode: "popular",
+      expiredEventId: "E1",
+      credential: { ...credential, bankCode: "bhd" },
+      lock: { acquire, release },
+      ensureBrowser: vi.fn(),
+    };
+
+    await expect(executeScrapeTimeAutoLoginTrigger({
+      ...base,
+      adapter: { bankCode: "popular", createAutoLoginStrategy },
+      cdpUrl: "http://127.0.0.1:9222",
+    })).resolves.toMatchObject({ status: "needs_admin_action", reason: "credential_bank_mismatch" });
+
+    await expect(executeScrapeTimeAutoLoginTrigger({
+      ...base,
+      credential,
+      adapter: { bankCode: "popular", createAutoLoginStrategy },
+      cdpUrl: "http://10.0.0.5:9222",
+    })).resolves.toMatchObject({ status: "needs_admin_action", reason: "browser_unavailable" });
+
+    expect(createAutoLoginStrategy).not.toHaveBeenCalled();
+    expect(acquire).not.toHaveBeenCalled();
+  });
+
+  it("fails closed on adapter/context bank mismatch before lock, browser, or credential use", async () => {
+    const createAutoLoginStrategy = vi.fn();
+    const acquire = vi.fn();
+    const release = vi.fn();
+    const ensureBrowser = vi.fn();
+
+    await expect(executeScrapeTimeAutoLoginTrigger({
+      bankCode: "bhd",
+      expiredEventId: "E1",
+      adapter: { bankCode: "popular", createAutoLoginStrategy },
+      credential,
+      cdpUrl: "http://127.0.0.1:9222",
+      lock: { acquire, release },
+      ensureBrowser,
+    })).resolves.toMatchObject({ status: "needs_admin_action", reason: "unsupported_bank" });
+
+    expect(createAutoLoginStrategy).not.toHaveBeenCalled();
+    expect(acquire).not.toHaveBeenCalled();
+    expect(ensureBrowser).not.toHaveBeenCalled();
+    expect(release).not.toHaveBeenCalled();
+  });
+
+  it("owner-releases the lock when browser capacity is throttled", async () => {
+    const acquire = vi.fn().mockResolvedValue({ leaseToken: "lease-1", fencingToken: 7, expiresAt: 12345 });
+    const release = vi.fn().mockResolvedValue(true);
+    const autoLogin = vi.fn();
+
+    await expect(executeScrapeTimeAutoLoginTrigger({
+      bankCode: "popular",
+      expiredEventId: "E1",
+      adapter: { bankCode: "popular", createAutoLoginStrategy: () => ({ bankCode: "popular", autoLogin }) },
+      credential,
+      cdpUrl: "http://127.0.0.1:9222",
+      lock: { acquire, release },
+      ensureBrowser: vi.fn().mockResolvedValue({ status: "throttled" }),
+    })).resolves.toEqual({ status: "throttled", safeSummary: "Bank browser capacity is temporarily unavailable" });
+
+    expect(autoLogin).not.toHaveBeenCalled();
+    expect(release).toHaveBeenCalledWith("popular", "E1", "lease-1");
+  });
+
+  it("owner-releases the lock when browser startup fails without leaking raw errors", async () => {
+    const release = vi.fn().mockResolvedValue(true);
+
+    await expect(executeScrapeTimeAutoLoginTrigger({
+      bankCode: "popular",
+      expiredEventId: "E1",
+      adapter: { bankCode: "popular", createAutoLoginStrategy: () => ({ bankCode: "popular", autoLogin: vi.fn() }) },
+      credential,
+      cdpUrl: "http://127.0.0.1:9222",
+      lock: { acquire: vi.fn().mockResolvedValue({ leaseToken: "lease-1", fencingToken: 7, expiresAt: 12345 }), release },
+      ensureBrowser: vi.fn().mockRejectedValue(new Error("cdp token=secret refused")),
+    })).resolves.toEqual({
+      status: "needs_admin_action",
+      reason: "browser_unavailable",
+      safeSummary: "Bank auto-login requires admin action",
+    });
+
+    expect(release).toHaveBeenCalledWith("popular", "E1", "lease-1");
+  });
+
+  it("owner-releases the lock when delegated login returns admin action", async () => {
+    const release = vi.fn().mockResolvedValue(true);
+    const autoLogin = vi.fn().mockResolvedValue({
+      status: "needs_admin_action",
+      reason: "protected_flow",
+      safeSummary: "MFA is required",
+    });
+
+    await expect(executeScrapeTimeAutoLoginTrigger({
+      bankCode: "popular",
+      expiredEventId: "E1",
+      adapter: { bankCode: "popular", createAutoLoginStrategy: () => ({ bankCode: "popular", autoLogin }) },
+      credential,
+      cdpUrl: "http://127.0.0.1:9222",
+      lock: { acquire: vi.fn().mockResolvedValue({ leaseToken: "lease-1", fencingToken: 7, expiresAt: 12345 }), release },
+      ensureBrowser: vi.fn().mockResolvedValue({ status: "ready", page: makePage() }),
+    })).resolves.toEqual({
+      status: "needs_admin_action",
+      reason: "protected_flow",
+      safeSummary: "MFA is required",
+    });
+
+    expect(release).toHaveBeenCalledWith("popular", "E1", "lease-1");
+  });
+
+  it("owner-releases the lock and reports portal state unavailable when delegated login rejects", async () => {
+    const release = vi.fn().mockResolvedValue(true);
+    const autoLogin = vi.fn().mockRejectedValue(new Error("portal token=secret crashed"));
+
+    await expect(executeScrapeTimeAutoLoginTrigger({
+      bankCode: "popular",
+      expiredEventId: "E1",
+      adapter: { bankCode: "popular", createAutoLoginStrategy: () => ({ bankCode: "popular", autoLogin }) },
+      credential,
+      cdpUrl: "http://127.0.0.1:9222",
+      lock: { acquire: vi.fn().mockResolvedValue({ leaseToken: "lease-1", fencingToken: 7, expiresAt: 12345 }), release },
+      ensureBrowser: vi.fn().mockResolvedValue({ status: "ready", page: makePage() }),
+    })).resolves.toEqual({
+      status: "needs_admin_action",
+      reason: "portal_state_unavailable",
+      safeSummary: "Bank auto-login requires admin action",
+    });
+
+    expect(release).toHaveBeenCalledWith("popular", "E1", "lease-1");
+  });
+
+  it("does not let release failures leak raw infrastructure errors", async () => {
+    const release = vi.fn().mockRejectedValue(new Error("Redis token=secret failed"));
+
+    await expect(executeScrapeTimeAutoLoginTrigger({
+      bankCode: "popular",
+      expiredEventId: "E1",
+      adapter: { bankCode: "popular", createAutoLoginStrategy: () => ({ bankCode: "popular", autoLogin: vi.fn().mockResolvedValue({ status: "succeeded" }) }) },
+      credential,
+      cdpUrl: "http://127.0.0.1:9222",
+      lock: { acquire: vi.fn().mockResolvedValue({ leaseToken: "lease-1", fencingToken: 7, expiresAt: 12345 }), release },
+      ensureBrowser: vi.fn().mockResolvedValue({ status: "ready", page: makePage() }),
+    })).resolves.toEqual({ status: "succeeded" });
   });
 });

--- a/src/worker/scraper/auto-login.ts
+++ b/src/worker/scraper/auto-login.ts
@@ -1,4 +1,6 @@
 import { LOGIN_MUTATION_GUARD_ERROR_SUMMARIES, LoginMutationGuard, LoginMutationGuardError, type BankPortalConfig, type LoginMutationPage } from "./login-mutation-guard";
+import { assertCdpLoopback, getSafeCdpErrorSummary } from "./browser-runtime";
+import type { AutoLoginLock } from "../../modules/bank-auto-login-lock";
 
 export interface BankAutoLoginCredential {
   bankCode: string;
@@ -20,7 +22,8 @@ export type BankAutoLoginAdminActionReason =
   | "portal_state_unavailable"
   | "malformed_url"
   | "unauthorized_login_page"
-  | "unknown_post_submit_state";
+  | "unknown_post_submit_state"
+  | "browser_unavailable";
 
 export type BankAutoLoginOutcome =
   | { status: "succeeded" }
@@ -31,7 +34,80 @@ export interface BankAutoLoginStrategy {
   autoLogin(context: { credential: BankAutoLoginCredential; page: BankAutoLoginPage }): Promise<BankAutoLoginOutcome>;
 }
 
+export type ScrapeTimeAutoLoginOutcome =
+  | BankAutoLoginOutcome
+  | { status: "manual_required"; reason: "lock_busy" | "lock_unavailable"; safeSummary: string }
+  | { status: "throttled"; safeSummary: string };
+
+export interface ScrapeTimeAutoLoginTriggerContext {
+  bankCode: string;
+  expiredEventId: string;
+  adapter: { readonly bankCode: string; createAutoLoginStrategy(): BankAutoLoginStrategy };
+  credential: BankAutoLoginCredential;
+  cdpUrl: string;
+  lock: Pick<AutoLoginLock, "acquire" | "release">;
+  ensureBrowser(cdpUrl: string): Promise<{ status: "ready"; page: BankAutoLoginPage } | { status: "throttled" }>;
+}
+
 const SAFE_ADMIN_ACTION_SUMMARY = "Bank auto-login requires admin action";
+const SAFE_BROWSER_THROTTLED_SUMMARY = "Bank browser capacity is temporarily unavailable";
+const SAFE_MANUAL_REQUIRED_SUMMARY = "Manual scrape required before retrying bank auto-login";
+
+export async function executeScrapeTimeAutoLoginTrigger(context: ScrapeTimeAutoLoginTriggerContext): Promise<ScrapeTimeAutoLoginOutcome> {
+  if (context.adapter.bankCode !== context.bankCode) return needsAdminAction("unsupported_bank");
+  if (context.adapter.bankCode !== context.credential.bankCode) return needsAdminAction("credential_bank_mismatch");
+
+  const cdpUrl = context.cdpUrl;
+  try {
+    assertCdpLoopback(cdpUrl);
+  } catch (error) {
+    return needsAdminAction("browser_unavailable", getSafeCdpErrorSummary(error));
+  }
+
+  let acquired: Awaited<ReturnType<ScrapeTimeAutoLoginTriggerContext["lock"]["acquire"]>>;
+  try {
+    acquired = await context.lock.acquire(context.bankCode, context.expiredEventId);
+  } catch {
+    return manualRequired("lock_unavailable");
+  }
+  if (!acquired) return manualRequired("lock_busy");
+
+  try {
+    return await runOwnedAutoLogin(context, cdpUrl);
+  } finally {
+    await releaseOwnedLock(context, acquired.leaseToken);
+  }
+}
+
+async function releaseOwnedLock(context: ScrapeTimeAutoLoginTriggerContext, leaseToken: string): Promise<void> {
+  try {
+    await context.lock.release(context.bankCode, context.expiredEventId, leaseToken);
+  } catch {
+    // Lock TTL bounds eventual cleanup; do not let infrastructure details leak past the safe outcome.
+  }
+}
+
+async function runOwnedAutoLogin(context: ScrapeTimeAutoLoginTriggerContext, cdpUrl: string): Promise<ScrapeTimeAutoLoginOutcome> {
+  let browser: { status: "ready"; page: BankAutoLoginPage } | { status: "throttled" };
+
+  try {
+    browser = await context.ensureBrowser(cdpUrl);
+  } catch {
+    return needsAdminAction("browser_unavailable");
+  }
+
+  if (browser.status === "throttled") return { status: "throttled", safeSummary: SAFE_BROWSER_THROTTLED_SUMMARY };
+
+  try {
+    return await context.adapter.createAutoLoginStrategy().autoLogin({ credential: context.credential, page: browser.page });
+  } catch {
+    return needsAdminAction("portal_state_unavailable");
+  }
+}
+
+function manualRequired(reason: "lock_busy" | "lock_unavailable"): ScrapeTimeAutoLoginOutcome {
+  return { status: "manual_required", reason, safeSummary: SAFE_MANUAL_REQUIRED_SUMMARY };
+}
 
 export function createBankAutoLoginStrategy(
   portalConfig: BankPortalConfig,

--- a/src/worker/scraper/auto-login.ts
+++ b/src/worker/scraper/auto-login.ts
@@ -47,6 +47,7 @@ export interface ScrapeTimeAutoLoginTriggerContext {
   cdpUrl: string;
   lock: Pick<AutoLoginLock, "acquire" | "release">;
   ensureBrowser(cdpUrl: string): Promise<{ status: "ready"; page: BankAutoLoginPage } | { status: "throttled" }>;
+  recordLockReleaseFailure?(metadata: { bankCode: string; expiredEventId: string }): void | Promise<void>;
 }
 
 const SAFE_ADMIN_ACTION_SUMMARY = "Bank auto-login requires admin action";
@@ -81,9 +82,19 @@ export async function executeScrapeTimeAutoLoginTrigger(context: ScrapeTimeAutoL
 
 async function releaseOwnedLock(context: ScrapeTimeAutoLoginTriggerContext, leaseToken: string): Promise<void> {
   try {
-    await context.lock.release(context.bankCode, context.expiredEventId, leaseToken);
+    const released = await context.lock.release(context.bankCode, context.expiredEventId, leaseToken);
+    if (!released) await recordLockReleaseFailure(context);
   } catch {
     // Lock TTL bounds eventual cleanup; do not let infrastructure details leak past the safe outcome.
+    await recordLockReleaseFailure(context);
+  }
+}
+
+async function recordLockReleaseFailure(context: ScrapeTimeAutoLoginTriggerContext): Promise<void> {
+  try {
+    await context.recordLockReleaseFailure?.({ bankCode: context.bankCode, expiredEventId: context.expiredEventId });
+  } catch {
+    // Observability failures must not change the safe auto-login outcome.
   }
 }
 


### PR DESCRIPTION
## Summary

- Adds isolated executeScrapeTimeAutoLoginTrigger helper for the first PR4.5 scrape-time trigger sub-slice.
- Coordinates bank identity checks, CDP loopback validation, expired-event lock acquisition, browser readiness, delegated auto-login, owner lock release, and safe release-failure observability.
- Keeps production scrape-run wiring out of scope; task 4.5 remains unchecked.

## Scope

- src/worker/scraper/auto-login.ts`n- src/worker/scraper/auto-login.test.ts`n
## Safety boundaries

- No production scraper/runtime/admin/UI wiring.
- No real bank portal config or credentials.
- No MFA/CAPTCHA/security-question/anti-bot bypass.
- Credentials stay behind bank/CDP/lock/browser gates.
- ensureBrowser(cdpUrl) receives the validated loopback CDP URL.
- Lock acquire failures return safe manual_required; owner lock release is awaited; release throw/false records safe metadata only and hook failures are contained.

## Verification

- pnpm test — 95 files passed, 1 skipped; 987 tests passed, 38 skipped.
- pnpm lint — passed.
- pnpm typecheck — passed.
- git diff --check — passed with LF/CRLF warnings only.
- Fresh 4R final — R1/R2/R3/R4 passed.
- Judgment Day final — Judge A and Judge B approved.

## Review budget

- 2 files, 379 additions / 2 deletions. Under the 400-line budget.

## Chain context

- Base: eature/multi-bank-auto-login.
- PR4.4 completed by #26 and #27.
- This is PR4.5a helper only; next slice should wire the helper into the real scrape-run path.

## HIGH RISK note

PR4 slice passed PR-level fresh 4R and Judgment Day before merge.