### PR TITLE
feat(scraper): add queue auto-login seam (PR4.5b)

### DIFF
--- a/src/worker/queues/index.ts
+++ b/src/worker/queues/index.ts
@@ -2,6 +2,7 @@ import type { JobsOptions } from "bullmq";
 
 import { createAuditEvent, type AuditSink } from "../../modules/audit";
 import { type BankMovement, type TransactionRecord, normalizeBankMovement } from "../../modules/transactions";
+import type { ScrapeTimeAutoLoginOutcome } from "../scraper/auto-login";
 import { redactDiagnosticText, type ScrapeCollectionResult } from "../scraper";
 
 export type ScrapeRunStatus = "queued" | "running" | "succeeded" | "failed" | "needs_admin_action";
@@ -14,6 +15,8 @@ export interface IngestionJobData {
    * the value is a domain code, NOT the Prisma `Bank.id` cuid.
    */
   bankId: string;
+  /** Stable session-expiry event id. When present, the processor may run the canonical scrape-time auto-login trigger before collection. */
+  expiredEventId?: string;
   accountFingerprint: string;
 }
 
@@ -96,6 +99,7 @@ export interface IngestionProcessorDependencies {
   adminAlerts?: AdminAlertSink;
   auditSink?: Pick<AuditSink, "record">;
   now?: () => Date;
+  runScrapeTimeAutoLogin?: (job: IngestionJob) => Promise<ScrapeTimeAutoLoginOutcome | null>;
 }
 
 export interface QueueLike {
@@ -130,24 +134,28 @@ export function createIngestionProcessor(dependencies: IngestionProcessorDepende
     });
 
     try {
+      const autoLoginOutcome = await runScrapeTimeAutoLoginIfNeeded(job, dependencies.runScrapeTimeAutoLogin);
+      if (autoLoginOutcome && shouldStopAfterAutoLogin(autoLoginOutcome)) {
+        return markNeedsAdminActionTerminal(
+          dependencies,
+          job.data,
+          requestedBankCode,
+          autoLoginOutcome.safeSummary,
+          now,
+        );
+      }
+
       const scrapeResult = await scraper.collect();
 
       if (scrapeResult.status === "needs_admin_action") {
         const safeErrorSummary = scrapeResult.safeErrorSummary ?? "Bank session requires admin action";
-        await dependencies.scrapeRuns.markNeedsAdminAction(
-          job.data.runId,
+        return markNeedsAdminActionTerminal(
+          dependencies,
+          job.data,
+          requestedBankCode,
           safeErrorSummary,
-          now(),
+          now,
         );
-        await notifyAdminAttention(dependencies.adminAlerts, job.data, "needs_admin_action", safeErrorSummary);
-        await emitAuditEvent(dependencies.auditSink, {
-          action: "scrape_run.needs_admin_action",
-          runId: job.data.runId,
-          bankId: requestedBankCode,
-          metadata: { safeErrorSummary },
-        });
-
-        return { status: "needs_admin_action", inserted: 0, skipped: 0 };
       }
 
       const records = normalizeMovements(scrapeResult.movements, job.data.runId);
@@ -179,6 +187,49 @@ export function createIngestionProcessor(dependencies: IngestionProcessorDepende
       return { status: "failed", inserted: 0, skipped: 0 };
     }
   };
+}
+
+async function runScrapeTimeAutoLoginIfNeeded(
+  job: IngestionJob,
+  runScrapeTimeAutoLogin: IngestionProcessorDependencies["runScrapeTimeAutoLogin"],
+): Promise<ScrapeTimeAutoLoginOutcome | null> {
+  if (!job.data.expiredEventId || !runScrapeTimeAutoLogin) return null;
+  try {
+    return await runScrapeTimeAutoLogin(job);
+  } catch {
+    return {
+      status: "needs_admin_action",
+      reason: "browser_unavailable",
+      safeSummary: "Bank auto-login requires admin action",
+    };
+  }
+}
+
+function shouldStopAfterAutoLogin(outcome: ScrapeTimeAutoLoginOutcome): outcome is Extract<ScrapeTimeAutoLoginOutcome, { status: "needs_admin_action" | "throttled" }> {
+  return outcome.status === "needs_admin_action" || outcome.status === "throttled";
+}
+
+async function markNeedsAdminActionTerminal(
+  dependencies: Pick<IngestionProcessorDependencies, "scrapeRuns" | "adminAlerts" | "auditSink">,
+  jobData: IngestionJobData,
+  requestedBankCode: string,
+  safeErrorSummary: string,
+  now: () => Date,
+): Promise<IngestionResult> {
+  await dependencies.scrapeRuns.markNeedsAdminAction(
+    jobData.runId,
+    safeErrorSummary,
+    now(),
+  );
+  await notifyAdminAttention(dependencies.adminAlerts, jobData, "needs_admin_action", safeErrorSummary);
+  await emitAuditEvent(dependencies.auditSink, {
+    action: "scrape_run.needs_admin_action",
+    runId: jobData.runId,
+    bankId: requestedBankCode,
+    metadata: { safeErrorSummary },
+  });
+
+  return { status: "needs_admin_action", inserted: 0, skipped: 0 };
 }
 
 export function createIngestionQueueOptions(runId: string): JobsOptions {

--- a/src/worker/queues/queues.test.ts
+++ b/src/worker/queues/queues.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   createIngestionProcessor,
@@ -491,6 +491,257 @@ describe("ingestion processor — resolveScraper routing", () => {
     const result = await processor({ data: jobData });
 
     expect(result).toEqual({ status: "succeeded", inserted: 1, skipped: 0 });
+  });
+});
+
+describe("ingestion processor — scrape-time auto-login trigger", () => {
+  it("runs the scrape-time auto-login trigger before collection when the job carries an expired event", async () => {
+    const calls: string[] = [];
+    const processor = createIngestionProcessor({
+      scrapeRuns: new FakeScrapeRunRepository(),
+      transactions: new FakeTransactionRepository({ inserted: 0, skipped: 0 }),
+      scraper: {
+        collect: async () => {
+          calls.push("collect");
+          return { status: "collected", movements: [] };
+        },
+      },
+      runScrapeTimeAutoLogin: async (job) => {
+        calls.push(`auto-login:${job.data.bankId}:${job.data.expiredEventId}`);
+        return { status: "succeeded" };
+      },
+    });
+
+    const result = await processor({
+      data: { ...jobData, expiredEventId: "expired-1" },
+    });
+
+    expect(result).toEqual({ status: "succeeded", inserted: 0, skipped: 0 });
+    expect(calls).toEqual(["auto-login:popular:expired-1", "collect"]);
+  });
+
+  it("does not run the scrape-time auto-login trigger without expiredEventId and still collects", async () => {
+    const collect = vi.fn(async () => ({ status: "collected" as const, movements: [] }));
+    const runScrapeTimeAutoLogin = vi.fn(async () => ({
+      status: "needs_admin_action" as const,
+      reason: "protected_flow" as const,
+      safeSummary: "Bank auto-login requires admin action",
+    }));
+    const processor = createIngestionProcessor({
+      scrapeRuns: new FakeScrapeRunRepository(),
+      transactions: new FakeTransactionRepository({ inserted: 0, skipped: 0 }),
+      scraper: { collect },
+      runScrapeTimeAutoLogin,
+    });
+
+    const result = await processor({ data: jobData });
+
+    expect(result).toEqual({ status: "succeeded", inserted: 0, skipped: 0 });
+    expect(runScrapeTimeAutoLogin).not.toHaveBeenCalled();
+    expect(collect).toHaveBeenCalledOnce();
+  });
+
+  it("collects normally when expiredEventId is present but no scrape-time auto-login runner is wired", async () => {
+    const scrapeRuns = new FakeScrapeRunRepository();
+    const collect = vi.fn(async () => ({ status: "collected" as const, movements: [] }));
+    const processor = createIngestionProcessor({
+      scrapeRuns,
+      transactions: new FakeTransactionRepository({ inserted: 0, skipped: 0 }),
+      scraper: { collect },
+    });
+
+    const result = await processor({ data: { ...jobData, expiredEventId: "expired-no-runner" } });
+
+    expect(result).toEqual({ status: "succeeded", inserted: 0, skipped: 0 });
+    expect(collect).toHaveBeenCalledOnce();
+    expect(scrapeRuns.transitions).toEqual([
+      { runId: "run-1", status: "running" },
+      { runId: "run-1", status: "succeeded", insertedCount: 0, skippedCount: 0 },
+    ]);
+  });
+
+  it("collects normally when the scrape-time auto-login runner returns null", async () => {
+    const scrapeRuns = new FakeScrapeRunRepository();
+    const collect = vi.fn(async () => ({ status: "collected" as const, movements: [] }));
+    const runScrapeTimeAutoLogin = vi.fn(async () => null);
+    const processor = createIngestionProcessor({
+      scrapeRuns,
+      transactions: new FakeTransactionRepository({ inserted: 0, skipped: 0 }),
+      scraper: { collect },
+      runScrapeTimeAutoLogin,
+    });
+
+    const result = await processor({ data: { ...jobData, expiredEventId: "expired-null-runner" } });
+
+    expect(result).toEqual({ status: "succeeded", inserted: 0, skipped: 0 });
+    expect(runScrapeTimeAutoLogin).toHaveBeenCalledOnce();
+    expect(collect).toHaveBeenCalledOnce();
+    expect(scrapeRuns.transitions).toEqual([
+      { runId: "run-1", status: "running" },
+      { runId: "run-1", status: "succeeded", insertedCount: 0, skippedCount: 0 },
+    ]);
+  });
+
+  it("stops safely without collecting when auto-login requires admin action", async () => {
+    const scrapeRuns = new FakeScrapeRunRepository();
+    const transactions = new FakeTransactionRepository({ inserted: 0, skipped: 0 });
+    const processor = createIngestionProcessor({
+      scrapeRuns,
+      transactions,
+      scraper: {
+        collect: async () => {
+          throw new Error("collect must not run after auto-login admin action");
+        },
+      },
+      runScrapeTimeAutoLogin: async () => ({
+        status: "needs_admin_action",
+        reason: "protected_flow",
+        safeSummary: "Bank auto-login requires admin action",
+      }),
+    });
+
+    const result = await processor({ data: { ...jobData, expiredEventId: "expired-2" } });
+
+    expect(result).toEqual({ status: "needs_admin_action", inserted: 0, skipped: 0 });
+    expect(scrapeRuns.transitions).toEqual([
+      { runId: "run-1", status: "running" },
+      {
+        runId: "run-1",
+        status: "needs_admin_action",
+        safeErrorSummary: "Bank auto-login requires admin action",
+      },
+    ]);
+    expect(transactions.received).toEqual([]);
+  });
+
+  it("maps throttled auto-login to safe admin action without collecting", async () => {
+    const scrapeRuns = new FakeScrapeRunRepository();
+    const transactions = new FakeTransactionRepository({ inserted: 0, skipped: 0 });
+    const adminAlerts = new FakeAdminAlertSink();
+    const auditSink = new InMemoryAuditSink();
+    const collect = vi.fn(async () => {
+      throw new Error("collect must not run after throttled auto-login");
+    });
+    const processor = createIngestionProcessor({
+      scrapeRuns,
+      transactions,
+      adminAlerts,
+      auditSink,
+      scraper: { collect },
+      runScrapeTimeAutoLogin: async () => ({
+        status: "throttled",
+        safeSummary: "Bank browser capacity is temporarily unavailable",
+      }),
+    });
+
+    const result = await processor({ data: { ...jobData, expiredEventId: "expired-throttled" } });
+
+    expect(result).toEqual({ status: "needs_admin_action", inserted: 0, skipped: 0 });
+    expect(collect).not.toHaveBeenCalled();
+    expect(scrapeRuns.transitions).toEqual([
+      { runId: "run-1", status: "running" },
+      {
+        runId: "run-1",
+        status: "needs_admin_action",
+        safeErrorSummary: "Bank browser capacity is temporarily unavailable",
+      },
+    ]);
+    expect(transactions.received).toEqual([]);
+    expect(adminAlerts.events).toEqual([
+      {
+        runId: "run-1",
+        bankId: "popular",
+        status: "needs_admin_action",
+        safeErrorSummary: "Bank browser capacity is temporarily unavailable",
+      },
+    ]);
+    const events = await auditSink.list();
+    expect(events.find((e) => e.action === "scrape_run.needs_admin_action")).toMatchObject({
+      targetId: "run-1",
+      metadata: {
+        bankId: "popular",
+        safeErrorSummary: "Bank browser capacity is temporarily unavailable",
+      },
+    });
+  });
+
+  it("maps thrown auto-login to safe admin action without leaking raw errors or collecting", async () => {
+    const scrapeRuns = new FakeScrapeRunRepository();
+    const transactions = new FakeTransactionRepository({ inserted: 0, skipped: 0 });
+    const adminAlerts = new FakeAdminAlertSink();
+    const auditSink = new InMemoryAuditSink();
+    const collect = vi.fn(async () => {
+      throw new Error("collect must not run after thrown auto-login");
+    });
+    const processor = createIngestionProcessor({
+      scrapeRuns,
+      transactions,
+      adminAlerts,
+      auditSink,
+      scraper: { collect },
+      runScrapeTimeAutoLogin: async () => {
+        throw new Error("cdp unavailable token=secret password=abc cdp_url=internal-bank-host/session");
+      },
+    });
+
+    const result = await processor({ data: { ...jobData, expiredEventId: "expired-throw" } });
+
+    expect(result).toEqual({ status: "needs_admin_action", inserted: 0, skipped: 0 });
+    expect(collect).not.toHaveBeenCalled();
+    expect(scrapeRuns.transitions).toEqual([
+      { runId: "run-1", status: "running" },
+      {
+        runId: "run-1",
+        status: "needs_admin_action",
+        safeErrorSummary: "Bank auto-login requires admin action",
+      },
+    ]);
+    expect(transactions.received).toEqual([]);
+    expect(adminAlerts.events).toEqual([
+      {
+        runId: "run-1",
+        bankId: "popular",
+        status: "needs_admin_action",
+        safeErrorSummary: "Bank auto-login requires admin action",
+      },
+    ]);
+    const events = await auditSink.list();
+    const needsAdminEvent = events.find((e) => e.action === "scrape_run.needs_admin_action");
+    expect(needsAdminEvent).toMatchObject({
+      targetId: "run-1",
+      metadata: { bankId: "popular", safeErrorSummary: "Bank auto-login requires admin action" },
+    });
+    const serializedTerminalState = JSON.stringify({
+      transitions: scrapeRuns.transitions,
+      alerts: adminAlerts.events,
+      auditMetadata: needsAdminEvent?.metadata,
+    });
+    expect(serializedTerminalState).not.toContain("secret");
+    expect(serializedTerminalState).not.toContain("abc");
+    expect(serializedTerminalState).not.toContain("internal-bank-host");
+  });
+
+  it("continues to manual scrape path when auto-login is manual_required and returns collection outcome", async () => {
+    const calls: string[] = [];
+    const processor = createIngestionProcessor({
+      scrapeRuns: new FakeScrapeRunRepository(),
+      transactions: new FakeTransactionRepository({ inserted: 0, skipped: 0 }),
+      scraper: {
+        collect: async () => {
+          calls.push("collect");
+          return { status: "needs_admin_action", movements: [], safeErrorSummary: "Manual login required" };
+        },
+      },
+      runScrapeTimeAutoLogin: async () => {
+        calls.push("auto-login");
+        return { status: "manual_required", reason: "lock_busy", safeSummary: "Manual scrape required before retrying bank auto-login" };
+      },
+    });
+
+    const result = await processor({ data: { ...jobData, expiredEventId: "expired-3" } });
+
+    expect(result).toEqual({ status: "needs_admin_action", inserted: 0, skipped: 0 });
+    expect(calls).toEqual(["auto-login", "collect"]);
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds the queue-level seam for scrape-time auto-login when an ingestion job carries expiredEventId.
- Invokes optional unScrapeTimeAutoLogin before read-only collection and maps safe outcomes into existing queue terminal handling.
- Keeps concrete default runner construction out of scope; task 4.5 remains unchecked.

## Scope

- src/worker/queues/index.ts`n- src/worker/queues/queues.test.ts`n
## Safety boundaries

- No default production runner wiring yet.
- No credential decrypt wiring in this slice.
- No real bank portal config or credentials.
- No MFA/CAPTCHA/security-question/anti-bot bypass.
- Auto-login only runs when both expiredEventId and an injected runner are present.
- No-runner and null-runner paths continue normal read-only collection.
- Runner throws map to safe admin-action summary without leaking raw diagnostics.

## Verification

- pnpm test — 95 files passed, 1 skipped; 995 tests passed, 38 skipped.
- pnpm lint — passed.
- pnpm typecheck — passed.
- git diff --check — passed with LF/CRLF warnings only.
- Fresh 4R pre-commit final — R1/R2/R3/R4 passed.

## Review budget

- 2 files, 315 insertions / 13 deletions. Under the 400-line budget.

## Chain context

- Base: eature/multi-bank-auto-login.
- PR4.5a helper landed in #28.
- This is PR4.5b queue seam only; next slice should build/wire the concrete default runner around executeScrapeTimeAutoLoginTrigger.

## HIGH RISK note

PR4 slices require PR-level fresh 4R + Judgment Day before merge. This PR has pre-commit 4R clean but still needs PR-level review + Judgment Day before merge.