### PR TITLE
feat(scraper): wire default auto-login runner (PR4.5c)

### DIFF
--- a/src/worker/ingestion-worker.ts
+++ b/src/worker/ingestion-worker.ts
@@ -31,6 +31,16 @@ import { Worker } from "bullmq";
 import { buildRedisConnectionOptions } from "./queues/bullmq-queue";
 import { createIngestionWorker, type WorkerConstructor } from "./ingestion-worker-factory";
 import { resolveDefaultAlertSink } from "./alerts/email-alert-sink";
+import { bankAdapterRegistry } from "../modules/bank-adapters/registry";
+import { BankAutoLoginConfigRepository } from "../modules/bank-auto-login-config/repository";
+import { defaultAutoLoginLock } from "../modules/bank-auto-login-lock/defaults";
+import { BankCredentialRepository } from "../modules/bank-credentials/repository";
+import { resolveCredentialKey } from "../modules/bank-credentials/key-resolver";
+import { createAuditEvent } from "../modules/audit";
+import { BANK_AUTOLOGIN_ACTIONS, BANK_CREDENTIAL_ACTIONS } from "../modules/audit/bank-actions";
+import { getPrismaClient } from "../modules/persistence/prisma-client";
+import { resolveBankBrowserEnv } from "./scraper/browser-runtime";
+import { createScrapeTimeAutoLoginRunner, unavailableScrapeTimeAutoLoginBrowserOpener, type BankAutoLoginStrategy } from "./scraper/auto-login";
 import { resolveDefaultScraper } from "../app/api/scrape-runs/consumer-defaults";
 import { defaultScrapeRunRepository } from "../app/api/scrape-runs/defaults";
 import { defaultTransactionRepository } from "../app/api/transactions/defaults";
@@ -56,6 +66,62 @@ if (!redisUrl) {
 // ---------------------------------------------------------------------------
 
 const connection = buildRedisConnectionOptions(redisUrl);
+const prisma = getPrismaClient();
+
+function toScrapeTimeAutoLoginStrategy(strategy: unknown, bankCode: string): BankAutoLoginStrategy {
+  if (isScrapeTimeAutoLoginStrategy(strategy)) return strategy;
+  return {
+    bankCode,
+    async autoLogin() {
+      return { status: "needs_admin_action", reason: "incompatible_flow", safeSummary: "Bank auto-login requires admin action" };
+    },
+  };
+}
+
+function isScrapeTimeAutoLoginStrategy(strategy: unknown): strategy is BankAutoLoginStrategy {
+  if (typeof strategy !== "object" || strategy === null) return false;
+  const candidate = strategy as { autoLogin?: unknown };
+  return typeof candidate.autoLogin === "function";
+}
+
+const runScrapeTimeAutoLogin = createScrapeTimeAutoLoginRunner({
+  adapterRegistry: {
+    get(bankCode) {
+      const adapter = bankAdapterRegistry.get(bankCode);
+      if (!adapter) return undefined;
+      return {
+        bankCode: adapter.bankCode,
+        createAutoLoginStrategy: () => toScrapeTimeAutoLoginStrategy(adapter.createAutoLoginStrategy(), adapter.bankCode),
+      };
+    },
+  },
+  autoLoginConfigs: new BankAutoLoginConfigRepository(prisma),
+  credentials: new BankCredentialRepository(prisma),
+  keyResolver: resolveCredentialKey,
+  lock: defaultAutoLoginLock,
+  cdpUrlForBankCode: (bankCode) => resolveBankBrowserEnv(bankCode, process.env).cdpUrl || undefined,
+  ensureBrowser: unavailableScrapeTimeAutoLoginBrowserOpener,
+  async recordLockReleaseFailure({ bankCode, expiredEventId }) {
+    await defaultAuditSink.record(createAuditEvent({
+      actorId: "system:auto-login",
+      actorRole: null,
+      action: BANK_AUTOLOGIN_ACTIONS.FAILED,
+      target: "bank_autologin_lock",
+      targetId: null,
+      metadata: { bankCode, expiredEventId, failure: "lock_release_failed" },
+    }));
+  },
+  async recordCredentialDecryptUse({ bankCode, keyVersion }) {
+    await defaultAuditSink.record(createAuditEvent({
+      actorId: "system:auto-login",
+      actorRole: null,
+      action: BANK_CREDENTIAL_ACTIONS.DECRYPT_USE,
+      target: "bank_credential",
+      targetId: null,
+      metadata: { bankCode, keyVersion },
+    }));
+  },
+});
 
 const processor = createIngestionProcessor({
   scrapeRuns: defaultScrapeRunRepository,
@@ -63,6 +129,7 @@ const processor = createIngestionProcessor({
   adminAlerts: resolveDefaultAlertSink(),
   auditSink: defaultAuditSink,
   resolveScraper: resolveDefaultScraper,
+  runScrapeTimeAutoLogin,
 });
 
 // ---------------------------------------------------------------------------

--- a/src/worker/scraper/auto-login.test.ts
+++ b/src/worker/scraper/auto-login.test.ts
@@ -501,7 +501,6 @@ describe("createScrapeTimeAutoLoginRunner", () => {
       cdpUrlForBankCode: vi.fn(),
       ensureBrowser: vi.fn(),
     });
-
     await expect(run({ data: { bankId: "bhd", expiredEventId: "E1" } })).resolves.toMatchObject({
       status: "needs_admin_action",
       reason: "unsupported_bank",
@@ -521,7 +520,6 @@ describe("createScrapeTimeAutoLoginRunner", () => {
       cdpUrlForBankCode: vi.fn(),
       ensureBrowser: vi.fn(),
     });
-
     await expect(run({ data: { bankId: "popular", expiredEventId: "E1" } })).resolves.toBeNull();
     expect(findByBankCode).not.toHaveBeenCalled();
     expect(acquire).not.toHaveBeenCalled();

--- a/src/worker/scraper/auto-login.test.ts
+++ b/src/worker/scraper/auto-login.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { createBankAutoLoginStrategy, executeScrapeTimeAutoLoginTrigger, type BankAutoLoginPage } from "./auto-login";
+import { encryptCredentialField } from "../../modules/bank-credentials/crypto";
+import { createBankAutoLoginStrategy, createScrapeTimeAutoLoginRunner, executeScrapeTimeAutoLoginTrigger, unavailableScrapeTimeAutoLoginBrowserOpener, type BankAutoLoginPage } from "./auto-login";
 import type { BankPortalConfig } from "./login-mutation-guard";
 
 const portalConfig: BankPortalConfig = {
@@ -472,5 +473,166 @@ describe("executeScrapeTimeAutoLoginTrigger", () => {
     })).resolves.toEqual({ status: "needs_admin_action", reason: "protected_flow", safeSummary: "MFA is required" });
 
     expect(recordLockReleaseFailure.mock.calls).toEqual([[{ bankCode: "popular", expiredEventId: "E1" }]]);
+  });
+});
+
+describe("createScrapeTimeAutoLoginRunner", () => {
+  const key = Buffer.alloc(32, 7);
+  const keyResolver = () => key;
+
+  function encryptedCredentialRecord(bankCode = "popular") {
+    return {
+      bankCode,
+      isActive: true,
+      keyVersion: 1,
+      encryptedUsernameEnvelope: JSON.stringify(encryptCredentialField("bank-user", keyResolver)),
+      encryptedPasswordEnvelope: JSON.stringify(encryptCredentialField("bank-password", keyResolver)),
+    };
+  }
+
+  it("fails closed for an explicit unknown bank without falling back to Popular", async () => {
+    const findByBankCode = vi.fn();
+    const run = createScrapeTimeAutoLoginRunner({
+      adapterRegistry: { get: vi.fn().mockReturnValue(undefined) },
+      autoLoginConfigs: { getByBankCode: vi.fn() },
+      credentials: { findByBankCode },
+      keyResolver,
+      lock: { acquire: vi.fn(), release: vi.fn() },
+      cdpUrlForBankCode: vi.fn(),
+      ensureBrowser: vi.fn(),
+    });
+
+    await expect(run({ data: { bankId: "bhd", expiredEventId: "E1" } })).resolves.toMatchObject({
+      status: "needs_admin_action",
+      reason: "unsupported_bank",
+    });
+    expect(findByBankCode).not.toHaveBeenCalled();
+  });
+
+  it("skips auto-login safely when the per-bank kill switch is off", async () => {
+    const findByBankCode = vi.fn();
+    const acquire = vi.fn();
+    const run = createScrapeTimeAutoLoginRunner({
+      adapterRegistry: { get: vi.fn().mockReturnValue({ bankCode: "popular", createAutoLoginStrategy: vi.fn() }) },
+      autoLoginConfigs: { getByBankCode: vi.fn().mockResolvedValue({ autoLoginEnabled: false, breakerState: "closed" }) },
+      credentials: { findByBankCode },
+      keyResolver,
+      lock: { acquire, release: vi.fn() },
+      cdpUrlForBankCode: vi.fn(),
+      ensureBrowser: vi.fn(),
+    });
+
+    await expect(run({ data: { bankId: "popular", expiredEventId: "E1" } })).resolves.toBeNull();
+    expect(findByBankCode).not.toHaveBeenCalled();
+    expect(acquire).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the stored credential belongs to a different bank", async () => {
+    const acquire = vi.fn();
+    const ensureBrowser = vi.fn();
+    const run = createScrapeTimeAutoLoginRunner({
+      adapterRegistry: { get: vi.fn().mockReturnValue({ bankCode: "popular", createAutoLoginStrategy: vi.fn() }) },
+      autoLoginConfigs: { getByBankCode: vi.fn().mockResolvedValue({ autoLoginEnabled: true, breakerState: "closed" }) },
+      credentials: { findByBankCode: vi.fn().mockResolvedValue(encryptedCredentialRecord("bhd")) },
+      keyResolver,
+      lock: { acquire, release: vi.fn() },
+      cdpUrlForBankCode: vi.fn().mockReturnValue("http://127.0.0.1:9222"),
+      ensureBrowser,
+    });
+
+    await expect(run({ data: { bankId: "popular", expiredEventId: "E1" } })).resolves.toMatchObject({
+      status: "needs_admin_action",
+      reason: "credential_bank_mismatch",
+    });
+    expect(acquire).not.toHaveBeenCalled();
+    expect(ensureBrowser).not.toHaveBeenCalled();
+  });
+
+  it("maps expected config and credential dependency failures to safe admin action outcomes", async () => {
+    const baseDeps = {
+      adapterRegistry: { get: vi.fn().mockReturnValue({ bankCode: "popular", createAutoLoginStrategy: vi.fn() }) },
+      keyResolver,
+      lock: { acquire: vi.fn(), release: vi.fn() },
+      cdpUrlForBankCode: vi.fn().mockReturnValue("http://127.0.0.1:9222"),
+      ensureBrowser: vi.fn(),
+    };
+
+    await expect(createScrapeTimeAutoLoginRunner({
+      ...baseDeps,
+      autoLoginConfigs: { getByBankCode: vi.fn().mockRejectedValue(new Error("database host internal failed")) },
+      credentials: { findByBankCode: vi.fn() },
+    })({ data: { bankId: "popular", expiredEventId: "E1" } })).resolves.toMatchObject({
+      status: "needs_admin_action",
+      reason: "auto_login_config_unavailable",
+    });
+
+    await expect(createScrapeTimeAutoLoginRunner({
+      ...baseDeps,
+      autoLoginConfigs: { getByBankCode: vi.fn().mockResolvedValue({ autoLoginEnabled: true, breakerState: "closed" }) },
+      credentials: { findByBankCode: vi.fn().mockRejectedValue(new Error("vault token=secret failed")) },
+    })({ data: { bankId: "popular", expiredEventId: "E1" } })).resolves.toMatchObject({
+      status: "needs_admin_action",
+      reason: "credential_unavailable",
+    });
+    expect(baseDeps.lock.acquire).not.toHaveBeenCalled();
+  });
+
+  it("uses the production default unavailable browser opener as a safe terminal admin action", async () => {
+    const release = vi.fn().mockResolvedValue(true);
+    const run = createScrapeTimeAutoLoginRunner({
+      adapterRegistry: { get: vi.fn().mockReturnValue({ bankCode: "popular", createAutoLoginStrategy: vi.fn() }) },
+      autoLoginConfigs: { getByBankCode: vi.fn().mockResolvedValue({ autoLoginEnabled: true, breakerState: "closed" }) },
+      credentials: { findByBankCode: vi.fn().mockResolvedValue(encryptedCredentialRecord()) },
+      keyResolver,
+      lock: { acquire: vi.fn().mockResolvedValue({ leaseToken: "lease-1", fencingToken: 1, expiresAt: 123 }), release },
+      cdpUrlForBankCode: vi.fn().mockReturnValue("http://127.0.0.1:9222"),
+      ensureBrowser: unavailableScrapeTimeAutoLoginBrowserOpener,
+    });
+
+    await expect(run({ data: { bankId: "popular", expiredEventId: "E1" } })).resolves.toEqual({
+      status: "needs_admin_action",
+      reason: "browser_unavailable",
+      safeSummary: "Bank auto-login requires admin action",
+    });
+    expect(release).toHaveBeenCalledWith("popular", "E1", "lease-1");
+  });
+
+  it("passes safe lock-release failure metadata through the runner dependency seam", async () => {
+    const recordLockReleaseFailure = vi.fn();
+    const run = createScrapeTimeAutoLoginRunner({
+      adapterRegistry: { get: vi.fn().mockReturnValue({ bankCode: "popular", createAutoLoginStrategy: () => ({ bankCode: "popular", autoLogin: vi.fn().mockResolvedValue({ status: "succeeded" }) }) }) },
+      autoLoginConfigs: { getByBankCode: vi.fn().mockResolvedValue({ autoLoginEnabled: true, breakerState: "closed" }) },
+      credentials: { findByBankCode: vi.fn().mockResolvedValue(encryptedCredentialRecord()) },
+      keyResolver,
+      lock: { acquire: vi.fn().mockResolvedValue({ leaseToken: "lease-1", fencingToken: 1, expiresAt: 123 }), release: vi.fn().mockResolvedValue(false) },
+      cdpUrlForBankCode: vi.fn().mockReturnValue("http://127.0.0.1:9222"),
+      ensureBrowser: vi.fn().mockResolvedValue({ status: "ready", page: makePage() }),
+      recordLockReleaseFailure,
+    });
+
+    await expect(run({ data: { bankId: "popular", expiredEventId: "E1" } })).resolves.toEqual({ status: "succeeded" });
+    expect(recordLockReleaseFailure).toHaveBeenCalledWith({ bankCode: "popular", expiredEventId: "E1" });
+  });
+
+  it("decrypts active credentials in memory and delegates enabled runs to the scrape-time trigger", async () => {
+    const page = makePage();
+    const autoLogin = vi.fn().mockResolvedValue({ status: "succeeded" });
+    const adapter = { bankCode: "popular", createAutoLoginStrategy: () => ({ bankCode: "popular", autoLogin }) };
+    const acquire = vi.fn().mockResolvedValue({ leaseToken: "lease-1", fencingToken: 1, expiresAt: 123 });
+    const release = vi.fn().mockResolvedValue(true);
+    const run = createScrapeTimeAutoLoginRunner({
+      adapterRegistry: { get: vi.fn().mockReturnValue(adapter) },
+      autoLoginConfigs: { getByBankCode: vi.fn().mockResolvedValue({ autoLoginEnabled: true, breakerState: "closed" }) },
+      credentials: { findByBankCode: vi.fn().mockResolvedValue(encryptedCredentialRecord()) },
+      keyResolver,
+      lock: { acquire, release },
+      cdpUrlForBankCode: vi.fn().mockReturnValue("http://127.0.0.1:9222"),
+      ensureBrowser: vi.fn().mockResolvedValue({ status: "ready", page }),
+    });
+
+    await expect(run({ data: { bankId: "popular", expiredEventId: "E1" } })).resolves.toEqual({ status: "succeeded" });
+    expect(autoLogin).toHaveBeenCalledWith({ credential: { bankCode: "popular", username: "bank-user", password: "bank-password" }, page });
+    expect(acquire).toHaveBeenCalledWith("popular", "E1");
+    expect(release).toHaveBeenCalledWith("popular", "E1", "lease-1");
   });
 });

--- a/src/worker/scraper/auto-login.ts
+++ b/src/worker/scraper/auto-login.ts
@@ -1,5 +1,6 @@
 import { LOGIN_MUTATION_GUARD_ERROR_SUMMARIES, LoginMutationGuard, LoginMutationGuardError, type BankPortalConfig, type LoginMutationPage } from "./login-mutation-guard";
 import { assertCdpLoopback, getSafeCdpErrorSummary } from "./browser-runtime";
+import { decryptCredentialField, type AesGcmEnvelope, type KeyResolver } from "../../modules/bank-credentials/crypto";
 import type { AutoLoginLock } from "../../modules/bank-auto-login-lock";
 
 export interface BankAutoLoginCredential {
@@ -16,6 +17,8 @@ export interface BankAutoLoginPage extends LoginMutationPage {
 export type BankAutoLoginAdminActionReason =
   | "unsupported_bank"
   | "credential_bank_mismatch"
+  | "auto_login_config_unavailable"
+  | "credential_unavailable"
   | "incompatible_flow"
   | "protected_flow"
   | "missing_required_login_control"
@@ -50,9 +53,171 @@ export interface ScrapeTimeAutoLoginTriggerContext {
   recordLockReleaseFailure?(metadata: { bankCode: string; expiredEventId: string }): void | Promise<void>;
 }
 
+export interface ScrapeTimeAutoLoginRunnerJob {
+  data: {
+    bankId: string;
+    expiredEventId?: string;
+  };
+}
+
+export interface ScrapeTimeAutoLoginCredentialRecord {
+  bankCode: string;
+  isActive: boolean;
+  keyVersion: number;
+  encryptedUsernameEnvelope: string;
+  encryptedPasswordEnvelope: string;
+}
+
+export interface ScrapeTimeAutoLoginConfigRecord {
+  autoLoginEnabled: boolean;
+  breakerState: "closed" | "open";
+}
+
+export interface ScrapeTimeAutoLoginRunnerDependencies {
+  adapterRegistry: {
+    get(bankCode: string): { readonly bankCode: string; createAutoLoginStrategy(): BankAutoLoginStrategy } | undefined;
+  };
+  autoLoginConfigs: {
+    getByBankCode(bankCode: string): Promise<ScrapeTimeAutoLoginConfigRecord | null>;
+  };
+  credentials: {
+    findByBankCode(bankCode: string): Promise<ScrapeTimeAutoLoginCredentialRecord | null>;
+  };
+  keyResolver: KeyResolver;
+  lock: Pick<AutoLoginLock, "acquire" | "release"> | null;
+  cdpUrlForBankCode(bankCode: string): string | undefined;
+  ensureBrowser(bankCode: string, cdpUrl: string): Promise<{ status: "ready"; page: BankAutoLoginPage } | { status: "throttled" }>;
+  recordLockReleaseFailure?(metadata: { bankCode: string; expiredEventId: string }): void | Promise<void>;
+  recordCredentialDecryptUse?(metadata: { bankCode: string; keyVersion: number }): void | Promise<void>;
+}
+
 const SAFE_ADMIN_ACTION_SUMMARY = "Bank auto-login requires admin action";
 const SAFE_BROWSER_THROTTLED_SUMMARY = "Bank browser capacity is temporarily unavailable";
 const SAFE_MANUAL_REQUIRED_SUMMARY = "Manual scrape required before retrying bank auto-login";
+
+type CredentialResolution =
+  | { status: "found"; credential: BankAutoLoginCredential }
+  | { status: "not_found" }
+  | BankAutoLoginOutcome;
+
+type RunnerAdapter = ReturnType<ScrapeTimeAutoLoginRunnerDependencies["adapterRegistry"]["get"]>;
+
+export const unavailableScrapeTimeAutoLoginBrowserOpener: ScrapeTimeAutoLoginRunnerDependencies["ensureBrowser"] = async () => { throw new Error("Scrape-time auto-login browser page opener is not wired yet"); };
+
+export function createScrapeTimeAutoLoginRunner(deps: ScrapeTimeAutoLoginRunnerDependencies) {
+  return async function runScrapeTimeAutoLogin(job: ScrapeTimeAutoLoginRunnerJob): Promise<ScrapeTimeAutoLoginOutcome | null> {
+    const expiredEventId = job.data.expiredEventId;
+    if (!expiredEventId) return null;
+
+    const bankCode = job.data.bankId;
+    const adapter = safelyResolveAdapter(deps, bankCode);
+    if (isAdminActionOutcome(adapter)) return adapter;
+    if (!adapter) return needsAdminAction("unsupported_bank");
+
+    const config = await safelyResolveConfig(deps, bankCode);
+    if (isAdminActionOutcome(config)) return config;
+    if (!config?.autoLoginEnabled || config.breakerState === "open") return null;
+
+    if (!deps.lock) return manualRequired("lock_unavailable");
+
+    const cdpUrl = safelyResolveCdpUrl(deps, bankCode);
+    if (isAdminActionOutcome(cdpUrl)) return cdpUrl;
+    if (!cdpUrl) return needsAdminAction("browser_unavailable");
+
+    const credentialResolution = await resolveAutoLoginCredential(deps, bankCode);
+    if (credentialResolution.status === "not_found") return null;
+    if (isAdminActionOutcome(credentialResolution)) return credentialResolution;
+
+    return executeScrapeTimeAutoLoginTrigger({
+      bankCode,
+      expiredEventId,
+      adapter,
+      credential: credentialResolution.credential,
+      cdpUrl,
+      lock: deps.lock,
+      ensureBrowser: (url) => deps.ensureBrowser(bankCode, url),
+      recordLockReleaseFailure: deps.recordLockReleaseFailure,
+    });
+  };
+}
+
+function safelyResolveAdapter(
+  deps: Pick<ScrapeTimeAutoLoginRunnerDependencies, "adapterRegistry">,
+  bankCode: string,
+): RunnerAdapter | BankAutoLoginOutcome {
+  try {
+    return deps.adapterRegistry.get(bankCode);
+  } catch {
+    return needsAdminAction("auto_login_config_unavailable");
+  }
+}
+
+async function safelyResolveConfig(
+  deps: Pick<ScrapeTimeAutoLoginRunnerDependencies, "autoLoginConfigs">,
+  bankCode: string,
+): Promise<ScrapeTimeAutoLoginConfigRecord | null | BankAutoLoginOutcome> {
+  try {
+    return await deps.autoLoginConfigs.getByBankCode(bankCode);
+  } catch {
+    return needsAdminAction("auto_login_config_unavailable");
+  }
+}
+
+function safelyResolveCdpUrl(
+  deps: Pick<ScrapeTimeAutoLoginRunnerDependencies, "cdpUrlForBankCode">,
+  bankCode: string,
+): string | undefined | BankAutoLoginOutcome {
+  try {
+    return deps.cdpUrlForBankCode(bankCode);
+  } catch {
+    return needsAdminAction("browser_unavailable");
+  }
+}
+
+async function resolveAutoLoginCredential(
+  deps: Pick<ScrapeTimeAutoLoginRunnerDependencies, "credentials" | "keyResolver" | "recordCredentialDecryptUse">,
+  bankCode: string,
+): Promise<CredentialResolution> {
+  let record: ScrapeTimeAutoLoginCredentialRecord | null;
+  try {
+    record = await deps.credentials.findByBankCode(bankCode);
+  } catch {
+    return needsAdminAction("credential_unavailable");
+  }
+  if (!record?.isActive) return { status: "not_found" };
+  if (record.bankCode !== bankCode) return needsAdminAction("credential_bank_mismatch");
+
+  try {
+    const credential = {
+      bankCode,
+      username: decryptCredentialField(parseCredentialEnvelope(record.encryptedUsernameEnvelope), deps.keyResolver),
+      password: decryptCredentialField(parseCredentialEnvelope(record.encryptedPasswordEnvelope), deps.keyResolver),
+    };
+    await recordCredentialDecryptUse(deps, { bankCode, keyVersion: record.keyVersion });
+    return { status: "found", credential };
+  } catch {
+    return needsAdminAction("credential_unavailable");
+  }
+}
+
+async function recordCredentialDecryptUse(
+  deps: Pick<ScrapeTimeAutoLoginRunnerDependencies, "recordCredentialDecryptUse">,
+  metadata: { bankCode: string; keyVersion: number },
+): Promise<void> {
+  try {
+    await deps.recordCredentialDecryptUse?.(metadata);
+  } catch {
+    // Audit/metrics failures must not leak or change scrape-time auto-login safety.
+  }
+}
+
+function parseCredentialEnvelope(json: string): AesGcmEnvelope {
+  const parsed = JSON.parse(json) as Partial<AesGcmEnvelope> | null;
+  if (!parsed || typeof parsed.keyVersion !== "number" || typeof parsed.iv !== "string" || typeof parsed.ciphertext !== "string" || typeof parsed.tag !== "string") {
+    throw new Error("Malformed credential envelope");
+  }
+  return parsed as AesGcmEnvelope;
+}
 
 export async function executeScrapeTimeAutoLoginTrigger(context: ScrapeTimeAutoLoginTriggerContext): Promise<ScrapeTimeAutoLoginOutcome> {
   if (context.adapter.bankCode !== context.bankCode) return needsAdminAction("unsupported_bank");
@@ -224,6 +389,10 @@ async function runGuard(operation: () => Promise<void>): Promise<BankAutoLoginOu
 
 function needsAdminAction(reason: BankAutoLoginAdminActionReason, safeSummary = SAFE_ADMIN_ACTION_SUMMARY): BankAutoLoginOutcome {
   return { status: "needs_admin_action", reason, safeSummary };
+}
+
+function isAdminActionOutcome(value: unknown): value is BankAutoLoginOutcome {
+  return typeof value === "object" && value !== null && "status" in value && value.status === "needs_admin_action";
 }
 
 function hasNonBlankString(value: unknown): value is string { return typeof value === "string" && value.trim().length > 0; }

--- a/src/worker/scraper/auto-login.ts
+++ b/src/worker/scraper/auto-login.ts
@@ -55,7 +55,7 @@ export interface ScrapeTimeAutoLoginTriggerContext {
 
 export interface ScrapeTimeAutoLoginRunnerJob {
   data: {
-    bankId: string;
+    bankId: string; // Canonical bank code from IngestionJobData, not a database id.
     expiredEventId?: string;
   };
 }
@@ -98,7 +98,7 @@ const SAFE_MANUAL_REQUIRED_SUMMARY = "Manual scrape required before retrying ban
 type CredentialResolution =
   | { status: "found"; credential: BankAutoLoginCredential }
   | { status: "not_found" }
-  | BankAutoLoginOutcome;
+  | Extract<BankAutoLoginOutcome, { status: "needs_admin_action" }>;
 
 type RunnerAdapter = ReturnType<ScrapeTimeAutoLoginRunnerDependencies["adapterRegistry"]["get"]>;
 
@@ -144,7 +144,7 @@ export function createScrapeTimeAutoLoginRunner(deps: ScrapeTimeAutoLoginRunnerD
 function safelyResolveAdapter(
   deps: Pick<ScrapeTimeAutoLoginRunnerDependencies, "adapterRegistry">,
   bankCode: string,
-): RunnerAdapter | BankAutoLoginOutcome {
+): RunnerAdapter | Extract<BankAutoLoginOutcome, { status: "needs_admin_action" }> {
   try {
     return deps.adapterRegistry.get(bankCode);
   } catch {
@@ -155,7 +155,7 @@ function safelyResolveAdapter(
 async function safelyResolveConfig(
   deps: Pick<ScrapeTimeAutoLoginRunnerDependencies, "autoLoginConfigs">,
   bankCode: string,
-): Promise<ScrapeTimeAutoLoginConfigRecord | null | BankAutoLoginOutcome> {
+): Promise<ScrapeTimeAutoLoginConfigRecord | null | Extract<BankAutoLoginOutcome, { status: "needs_admin_action" }>> {
   try {
     return await deps.autoLoginConfigs.getByBankCode(bankCode);
   } catch {
@@ -166,7 +166,7 @@ async function safelyResolveConfig(
 function safelyResolveCdpUrl(
   deps: Pick<ScrapeTimeAutoLoginRunnerDependencies, "cdpUrlForBankCode">,
   bankCode: string,
-): string | undefined | BankAutoLoginOutcome {
+): string | undefined | Extract<BankAutoLoginOutcome, { status: "needs_admin_action" }> {
   try {
     return deps.cdpUrlForBankCode(bankCode);
   } catch {
@@ -387,11 +387,11 @@ async function runGuard(operation: () => Promise<void>): Promise<BankAutoLoginOu
   }
 }
 
-function needsAdminAction(reason: BankAutoLoginAdminActionReason, safeSummary = SAFE_ADMIN_ACTION_SUMMARY): BankAutoLoginOutcome {
+function needsAdminAction(reason: BankAutoLoginAdminActionReason, safeSummary = SAFE_ADMIN_ACTION_SUMMARY): Extract<BankAutoLoginOutcome, { status: "needs_admin_action" }> {
   return { status: "needs_admin_action", reason, safeSummary };
 }
 
-function isAdminActionOutcome(value: unknown): value is BankAutoLoginOutcome {
+function isAdminActionOutcome(value: unknown): value is Extract<BankAutoLoginOutcome, { status: "needs_admin_action" }> {
   return typeof value === "object" && value !== null && "status" in value && value.status === "needs_admin_action";
 }
 


### PR DESCRIPTION
## Summary

- Wires the standalone ingestion worker to a default scrape-time auto-login runner.
- Adds safe config/credential/lock/CDP/audit dependency composition around executeScrapeTimeAutoLoginTrigger.
- Keeps browser page opener and Popular strategy incomplete/explicitly unavailable; task 4.5 remains unchecked.

## Scope

- src/worker/ingestion-worker.ts
- src/worker/scraper/auto-login.ts
- src/worker/scraper/auto-login.test.ts

## Safety boundaries

- No MFA/CAPTCHA/security-question/anti-bot bypass.
- Unknown banks fail closed; no Popular fallback.
- Credential bank mismatch fails closed.
- Credentials decrypt in memory only.
- Default browser opener returns safe admin-action posture until concrete opener lands.
- Lock release failures are surfaced via safe audit metadata.

## Verification

- pnpm test — passed: 95 files passed, 1 skipped; 1002 tests passed, 38 skipped.
- pnpm lint — passed.
- pnpm typecheck — passed.
- git diff --check — passed with LF/CRLF warnings only.
- Fresh final 4R — R1/R2/R3/R4 passed.
- Judgment Day — APPROVED with only suggestions/theoretical warnings.

## Review budget

- 3 files, 399 insertions / 1 deletion. Exactly 400 changed lines.

## Chain context

- Base: feature/multi-bank-auto-login.
- PR4.5a helper landed in #28.
- PR4.5b queue seam landed in #29.
- This is PR4.5c default runner/composition seam.
- Next slice: concrete CDP BankAutoLoginPage opener + Popular auto-login strategy wiring.

## HIGH RISK note

PR4 slices require PR-level fresh 4R + Judgment Day before merge. This branch has pre-PR 4R, Judgment Day, and full gate passing; repeat PR-level review if policy requires it after PR open.