### PR TITLE
feat(scraper): add browser opener lifecycle (PR4.5d)

### DIFF
--- a/src/modules/bank-sessions/index.ts
+++ b/src/modules/bank-sessions/index.ts
@@ -6,7 +6,12 @@ import {
   type CdpBrowserLike,
   type CdpPageLike,
 } from "../../worker/scraper/navigation/popular-cdp";
-import { assertCdpLoopback, DEFAULT_CDP_URL } from "../../worker/scraper/browser-runtime";
+import {
+  assertCdpLoopback,
+  connectPlaywrightOverCdp,
+  DEFAULT_CDP_URL,
+  openCdpPageInDefaultContext,
+} from "../../worker/scraper/browser-runtime";
 
 // ---------------------------------------------------------------------------
 // Re-export the structural types the CDP adapter already declares so callers
@@ -122,12 +127,6 @@ export interface CdpSessionChecker {
   check(): Promise<BankSessionCheckResult>;
 }
 
-async function lazyPlaywrightConnect(cdpUrl: string): Promise<CdpBrowserLike> {
-  assertCdpLoopback(cdpUrl);
-  const { chromium } = await import("playwright-core");
-  return chromium.connectOverCDP(cdpUrl) as Promise<CdpBrowserLike>;
-}
-
 /**
  * Creates a session checker that attaches to an existing human-opened Brave
  * browser session via CDP and probes the Popular portal dashboard.
@@ -142,7 +141,7 @@ export function createCdpSessionChecker(
     cdpUrl = DEFAULT_CDP_URL,
     baseUrl = "https://ib.bpd.com.do",
     waitTimeoutMs = 15_000,
-    connect = lazyPlaywrightConnect,
+    connect = connectPlaywrightOverCdp<CdpBrowserLike>,
     clock = () => new Date(),
   } = options;
 
@@ -172,12 +171,7 @@ export function createCdpSessionChecker(
           };
         }
 
-        // Use the existing human session context — same pattern as createPopularCdpScraper.
-        const defaultContext = browser.contexts()[0];
-        cdpPage =
-          defaultContext !== undefined
-            ? await defaultContext.newPage()
-            : await browser.newPage();
+        cdpPage = await openCdpPageInDefaultContext(browser);
 
         const probePage = new CdpPopularPortalPage(cdpPage);
         return await checkPopularSessionHealth(probePage, { baseUrl, waitTimeoutMs, clock });

--- a/src/worker/scraper/auto-login.test.ts
+++ b/src/worker/scraper/auto-login.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { encryptCredentialField } from "../../modules/bank-credentials/crypto";
-import { createBankAutoLoginStrategy, createScrapeTimeAutoLoginBrowserOpener, createScrapeTimeAutoLoginProductionOpener, createScrapeTimeAutoLoginRunner, executeScrapeTimeAutoLoginTrigger, unavailableScrapeTimeAutoLoginBrowserOpener, type BankAutoLoginPage } from "./auto-login";
+import { createBankAutoLoginStrategy, createScrapeTimeAutoLoginBrowserOpener, createScrapeTimeAutoLoginRunner, executeScrapeTimeAutoLoginTrigger, unavailableScrapeTimeAutoLoginBrowserOpener, type BankAutoLoginPage } from "./auto-login";
 import type { BankPortalConfig } from "./login-mutation-guard";
 
 const portalConfig: BankPortalConfig = {
@@ -677,6 +677,9 @@ describe("createScrapeTimeAutoLoginBrowserOpener", () => {
     if (result.status !== "ready") throw new Error("expected ready browser");
     return result;
   }
+  function cleanupCallCounts(page: ReturnType<typeof makeCdpPage>, browser: ReturnType<typeof makeBrowser>, release: ReturnType<typeof vi.fn>) {
+    return { page: page.close.mock.calls.length, browser: browser.close.mock.calls.length, browserSlot: release.mock.calls.length };
+  }
   function makeDeferredPageSetup(stage: "newPage" | "goto") {
     let resolveSetup: () => void = () => undefined;
     const pendingSetup = new Promise<void>((resolve) => { resolveSetup = resolve; });
@@ -685,52 +688,33 @@ describe("createScrapeTimeAutoLoginBrowserOpener", () => {
     if (stage === "newPage") browser.contexts.mockReturnValue([{ newPage: vi.fn(() => pendingSetup.then(() => page)) }]); else page.goto.mockImplementation(() => pendingSetup);
     return { page, browser, release: vi.fn().mockResolvedValue(undefined), resolveSetup };
   }
-  it("maps Popular's trusted URL and validates the supplied CDP endpoint", async () => {
-    const page = makeCdpPage();
-    const runtime = vi.fn().mockResolvedValue({ ok: true, launched: false });
-    const result = await createScrapeTimeAutoLoginProductionOpener({
-      connect: vi.fn().mockResolvedValue(makeBrowser(page)), ensureBrowserRuntimeForCdpUrl: runtime,
-      trustedLoginUrlForBank: (bankCode) => bankCode === "popular" ? POPULAR_LOGIN_URL : undefined,
-    })("popular", CDP_URL);
-    if (result.status !== "ready") throw new Error("expected ready browser");
-    await result.close();
-    expect(runtime).toHaveBeenCalledWith(CDP_URL);
-    expect(page.goto).toHaveBeenCalledWith(POPULAR_LOGIN_URL);
-  });
-  it("fails closed without a trusted URL", async () => {
-    const connect = vi.fn();
-    const production = createScrapeTimeAutoLoginProductionOpener({ connect, trustedLoginUrlForBank: () => undefined, ensureBrowserRuntimeForCdpUrl: vi.fn() });
-    await expect(production("untrusted", CDP_URL)).rejects.toThrow("Bank login page is not configured");
-    expect(connect).not.toHaveBeenCalled();
-  });
-  it("does not connect after a safe runtime readiness failure", async () => {
-    const connect = vi.fn();
-    const runtime = vi.fn().mockResolvedValue({ ok: false, launched: false, safeErrorSummary: "Bank browser did not become ready in time" });
-    await expect(createScrapeTimeAutoLoginProductionOpener({ connect, trustedLoginUrlForBank: () => POPULAR_LOGIN_URL, ensureBrowserRuntimeForCdpUrl: runtime })("popular", CDP_URL)).rejects.toThrow("Bank browser did not become ready in time");
-    expect(connect).not.toHaveBeenCalled();
-    expect(runtime).toHaveBeenCalledWith(CDP_URL);
-  });
   it("cleans up the slot and browser after an immediate default-context page rejection", async () => {
     const release = vi.fn().mockResolvedValue(undefined);
     const browser = makeBrowser(makeCdpPage());
     browser.contexts.mockReturnValue([{ newPage: vi.fn().mockRejectedValue(new Error("page creation failed")) }]);
     await expect(open({ connect: vi.fn().mockResolvedValue(browser), acquireBrowserSlot: vi.fn().mockResolvedValue({ kind: "acquired", release }) })).rejects.toThrow("page creation failed");
-    expect([browser.close, release].map((fn) => fn.mock.calls.length)).toEqual([1, 1]);
+    expect({ browser: browser.close.mock.calls.length, browserSlot: release.mock.calls.length }).toEqual({ browser: 1, browserSlot: 1 });
   });
   it("cleans up the page, browser, and slot after trusted navigation rejects", async () => {
     const release = vi.fn().mockResolvedValue(undefined);
+    const rawCloseDetail = "CDP ws://operator:secret@127.0.0.1:9222";
+    const failures = vi.fn().mockResolvedValue(undefined);
     const page = makeCdpPage();
     page.goto.mockRejectedValue(new Error("navigation failed"));
+    page.close.mockRejectedValue(new Error(rawCloseDetail));
     const browser = makeBrowser(page);
-    await expect(open({ connect: vi.fn().mockResolvedValue(browser), acquireBrowserSlot: vi.fn().mockResolvedValue({ kind: "acquired", release }) })).rejects.toThrow("navigation failed");
-    expect([page.close, browser.close, release].map((fn) => fn.mock.calls.length)).toEqual([1, 1, 1]);
+    await expect(open({ connect: vi.fn().mockResolvedValue(browser), acquireBrowserSlot: vi.fn().mockResolvedValue({ kind: "acquired", release }), cleanupTimeoutMs: CLEANUP_TIMEOUT_MS, recordCleanupFailure: failures })).rejects.toThrow("navigation failed");
+    expect(cleanupCallCounts(page, browser, release)).toEqual({ page: 1, browser: 1, browserSlot: 1 });
+    expect(failures).toHaveBeenCalledWith({ bankCode: "popular", failure: "page_close_failed" });
+    expect(JSON.stringify(failures.mock.calls)).not.toContain(rawCloseDetail);
   });
-  it.each([
-    ["slot never settles", "browser_slot_release_failed", "slot", "never settles"],
-    ["page never settles", "page_close_failed", "page", "never settles"],
-    ["browser rejects", "browser_close_failed", "browser", "rejects"],
-    ["browser never settles", "browser_close_failed", "browser", "never settles"],
-  ] as const)("records a safe %s cleanup failure", async (_, failure, resource, mode) => {
+  const cleanupFailureCases = [
+    { description: "slot never settles", failure: "browser_slot_release_failed", resource: "slot", mode: "never settles" },
+    { description: "page never settles", failure: "page_close_failed", resource: "page", mode: "never settles" },
+    { description: "browser rejects", failure: "browser_close_failed", resource: "browser", mode: "rejects" },
+    { description: "browser never settles", failure: "browser_close_failed", resource: "browser", mode: "never settles" },
+  ] as const;
+  it.each(cleanupFailureCases)("records a safe $description cleanup failure", async ({ failure, resource, mode }) => {
     const rawCdpDetail = "CDP ws://operator:secret@127.0.0.1:9222";
     const failures = vi.fn().mockResolvedValue(undefined);
     const never = () => new Promise<void>(() => undefined);
@@ -738,27 +722,46 @@ describe("createScrapeTimeAutoLoginBrowserOpener", () => {
     const browser = makeBrowser(page);
     browser.close.mockImplementation(() => resource !== "browser" ? Promise.resolve() : mode === "rejects" ? Promise.reject(new Error(rawCdpDetail)) : never());
     const release = vi.fn(resource === "slot" ? never : () => Promise.resolve());
-    await (await openReadyBrowser({ connect: vi.fn().mockResolvedValue(browser), acquireBrowserSlot: vi.fn().mockResolvedValue({ kind: "acquired", release }), cleanupTimeoutMs: CLEANUP_TIMEOUT_MS, recordCleanupFailure: failures })).close();
+    const owned = await openReadyBrowser({ connect: vi.fn().mockResolvedValue(browser), acquireBrowserSlot: vi.fn().mockResolvedValue({ kind: "acquired", release }), cleanupTimeoutMs: CLEANUP_TIMEOUT_MS, recordCleanupFailure: failures });
+    await owned.close();
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(failures).toHaveBeenCalledWith({ bankCode: "popular", failure });
     expect(JSON.stringify(failures.mock.calls)).not.toContain(rawCdpDetail);
   });
-  it.each([
-    ["newPage remains pending", "newPage", 0, [0, 1, 1]], ["trusted goto remains pending", "goto", 1, [1, 1, 1]],
-  ] as const)("bounds page setup when %s past the timeout", async (_, stage, expectedGotoCalls, cleanupBeforeResolution) => {
+
+  it("closes each owned resource once when close is called repeatedly", async () => {
+    const page = makeCdpPage();
+    const browser = makeBrowser(page);
+    const release = vi.fn().mockResolvedValue(undefined);
+    const owned = await openReadyBrowser({ connect: vi.fn().mockResolvedValue(browser), acquireBrowserSlot: vi.fn().mockResolvedValue({ kind: "acquired", release }) });
+    await owned.close();
+    await owned.close();
+
+    expect(cleanupCallCounts(page, browser, release)).toEqual({ page: 1, browser: 1, browserSlot: 1 });
+  });
+  const pageSetupTimeoutCases = [
+    { description: "newPage remains pending", stage: "newPage", expectedGotoCalls: 0, cleanupBeforeResolution: { page: 0, browser: 1, browserSlot: 1 } },
+    { description: "trusted goto remains pending", stage: "goto", expectedGotoCalls: 1, cleanupBeforeResolution: { page: 1, browser: 1, browserSlot: 1 } },
+  ] as const;
+  it.each(pageSetupTimeoutCases)("bounds page setup when $description past the timeout", async ({ stage, expectedGotoCalls, cleanupBeforeResolution }) => {
     vi.useFakeTimers();
     try {
       const { page, browser, release, resolveSetup } = makeDeferredPageSetup(stage);
+      const failures = vi.fn().mockResolvedValue(undefined);
+      page.close.mockImplementation(() => new Promise<void>(() => undefined));
       const opening = open({ connect: vi.fn().mockResolvedValue(browser),
-        acquireBrowserSlot: vi.fn().mockResolvedValue({ kind: "acquired", release }), pageSetupTimeoutMs: PAGE_SETUP_TIMEOUT_MS });
+        acquireBrowserSlot: vi.fn().mockResolvedValue({ kind: "acquired", release }), pageSetupTimeoutMs: PAGE_SETUP_TIMEOUT_MS,
+        cleanupTimeoutMs: CLEANUP_TIMEOUT_MS, recordCleanupFailure: failures });
       const rejected = expect(opening).rejects.toThrow("Timed out while preparing the trusted bank login page");
       await vi.advanceTimersByTimeAsync(PAGE_SETUP_TIMEOUT_MS);
       await rejected;
-      expect([page.close, browser.close, release].map((cleanup) => cleanup.mock.calls.length)).toEqual(cleanupBeforeResolution);
+      expect(cleanupCallCounts(page, browser, release)).toEqual(cleanupBeforeResolution);
       resolveSetup();
       await vi.advanceTimersByTimeAsync(0);
-      expect([page.close, browser.close, release].map((cleanup) => cleanup.mock.calls.length)).toEqual([1, 1, 1]);
+      expect(cleanupCallCounts(page, browser, release)).toEqual({ page: 1, browser: 1, browserSlot: 1 });
       expect(page.goto).toHaveBeenCalledTimes(expectedGotoCalls);
+      await vi.advanceTimersByTimeAsync(CLEANUP_TIMEOUT_MS);
+      expect(failures).toHaveBeenCalledWith({ bankCode: "popular", failure: "page_close_failed" });
     } finally {
       vi.useRealTimers();
     }

--- a/src/worker/scraper/auto-login.test.ts
+++ b/src/worker/scraper/auto-login.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { encryptCredentialField } from "../../modules/bank-credentials/crypto";
-import { createBankAutoLoginStrategy, createScrapeTimeAutoLoginRunner, executeScrapeTimeAutoLoginTrigger, unavailableScrapeTimeAutoLoginBrowserOpener, type BankAutoLoginPage } from "./auto-login";
+import { createBankAutoLoginStrategy, createScrapeTimeAutoLoginBrowserOpener, createScrapeTimeAutoLoginProductionOpener, createScrapeTimeAutoLoginRunner, executeScrapeTimeAutoLoginTrigger, unavailableScrapeTimeAutoLoginBrowserOpener, type BankAutoLoginPage } from "./auto-login";
 import type { BankPortalConfig } from "./login-mutation-guard";
 
 const portalConfig: BankPortalConfig = {
@@ -33,6 +33,14 @@ function makePage(options: { url?: string; visible?: readonly string[]; onFill?:
     },
     setUrl(nextUrl: string) { url = nextUrl; },
     show(selector: string) { visible.add(selector); },
+  };
+}
+
+function readyBrowser(page: BankAutoLoginPage) {
+  return {
+    status: "ready" as const,
+    page,
+    close: vi.fn().mockResolvedValue(undefined),
   };
 }
 
@@ -204,9 +212,10 @@ describe("executeScrapeTimeAutoLoginTrigger", () => {
       events.push("autoLogin settled");
       return outcome;
     }));
+    const close = vi.fn(() => { events.push("browser closed"); return Promise.resolve(); });
     const ensureBrowser = vi.fn(() => Promise.resolve({ status: "ready" as const, page }).then((browser) => {
       events.push("ensureBrowser settled");
-      return browser;
+      return { ...browser, close };
     }));
 
     let helperResolved = false;
@@ -227,7 +236,7 @@ describe("executeScrapeTimeAutoLoginTrigger", () => {
     await releaseStarted;
     await Promise.resolve();
     expect(helperResolved).toBe(false);
-    expect(events).toEqual(["ensureBrowser settled", "autoLogin settled", "release started"]);
+    expect(events).toEqual(["ensureBrowser settled", "autoLogin settled", "browser closed", "release started"]);
 
     releaseSettledResolve(true);
     await expect(result).resolves.toEqual({ status: "succeeded" });
@@ -235,8 +244,9 @@ describe("executeScrapeTimeAutoLoginTrigger", () => {
     expect(acquire).toHaveBeenCalledWith("popular", "E1");
     expect(ensureBrowser).toHaveBeenCalledWith("http://127.0.0.1:9222");
     expect(autoLogin).toHaveBeenCalledWith({ credential, page });
+    expect(close).toHaveBeenCalledTimes(1);
     expect(release).toHaveBeenCalledWith("popular", "E1", "lease-1");
-    expect(events).toEqual(["ensureBrowser settled", "autoLogin settled", "release started", "helper resolved"]);
+    expect(events).toEqual(["ensureBrowser settled", "autoLogin settled", "browser closed", "release started", "helper resolved"]);
   });
 
   it("requires manual scraping when the same expired event lock is already held", async () => {
@@ -376,12 +386,15 @@ describe("executeScrapeTimeAutoLoginTrigger", () => {
   });
 
   it("owner-releases the lock when delegated login returns admin action", async () => {
-    const release = vi.fn().mockResolvedValue(true);
+    const events: string[] = [];
+    const release = vi.fn(() => { events.push("lock.release"); return Promise.resolve(true); });
     const autoLogin = vi.fn().mockResolvedValue({
       status: "needs_admin_action",
       reason: "protected_flow",
       safeSummary: "MFA is required",
     });
+    const browser = readyBrowser(makePage());
+    browser.close.mockImplementation(() => { events.push("browser.close"); return Promise.resolve(); });
 
     await expect(executeScrapeTimeAutoLoginTrigger({
       bankCode: "popular",
@@ -390,7 +403,7 @@ describe("executeScrapeTimeAutoLoginTrigger", () => {
       credential,
       cdpUrl: "http://127.0.0.1:9222",
       lock: { acquire: vi.fn().mockResolvedValue({ leaseToken: "lease-1", fencingToken: 7, expiresAt: 12345 }), release },
-      ensureBrowser: vi.fn().mockResolvedValue({ status: "ready", page: makePage() }),
+      ensureBrowser: vi.fn().mockResolvedValue(browser),
     })).resolves.toEqual({
       status: "needs_admin_action",
       reason: "protected_flow",
@@ -398,11 +411,15 @@ describe("executeScrapeTimeAutoLoginTrigger", () => {
     });
 
     expect(release).toHaveBeenCalledWith("popular", "E1", "lease-1");
+    expect(events).toEqual(["browser.close", "lock.release"]);
   });
 
   it("owner-releases the lock and reports portal state unavailable when delegated login rejects", async () => {
-    const release = vi.fn().mockResolvedValue(true);
+    const events: string[] = [];
+    const release = vi.fn(() => { events.push("lock.release"); return Promise.resolve(true); });
     const autoLogin = vi.fn().mockRejectedValue(new Error("portal token=secret crashed"));
+    const browser = readyBrowser(makePage());
+    browser.close.mockImplementation(() => { events.push("browser.close"); return Promise.resolve(); });
 
     await expect(executeScrapeTimeAutoLoginTrigger({
       bankCode: "popular",
@@ -411,7 +428,7 @@ describe("executeScrapeTimeAutoLoginTrigger", () => {
       credential,
       cdpUrl: "http://127.0.0.1:9222",
       lock: { acquire: vi.fn().mockResolvedValue({ leaseToken: "lease-1", fencingToken: 7, expiresAt: 12345 }), release },
-      ensureBrowser: vi.fn().mockResolvedValue({ status: "ready", page: makePage() }),
+      ensureBrowser: vi.fn().mockResolvedValue(browser),
     })).resolves.toEqual({
       status: "needs_admin_action",
       reason: "portal_state_unavailable",
@@ -419,6 +436,7 @@ describe("executeScrapeTimeAutoLoginTrigger", () => {
     });
 
     expect(release).toHaveBeenCalledWith("popular", "E1", "lease-1");
+    expect(events).toEqual(["browser.close", "lock.release"]);
   });
 
   it("records safe release failure metadata without changing a successful outcome", async () => {
@@ -432,7 +450,7 @@ describe("executeScrapeTimeAutoLoginTrigger", () => {
       credential,
       cdpUrl: "http://127.0.0.1:9222",
       lock: { acquire: vi.fn().mockResolvedValue({ leaseToken: "lease-1", fencingToken: 7, expiresAt: 12345 }), release },
-      ensureBrowser: vi.fn().mockResolvedValue({ status: "ready", page: makePage() }),
+      ensureBrowser: vi.fn().mockResolvedValue(readyBrowser(makePage())),
       recordLockReleaseFailure,
     })).resolves.toEqual({ status: "succeeded" });
 
@@ -450,7 +468,7 @@ describe("executeScrapeTimeAutoLoginTrigger", () => {
       credential,
       cdpUrl: "http://127.0.0.1:9222",
       lock: { acquire: vi.fn().mockResolvedValue({ leaseToken: "lease-1", fencingToken: 7, expiresAt: 12345 }), release },
-      ensureBrowser: vi.fn().mockResolvedValue({ status: "ready", page: makePage() }),
+      ensureBrowser: vi.fn().mockResolvedValue(readyBrowser(makePage())),
       recordLockReleaseFailure,
     })).resolves.toEqual({ status: "succeeded" });
 
@@ -458,7 +476,7 @@ describe("executeScrapeTimeAutoLoginTrigger", () => {
   });
 
   it("swallows release failure hook rejections without changing admin outcomes", async () => {
-    const release = vi.fn().mockRejectedValue(new Error("Redis token=secret failed"));
+    const release = vi.fn().mockRejectedValue(new Error("lock release failed"));
     const recordLockReleaseFailure = vi.fn().mockRejectedValue(new Error("metrics token=secret failed"));
 
     await expect(executeScrapeTimeAutoLoginTrigger({
@@ -468,7 +486,7 @@ describe("executeScrapeTimeAutoLoginTrigger", () => {
       credential,
       cdpUrl: "http://127.0.0.1:9222",
       lock: { acquire: vi.fn().mockResolvedValue({ leaseToken: "lease-1", fencingToken: 7, expiresAt: 12345 }), release },
-      ensureBrowser: vi.fn().mockResolvedValue({ status: "ready", page: makePage() }),
+      ensureBrowser: vi.fn().mockResolvedValue(readyBrowser(makePage())),
       recordLockReleaseFailure,
     })).resolves.toEqual({ status: "needs_admin_action", reason: "protected_flow", safeSummary: "MFA is required" });
 
@@ -604,7 +622,7 @@ describe("createScrapeTimeAutoLoginRunner", () => {
       keyResolver,
       lock: { acquire: vi.fn().mockResolvedValue({ leaseToken: "lease-1", fencingToken: 1, expiresAt: 123 }), release: vi.fn().mockResolvedValue(false) },
       cdpUrlForBankCode: vi.fn().mockReturnValue("http://127.0.0.1:9222"),
-      ensureBrowser: vi.fn().mockResolvedValue({ status: "ready", page: makePage() }),
+      ensureBrowser: vi.fn().mockResolvedValue(readyBrowser(makePage())),
       recordLockReleaseFailure,
     });
 
@@ -625,12 +643,124 @@ describe("createScrapeTimeAutoLoginRunner", () => {
       keyResolver,
       lock: { acquire, release },
       cdpUrlForBankCode: vi.fn().mockReturnValue("http://127.0.0.1:9222"),
-      ensureBrowser: vi.fn().mockResolvedValue({ status: "ready", page }),
+      ensureBrowser: vi.fn().mockResolvedValue(readyBrowser(page)),
     });
 
     await expect(run({ data: { bankId: "popular", expiredEventId: "E1" } })).resolves.toEqual({ status: "succeeded" });
     expect(autoLogin).toHaveBeenCalledWith({ credential: { bankCode: "popular", username: "bank-user", password: "bank-password" }, page });
     expect(acquire).toHaveBeenCalledWith("popular", "E1");
     expect(release).toHaveBeenCalledWith("popular", "E1", "lease-1");
+  });
+});
+
+describe("createScrapeTimeAutoLoginBrowserOpener", () => {
+  const CDP_URL = "http://127.0.0.1:9222";
+  const CLEANUP_TIMEOUT_MS = 2;
+  const PAGE_SETUP_TIMEOUT_MS = 2;
+  const POPULAR_LOGIN_URL = "https://ib.bpd.com.do/login";
+  function makeCdpPage() {
+    return {
+      url: vi.fn(() => "https://ib.bpd.com.do/login"),
+      goto: vi.fn(),
+      waitForSelector: vi.fn((selector: string) => selector === "#missing"
+        ? Promise.reject(Object.assign(new Error("not visible"), { name: "TimeoutError" })) : Promise.resolve({})),
+      fill: vi.fn(), click: vi.fn(), close: vi.fn().mockResolvedValue(undefined),
+    };
+  }
+  function makeBrowser(page: ReturnType<typeof makeCdpPage>) {
+    return { contexts: vi.fn(() => [{ newPage: vi.fn().mockResolvedValue(page) }]), newPage: vi.fn(), close: vi.fn().mockResolvedValue(undefined) };
+  }
+  type OpenerOptions = Omit<Parameters<typeof createScrapeTimeAutoLoginBrowserOpener>[0], "trustedLoginUrl">;
+  const open = (options: OpenerOptions) => createScrapeTimeAutoLoginBrowserOpener({ trustedLoginUrl: POPULAR_LOGIN_URL, ...options })("popular", CDP_URL);
+  async function openReadyBrowser(options: OpenerOptions) {
+    const result = await open(options);
+    if (result.status !== "ready") throw new Error("expected ready browser");
+    return result;
+  }
+  function makeDeferredPageSetup(stage: "newPage" | "goto") {
+    let resolveSetup: () => void = () => undefined;
+    const pendingSetup = new Promise<void>((resolve) => { resolveSetup = resolve; });
+    const page = makeCdpPage();
+    const browser = makeBrowser(page);
+    if (stage === "newPage") browser.contexts.mockReturnValue([{ newPage: vi.fn(() => pendingSetup.then(() => page)) }]); else page.goto.mockImplementation(() => pendingSetup);
+    return { page, browser, release: vi.fn().mockResolvedValue(undefined), resolveSetup };
+  }
+  it("maps Popular's trusted URL and validates the supplied CDP endpoint", async () => {
+    const page = makeCdpPage();
+    const runtime = vi.fn().mockResolvedValue({ ok: true, launched: false });
+    const result = await createScrapeTimeAutoLoginProductionOpener({
+      connect: vi.fn().mockResolvedValue(makeBrowser(page)), ensureBrowserRuntimeForCdpUrl: runtime,
+      trustedLoginUrlForBank: (bankCode) => bankCode === "popular" ? POPULAR_LOGIN_URL : undefined,
+    })("popular", CDP_URL);
+    if (result.status !== "ready") throw new Error("expected ready browser");
+    await result.close();
+    expect(runtime).toHaveBeenCalledWith(CDP_URL);
+    expect(page.goto).toHaveBeenCalledWith(POPULAR_LOGIN_URL);
+  });
+  it("fails closed without a trusted URL", async () => {
+    const connect = vi.fn();
+    const production = createScrapeTimeAutoLoginProductionOpener({ connect, trustedLoginUrlForBank: () => undefined, ensureBrowserRuntimeForCdpUrl: vi.fn() });
+    await expect(production("untrusted", CDP_URL)).rejects.toThrow("Bank login page is not configured");
+    expect(connect).not.toHaveBeenCalled();
+  });
+  it("does not connect after a safe runtime readiness failure", async () => {
+    const connect = vi.fn();
+    const runtime = vi.fn().mockResolvedValue({ ok: false, launched: false, safeErrorSummary: "Bank browser did not become ready in time" });
+    await expect(createScrapeTimeAutoLoginProductionOpener({ connect, trustedLoginUrlForBank: () => POPULAR_LOGIN_URL, ensureBrowserRuntimeForCdpUrl: runtime })("popular", CDP_URL)).rejects.toThrow("Bank browser did not become ready in time");
+    expect(connect).not.toHaveBeenCalled();
+    expect(runtime).toHaveBeenCalledWith(CDP_URL);
+  });
+  it("cleans up the slot and browser after an immediate default-context page rejection", async () => {
+    const release = vi.fn().mockResolvedValue(undefined);
+    const browser = makeBrowser(makeCdpPage());
+    browser.contexts.mockReturnValue([{ newPage: vi.fn().mockRejectedValue(new Error("page creation failed")) }]);
+    await expect(open({ connect: vi.fn().mockResolvedValue(browser), acquireBrowserSlot: vi.fn().mockResolvedValue({ kind: "acquired", release }) })).rejects.toThrow("page creation failed");
+    expect([browser.close, release].map((fn) => fn.mock.calls.length)).toEqual([1, 1]);
+  });
+  it("cleans up the page, browser, and slot after trusted navigation rejects", async () => {
+    const release = vi.fn().mockResolvedValue(undefined);
+    const page = makeCdpPage();
+    page.goto.mockRejectedValue(new Error("navigation failed"));
+    const browser = makeBrowser(page);
+    await expect(open({ connect: vi.fn().mockResolvedValue(browser), acquireBrowserSlot: vi.fn().mockResolvedValue({ kind: "acquired", release }) })).rejects.toThrow("navigation failed");
+    expect([page.close, browser.close, release].map((fn) => fn.mock.calls.length)).toEqual([1, 1, 1]);
+  });
+  it.each([
+    ["slot never settles", "browser_slot_release_failed", "slot", "never settles"],
+    ["page never settles", "page_close_failed", "page", "never settles"],
+    ["browser rejects", "browser_close_failed", "browser", "rejects"],
+    ["browser never settles", "browser_close_failed", "browser", "never settles"],
+  ] as const)("records a safe %s cleanup failure", async (_, failure, resource, mode) => {
+    const rawCdpDetail = "CDP ws://operator:secret@127.0.0.1:9222";
+    const failures = vi.fn().mockResolvedValue(undefined);
+    const never = () => new Promise<void>(() => undefined);
+    const page = { ...makeCdpPage(), close: vi.fn(resource === "page" ? never : () => Promise.resolve()) };
+    const browser = makeBrowser(page);
+    browser.close.mockImplementation(() => resource !== "browser" ? Promise.resolve() : mode === "rejects" ? Promise.reject(new Error(rawCdpDetail)) : never());
+    const release = vi.fn(resource === "slot" ? never : () => Promise.resolve());
+    await (await openReadyBrowser({ connect: vi.fn().mockResolvedValue(browser), acquireBrowserSlot: vi.fn().mockResolvedValue({ kind: "acquired", release }), cleanupTimeoutMs: CLEANUP_TIMEOUT_MS, recordCleanupFailure: failures })).close();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(failures).toHaveBeenCalledWith({ bankCode: "popular", failure });
+    expect(JSON.stringify(failures.mock.calls)).not.toContain(rawCdpDetail);
+  });
+  it.each([
+    ["newPage remains pending", "newPage", 0, [0, 1, 1]], ["trusted goto remains pending", "goto", 1, [1, 1, 1]],
+  ] as const)("bounds page setup when %s past the timeout", async (_, stage, expectedGotoCalls, cleanupBeforeResolution) => {
+    vi.useFakeTimers();
+    try {
+      const { page, browser, release, resolveSetup } = makeDeferredPageSetup(stage);
+      const opening = open({ connect: vi.fn().mockResolvedValue(browser),
+        acquireBrowserSlot: vi.fn().mockResolvedValue({ kind: "acquired", release }), pageSetupTimeoutMs: PAGE_SETUP_TIMEOUT_MS });
+      const rejected = expect(opening).rejects.toThrow("Timed out while preparing the trusted bank login page");
+      await vi.advanceTimersByTimeAsync(PAGE_SETUP_TIMEOUT_MS);
+      await rejected;
+      expect([page.close, browser.close, release].map((cleanup) => cleanup.mock.calls.length)).toEqual(cleanupBeforeResolution);
+      resolveSetup();
+      await vi.advanceTimersByTimeAsync(0);
+      expect([page.close, browser.close, release].map((cleanup) => cleanup.mock.calls.length)).toEqual([1, 1, 1]);
+      expect(page.goto).toHaveBeenCalledTimes(expectedGotoCalls);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/worker/scraper/auto-login.ts
+++ b/src/worker/scraper/auto-login.ts
@@ -36,15 +36,10 @@ export interface ScrapeTimeAutoLoginBrowserOpenerOptions {
   connect?: (cdpUrl: string) => Promise<AutoLoginCdpBrowserLike>;
   ensureBrowserRuntime?: (cdpUrl: string) => Promise<EnsureCdpBrowserResult>;
   acquireBrowserSlot?: AcquireBrowserSlot;
-  recordCleanupFailure?(metadata: { bankCode: string; failure: "browser_slot_release_failed" | "page_close_failed" | "browser_close_failed" }): void | Promise<void>;
+  recordCleanupFailure?(metadata: { bankCode: string; failure: BrowserCleanupFailure }): void | Promise<void>;
   cleanupTimeoutMs?: number;
   pageSetupTimeoutMs?: number;
   visibleSelectorTimeoutMs?: number;
-}
-type EnsureBrowserRuntime = NonNullable<ScrapeTimeAutoLoginBrowserOpenerOptions["ensureBrowserRuntime"]>;
-export interface ScrapeTimeAutoLoginProductionOpenerOptions extends Omit<ScrapeTimeAutoLoginBrowserOpenerOptions, "ensureBrowserRuntime" | "trustedLoginUrl"> {
-  ensureBrowserRuntimeForCdpUrl(cdpUrl: string): ReturnType<EnsureBrowserRuntime>;
-  trustedLoginUrlForBank(bankCode: string): string | undefined;
 }
 export type BankAutoLoginAdminActionReason =
   | "unsupported_bank"
@@ -142,10 +137,14 @@ const DEFAULT_VISIBLE_SELECTOR_TIMEOUT_MS = 500;
 const DEFAULT_BROWSER_CLEANUP_TIMEOUT_MS = 1_000;
 const DEFAULT_BROWSER_PAGE_SETUP_TIMEOUT_MS = 15_000;
 const PAGE_SETUP_TIMEOUT_ERROR = "Timed out while preparing the trusted bank login page";
+type BrowserCleanupFailure = "browser_slot_release_failed" | "page_close_failed" | "browser_close_failed";
+
 export function createScrapeTimeAutoLoginBrowserOpener(options: ScrapeTimeAutoLoginBrowserOpenerOptions): ScrapeTimeAutoLoginRunnerDependencies["ensureBrowser"] {
   const {
-    trustedLoginUrl, connect = connectPlaywrightOverCdp<AutoLoginCdpBrowserLike>, ensureBrowserRuntime, acquireBrowserSlot,
-    recordCleanupFailure,
+    trustedLoginUrl,
+    connect = connectPlaywrightOverCdp<AutoLoginCdpBrowserLike>,
+    ensureBrowserRuntime,
+    acquireBrowserSlot, recordCleanupFailure,
     cleanupTimeoutMs = DEFAULT_BROWSER_CLEANUP_TIMEOUT_MS,
     pageSetupTimeoutMs = DEFAULT_BROWSER_PAGE_SETUP_TIMEOUT_MS,
     visibleSelectorTimeoutMs = DEFAULT_VISIBLE_SELECTOR_TIMEOUT_MS,
@@ -154,15 +153,27 @@ export function createScrapeTimeAutoLoginBrowserOpener(options: ScrapeTimeAutoLo
     assertCdpLoopback(cdpUrl);
     const browserSlot = await acquireBrowserSlot?.();
     if (browserSlot?.kind === "throttled") return { status: "throttled" };
+    const acquiredBrowserSlot = browserSlot?.kind === "acquired" ? browserSlot : null;
     let browser: AutoLoginCdpBrowserLike | null = null;
     let page: AutoLoginCdpPageLike | null = null;
-    const closeResources = () => closeAutoLoginBrowserResources({ bankCode, page, browser,
-      browserSlot: browserSlot?.kind === "acquired" ? browserSlot : null, recordCleanupFailure, cleanupTimeoutMs });
+    let closeOwnedResources: Promise<void> | undefined;
+    const closeResources = () => {
+      closeOwnedResources ??= closeAutoLoginBrowserResources({ bankCode, page, browser,
+        browserSlot: acquiredBrowserSlot, recordCleanupFailure, cleanupTimeoutMs });
+      return closeOwnedResources;
+    };
     try {
       const browserCheck = await ensureBrowserRuntime?.(cdpUrl);
       if (browserCheck && !browserCheck.ok) throw new Error(browserCheck.safeErrorSummary);
       browser = await connect(cdpUrl);
-      page = await openTrustedLoginPage(browser, trustedLoginUrl, pageSetupTimeoutMs);
+      page = await openTrustedLoginPage({
+        browser,
+        trustedLoginUrl,
+        timeoutMs: pageSetupTimeoutMs,
+        cleanupTimeoutMs,
+        onPageCloseFailure: () => recordBrowserCleanupFailure(recordCleanupFailure, bankCode, "page_close_failed"),
+      });
+
       return { status: "ready", page: new CdpBankAutoLoginPage(page, visibleSelectorTimeoutMs), close: closeResources };
     } catch (error) {
       await closeResources();
@@ -170,31 +181,36 @@ export function createScrapeTimeAutoLoginBrowserOpener(options: ScrapeTimeAutoLo
     }
   };
 }
-export function createScrapeTimeAutoLoginProductionOpener(options: ScrapeTimeAutoLoginProductionOpenerOptions): ScrapeTimeAutoLoginRunnerDependencies["ensureBrowser"] {
-  const { ensureBrowserRuntimeForCdpUrl, trustedLoginUrlForBank, ...openerOptions } = options;
-  return async (bankCode, cdpUrl) => {
-    const trustedLoginUrl = trustedLoginUrlForBank(bankCode);
-    if (!trustedLoginUrl) throw new Error("Bank login page is not configured");
-    return createScrapeTimeAutoLoginBrowserOpener({ ...openerOptions, trustedLoginUrl,
-      ensureBrowserRuntime: ensureBrowserRuntimeForCdpUrl })(bankCode, cdpUrl);
-  };
-}
-async function openTrustedLoginPage(browser: AutoLoginCdpBrowserLike, trustedLoginUrl: string, timeoutMs: number): Promise<AutoLoginCdpPageLike> {
-  let openedPage: AutoLoginCdpPageLike | null = null;
-  let closedPage: Promise<void> | undefined;
-  let timedOut = false;
-  const closeOpenedPage = () => {
-    if (!openedPage) return;
-    closedPage ??= Promise.resolve().then(() => openedPage!.close()).catch(() => undefined);
-    return closedPage;
+type OpenTrustedLoginPageOptions = { browser: AutoLoginCdpBrowserLike; trustedLoginUrl: string; timeoutMs: number; cleanupTimeoutMs: number; onPageCloseFailure(): Promise<void> };
+
+async function openTrustedLoginPage(options: OpenTrustedLoginPageOptions): Promise<AutoLoginCdpPageLike> {
+  const { browser, trustedLoginUrl, timeoutMs, cleanupTimeoutMs, onPageCloseFailure } = options;
+  let setupPage: AutoLoginCdpPageLike | null = null;
+  let setupOwnsPage = true;
+  let pageCleanup: Promise<void> | undefined;
+  let setupAbandoned = false;
+  const closeSetupPage = (): Promise<void> => {
+    if (!setupPage || !setupOwnsPage) return Promise.resolve();
+    pageCleanup ??= runBoundedCleanup(() => setupPage!.close(), cleanupTimeoutMs, onPageCloseFailure);
+    return pageCleanup;
   };
   const setup = openCdpPageInDefaultContext(browser).then(async (page) => {
-    openedPage = page;
-    if (timedOut) {
-      void closeOpenedPage();
+    setupPage = page;
+    if (setupAbandoned) {
+      await closeSetupPage();
       throw new Error(PAGE_SETUP_TIMEOUT_ERROR);
     }
-    await page.goto(trustedLoginUrl);
+    try {
+      await page.goto(trustedLoginUrl);
+    } catch (error) {
+      await closeSetupPage();
+      throw error;
+    }
+    if (setupAbandoned) {
+      await closeSetupPage();
+      throw new Error(PAGE_SETUP_TIMEOUT_ERROR);
+    }
+    setupOwnsPage = false;
     return page;
   });
   let timeout: ReturnType<typeof setTimeout> | undefined;
@@ -203,14 +219,15 @@ async function openTrustedLoginPage(browser: AutoLoginCdpBrowserLike, trustedLog
       setup,
       new Promise<never>((_, reject) => {
         timeout = setTimeout(() => {
-          timedOut = true;
+          setupAbandoned = true;
           reject(new Error(PAGE_SETUP_TIMEOUT_ERROR));
         }, timeoutMs);
       }),
     ]);
   } catch (error) {
-    void closeOpenedPage();
-    void setup.then(closeOpenedPage).catch(() => undefined);
+    setupAbandoned = true;
+    void closeSetupPage();
+    void setup.catch(() => undefined);
     throw error;
   } finally {
     if (timeout) clearTimeout(timeout);
@@ -241,10 +258,14 @@ async function closeAutoLoginBrowserResources(options: {
 }): Promise<void> {
   const { bankCode, page, browser, browserSlot, recordCleanupFailure, cleanupTimeoutMs } = options;
   // Free capacity before bounded CDP teardown; Popular owns its separate scraper lifecycle.
-  if (browserSlot) await runBoundedCleanup(() => browserSlot.release(), cleanupTimeoutMs, () => recordBrowserCleanupFailure(recordCleanupFailure, bankCode, "browser_slot_release_failed"));
-  if (page) await runBoundedCleanup(() => page.close(), cleanupTimeoutMs, () => recordBrowserCleanupFailure(recordCleanupFailure, bankCode, "page_close_failed"));
-  if (browser) await runBoundedCleanup(() => browser.close(), cleanupTimeoutMs, () => recordBrowserCleanupFailure(recordCleanupFailure, bankCode, "browser_close_failed"));
+  if (browserSlot) await runBoundedCleanup(() => browserSlot.release(), cleanupTimeoutMs, () =>
+    recordBrowserCleanupFailure(recordCleanupFailure, bankCode, "browser_slot_release_failed"));
+  if (page) await runBoundedCleanup(() => page.close(), cleanupTimeoutMs, () =>
+    recordBrowserCleanupFailure(recordCleanupFailure, bankCode, "page_close_failed"));
+  if (browser) await runBoundedCleanup(() => browser.close(), cleanupTimeoutMs, () =>
+    recordBrowserCleanupFailure(recordCleanupFailure, bankCode, "browser_close_failed"));
 }
+
 async function runBoundedCleanup(cleanup: () => Promise<void>, timeoutMs: number, onFailure: () => Promise<void>): Promise<void> {
   let timeout: ReturnType<typeof setTimeout> | undefined;
   const cleanupResult = Promise.resolve().then(cleanup).then(() => "completed" as const, () => "failed" as const);
@@ -254,8 +275,12 @@ async function runBoundedCleanup(cleanup: () => Promise<void>, timeoutMs: number
   if (result !== "completed") void Promise.resolve().then(onFailure).catch(() => undefined);
 }
 function isExpectedSelectorTimeout(error: unknown): boolean { return error instanceof Error && error.name === "TimeoutError"; }
-async function recordBrowserCleanupFailure(recordCleanupFailure: ScrapeTimeAutoLoginBrowserOpenerOptions["recordCleanupFailure"] | undefined,
-  bankCode: string, failure: "browser_slot_release_failed" | "page_close_failed" | "browser_close_failed"): Promise<void> {
+
+async function recordBrowserCleanupFailure(
+  recordCleanupFailure: ScrapeTimeAutoLoginBrowserOpenerOptions["recordCleanupFailure"] | undefined,
+  bankCode: string,
+  failure: BrowserCleanupFailure,
+): Promise<void> {
   return Promise.resolve(recordCleanupFailure?.({ bankCode, failure })).then(() => undefined);
 }
 export function createScrapeTimeAutoLoginRunner(deps: ScrapeTimeAutoLoginRunnerDependencies) {

--- a/src/worker/scraper/auto-login.ts
+++ b/src/worker/scraper/auto-login.ts
@@ -1,5 +1,14 @@
 import { LOGIN_MUTATION_GUARD_ERROR_SUMMARIES, LoginMutationGuard, LoginMutationGuardError, type BankPortalConfig, type LoginMutationPage } from "./login-mutation-guard";
-import { assertCdpLoopback, getSafeCdpErrorSummary } from "./browser-runtime";
+import {
+  assertCdpLoopback,
+  connectPlaywrightOverCdp,
+  getSafeCdpErrorSummary,
+  openCdpPageInDefaultContext,
+  type AcquireBrowserSlot,
+  type CdpBrowserLike,
+  type CdpPageLike,
+  type EnsureCdpBrowserResult,
+} from "./browser-runtime";
 import { decryptCredentialField, type AesGcmEnvelope, type KeyResolver } from "../../modules/bank-credentials/crypto";
 import type { AutoLoginLock } from "../../modules/bank-auto-login-lock";
 
@@ -14,6 +23,29 @@ export interface BankAutoLoginPage extends LoginMutationPage {
   click(selector: string): void | Promise<void>;
 }
 
+export type ScrapeTimeAutoLoginBrowserResult = { status: "ready"; page: BankAutoLoginPage; close(): Promise<void> } | { status: "throttled" };
+export interface AutoLoginCdpPageLike extends CdpPageLike {
+  waitForSelector(selector: string, options?: { timeout?: number; state?: string }): Promise<unknown>;
+  fill(selector: string, value: string): Promise<void>;
+  click(selector: string): Promise<void>;
+}
+export type AutoLoginCdpBrowserLike = CdpBrowserLike<AutoLoginCdpPageLike>;
+export interface ScrapeTimeAutoLoginBrowserOpenerOptions {
+  /** Trusted adapter/factory configuration; never derived from the attached page. */
+  trustedLoginUrl: string;
+  connect?: (cdpUrl: string) => Promise<AutoLoginCdpBrowserLike>;
+  ensureBrowserRuntime?: (cdpUrl: string) => Promise<EnsureCdpBrowserResult>;
+  acquireBrowserSlot?: AcquireBrowserSlot;
+  recordCleanupFailure?(metadata: { bankCode: string; failure: "browser_slot_release_failed" | "page_close_failed" | "browser_close_failed" }): void | Promise<void>;
+  cleanupTimeoutMs?: number;
+  pageSetupTimeoutMs?: number;
+  visibleSelectorTimeoutMs?: number;
+}
+type EnsureBrowserRuntime = NonNullable<ScrapeTimeAutoLoginBrowserOpenerOptions["ensureBrowserRuntime"]>;
+export interface ScrapeTimeAutoLoginProductionOpenerOptions extends Omit<ScrapeTimeAutoLoginBrowserOpenerOptions, "ensureBrowserRuntime" | "trustedLoginUrl"> {
+  ensureBrowserRuntimeForCdpUrl(cdpUrl: string): ReturnType<EnsureBrowserRuntime>;
+  trustedLoginUrlForBank(bankCode: string): string | undefined;
+}
 export type BankAutoLoginAdminActionReason =
   | "unsupported_bank"
   | "credential_bank_mismatch"
@@ -49,7 +81,7 @@ export interface ScrapeTimeAutoLoginTriggerContext {
   credential: BankAutoLoginCredential;
   cdpUrl: string;
   lock: Pick<AutoLoginLock, "acquire" | "release">;
-  ensureBrowser(cdpUrl: string): Promise<{ status: "ready"; page: BankAutoLoginPage } | { status: "throttled" }>;
+  ensureBrowser(cdpUrl: string): Promise<ScrapeTimeAutoLoginBrowserResult>;
   recordLockReleaseFailure?(metadata: { bankCode: string; expiredEventId: string }): void | Promise<void>;
 }
 
@@ -86,7 +118,7 @@ export interface ScrapeTimeAutoLoginRunnerDependencies {
   keyResolver: KeyResolver;
   lock: Pick<AutoLoginLock, "acquire" | "release"> | null;
   cdpUrlForBankCode(bankCode: string): string | undefined;
-  ensureBrowser(bankCode: string, cdpUrl: string): Promise<{ status: "ready"; page: BankAutoLoginPage } | { status: "throttled" }>;
+  ensureBrowser(bankCode: string, cdpUrl: string): Promise<ScrapeTimeAutoLoginBrowserResult>;
   recordLockReleaseFailure?(metadata: { bankCode: string; expiredEventId: string }): void | Promise<void>;
   recordCredentialDecryptUse?(metadata: { bankCode: string; keyVersion: number }): void | Promise<void>;
 }
@@ -102,8 +134,130 @@ type CredentialResolution =
 
 type RunnerAdapter = ReturnType<ScrapeTimeAutoLoginRunnerDependencies["adapterRegistry"]["get"]>;
 
-export const unavailableScrapeTimeAutoLoginBrowserOpener: ScrapeTimeAutoLoginRunnerDependencies["ensureBrowser"] = async () => { throw new Error("Scrape-time auto-login browser page opener is not wired yet"); };
+export const unavailableScrapeTimeAutoLoginBrowserOpener: ScrapeTimeAutoLoginRunnerDependencies["ensureBrowser"] = async () => {
+  throw new Error("Scrape-time auto-login browser page opener is not wired yet");
+};
 
+const DEFAULT_VISIBLE_SELECTOR_TIMEOUT_MS = 500;
+const DEFAULT_BROWSER_CLEANUP_TIMEOUT_MS = 1_000;
+const DEFAULT_BROWSER_PAGE_SETUP_TIMEOUT_MS = 15_000;
+const PAGE_SETUP_TIMEOUT_ERROR = "Timed out while preparing the trusted bank login page";
+export function createScrapeTimeAutoLoginBrowserOpener(options: ScrapeTimeAutoLoginBrowserOpenerOptions): ScrapeTimeAutoLoginRunnerDependencies["ensureBrowser"] {
+  const {
+    trustedLoginUrl, connect = connectPlaywrightOverCdp<AutoLoginCdpBrowserLike>, ensureBrowserRuntime, acquireBrowserSlot,
+    recordCleanupFailure,
+    cleanupTimeoutMs = DEFAULT_BROWSER_CLEANUP_TIMEOUT_MS,
+    pageSetupTimeoutMs = DEFAULT_BROWSER_PAGE_SETUP_TIMEOUT_MS,
+    visibleSelectorTimeoutMs = DEFAULT_VISIBLE_SELECTOR_TIMEOUT_MS,
+  } = options;
+  return async (bankCode, cdpUrl) => {
+    assertCdpLoopback(cdpUrl);
+    const browserSlot = await acquireBrowserSlot?.();
+    if (browserSlot?.kind === "throttled") return { status: "throttled" };
+    let browser: AutoLoginCdpBrowserLike | null = null;
+    let page: AutoLoginCdpPageLike | null = null;
+    const closeResources = () => closeAutoLoginBrowserResources({ bankCode, page, browser,
+      browserSlot: browserSlot?.kind === "acquired" ? browserSlot : null, recordCleanupFailure, cleanupTimeoutMs });
+    try {
+      const browserCheck = await ensureBrowserRuntime?.(cdpUrl);
+      if (browserCheck && !browserCheck.ok) throw new Error(browserCheck.safeErrorSummary);
+      browser = await connect(cdpUrl);
+      page = await openTrustedLoginPage(browser, trustedLoginUrl, pageSetupTimeoutMs);
+      return { status: "ready", page: new CdpBankAutoLoginPage(page, visibleSelectorTimeoutMs), close: closeResources };
+    } catch (error) {
+      await closeResources();
+      throw error;
+    }
+  };
+}
+export function createScrapeTimeAutoLoginProductionOpener(options: ScrapeTimeAutoLoginProductionOpenerOptions): ScrapeTimeAutoLoginRunnerDependencies["ensureBrowser"] {
+  const { ensureBrowserRuntimeForCdpUrl, trustedLoginUrlForBank, ...openerOptions } = options;
+  return async (bankCode, cdpUrl) => {
+    const trustedLoginUrl = trustedLoginUrlForBank(bankCode);
+    if (!trustedLoginUrl) throw new Error("Bank login page is not configured");
+    return createScrapeTimeAutoLoginBrowserOpener({ ...openerOptions, trustedLoginUrl,
+      ensureBrowserRuntime: ensureBrowserRuntimeForCdpUrl })(bankCode, cdpUrl);
+  };
+}
+async function openTrustedLoginPage(browser: AutoLoginCdpBrowserLike, trustedLoginUrl: string, timeoutMs: number): Promise<AutoLoginCdpPageLike> {
+  let openedPage: AutoLoginCdpPageLike | null = null;
+  let closedPage: Promise<void> | undefined;
+  let timedOut = false;
+  const closeOpenedPage = () => {
+    if (!openedPage) return;
+    closedPage ??= Promise.resolve().then(() => openedPage!.close()).catch(() => undefined);
+    return closedPage;
+  };
+  const setup = openCdpPageInDefaultContext(browser).then(async (page) => {
+    openedPage = page;
+    if (timedOut) {
+      void closeOpenedPage();
+      throw new Error(PAGE_SETUP_TIMEOUT_ERROR);
+    }
+    await page.goto(trustedLoginUrl);
+    return page;
+  });
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      setup,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => {
+          timedOut = true;
+          reject(new Error(PAGE_SETUP_TIMEOUT_ERROR));
+        }, timeoutMs);
+      }),
+    ]);
+  } catch (error) {
+    void closeOpenedPage();
+    void setup.then(closeOpenedPage).catch(() => undefined);
+    throw error;
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+class CdpBankAutoLoginPage implements BankAutoLoginPage {
+  constructor(private readonly page: AutoLoginCdpPageLike, private readonly visibleSelectorTimeoutMs: number) {}
+  async currentUrl(): Promise<string> { return this.page.url(); }
+  async fill(selector: string, value: string): Promise<void> { await this.page.fill(selector, value); }
+  async click(selector: string): Promise<void> { await this.page.click(selector); }
+  async hasVisibleSelector(selector: string): Promise<boolean> {
+    try {
+      await this.page.waitForSelector(selector, { timeout: this.visibleSelectorTimeoutMs, state: "visible" });
+      return true;
+    } catch (error) {
+      if (isExpectedSelectorTimeout(error)) return false;
+      throw error;
+    }
+  }
+}
+async function closeAutoLoginBrowserResources(options: {
+  bankCode: string;
+  page: AutoLoginCdpPageLike | null;
+  browser: AutoLoginCdpBrowserLike | null;
+  browserSlot: { release(): Promise<void> } | null;
+  recordCleanupFailure?: ScrapeTimeAutoLoginBrowserOpenerOptions["recordCleanupFailure"];
+  cleanupTimeoutMs: number;
+}): Promise<void> {
+  const { bankCode, page, browser, browserSlot, recordCleanupFailure, cleanupTimeoutMs } = options;
+  // Free capacity before bounded CDP teardown; Popular owns its separate scraper lifecycle.
+  if (browserSlot) await runBoundedCleanup(() => browserSlot.release(), cleanupTimeoutMs, () => recordBrowserCleanupFailure(recordCleanupFailure, bankCode, "browser_slot_release_failed"));
+  if (page) await runBoundedCleanup(() => page.close(), cleanupTimeoutMs, () => recordBrowserCleanupFailure(recordCleanupFailure, bankCode, "page_close_failed"));
+  if (browser) await runBoundedCleanup(() => browser.close(), cleanupTimeoutMs, () => recordBrowserCleanupFailure(recordCleanupFailure, bankCode, "browser_close_failed"));
+}
+async function runBoundedCleanup(cleanup: () => Promise<void>, timeoutMs: number, onFailure: () => Promise<void>): Promise<void> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const cleanupResult = Promise.resolve().then(cleanup).then(() => "completed" as const, () => "failed" as const);
+  const timeoutResult = new Promise<"timed_out">((resolve) => { timeout = setTimeout(() => resolve("timed_out"), timeoutMs); });
+  const result = await Promise.race([cleanupResult, timeoutResult]);
+  if (timeout) clearTimeout(timeout);
+  if (result !== "completed") void Promise.resolve().then(onFailure).catch(() => undefined);
+}
+function isExpectedSelectorTimeout(error: unknown): boolean { return error instanceof Error && error.name === "TimeoutError"; }
+async function recordBrowserCleanupFailure(recordCleanupFailure: ScrapeTimeAutoLoginBrowserOpenerOptions["recordCleanupFailure"] | undefined,
+  bankCode: string, failure: "browser_slot_release_failed" | "page_close_failed" | "browser_close_failed"): Promise<void> {
+  return Promise.resolve(recordCleanupFailure?.({ bankCode, failure })).then(() => undefined);
+}
 export function createScrapeTimeAutoLoginRunner(deps: ScrapeTimeAutoLoginRunnerDependencies) {
   return async function runScrapeTimeAutoLogin(job: ScrapeTimeAutoLoginRunnerJob): Promise<ScrapeTimeAutoLoginOutcome | null> {
     const expiredEventId = job.data.expiredEventId;
@@ -264,7 +418,7 @@ async function recordLockReleaseFailure(context: ScrapeTimeAutoLoginTriggerConte
 }
 
 async function runOwnedAutoLogin(context: ScrapeTimeAutoLoginTriggerContext, cdpUrl: string): Promise<ScrapeTimeAutoLoginOutcome> {
-  let browser: { status: "ready"; page: BankAutoLoginPage } | { status: "throttled" };
+  let browser: ScrapeTimeAutoLoginBrowserResult | undefined;
 
   try {
     browser = await context.ensureBrowser(cdpUrl);
@@ -272,12 +426,19 @@ async function runOwnedAutoLogin(context: ScrapeTimeAutoLoginTriggerContext, cdp
     return needsAdminAction("browser_unavailable");
   }
 
-  if (browser.status === "throttled") return { status: "throttled", safeSummary: SAFE_BROWSER_THROTTLED_SUMMARY };
+  if (browser?.status === "throttled") return { status: "throttled", safeSummary: SAFE_BROWSER_THROTTLED_SUMMARY };
+  if (!browser) return needsAdminAction("browser_unavailable");
 
   try {
     return await context.adapter.createAutoLoginStrategy().autoLogin({ credential: context.credential, page: browser.page });
   } catch {
     return needsAdminAction("portal_state_unavailable");
+  } finally {
+    try {
+      await browser.close();
+    } catch {
+      // Cleanup failures must not change or leak past the safe auto-login outcome.
+    }
   }
 }
 
@@ -356,9 +517,7 @@ async function detectPostSubmitOutcome(page: BankAutoLoginPage, config: BankPort
       !hasUserInfo(currentUrl) &&
       config.dashboardPathIndicator &&
       hasDashboardPathBoundary(currentUrl.pathname, config.dashboardPathIndicator)
-    ) {
-      return { status: "succeeded" };
-    }
+    ) return { status: "succeeded" };
   } catch {
     return needsAdminAction("portal_state_unavailable");
   }

--- a/src/worker/scraper/browser-runtime.ts
+++ b/src/worker/scraper/browser-runtime.ts
@@ -78,28 +78,31 @@ export function getSafeCdpErrorSummary(error: unknown): string {
     : SAFE_SUMMARY_MALFORMED_CDP_URL;
 }
 
-// ---------------------------------------------------------------------------
-// Shared CDP adapter seam
-// ---------------------------------------------------------------------------
-
 export interface CdpPageLike {
-  url(): string; goto(url: string, options?: { waitUntil?: string; timeout?: number }): Promise<unknown>; close(): Promise<void>;
+  url(): string;
+  goto(url: string, options?: { waitUntil?: string; timeout?: number }): Promise<unknown>;
+  close(): Promise<void>;
 }
-export interface CdpContextLike<Page extends CdpPageLike = CdpPageLike> { newPage(): Promise<Page>; }
+export interface CdpContextLike<Page extends CdpPageLike = CdpPageLike> {
+  newPage(): Promise<Page>;
+}
 export interface CdpBrowserLike<Page extends CdpPageLike = CdpPageLike> {
-  /** Existing contexts of the attached browser; contexts()[0] holds the human session. */
-  contexts(): CdpContextLike<Page>[]; newPage(): Promise<Page>; close(): Promise<void>;
+  contexts(): CdpContextLike<Page>[];
+  newPage(): Promise<Page>;
+  close(): Promise<void>;
 }
-/** Lazily attaches Playwright so browser code stays safe to import in test/build paths. */
 export async function connectPlaywrightOverCdp<Browser extends CdpBrowserLike>(cdpUrl: string): Promise<Browser> {
-  assertCdpLoopback(cdpUrl); const { chromium } = await import("playwright-core");
+  assertCdpLoopback(cdpUrl);
+
+  const { chromium } = await import("playwright-core");
   return chromium.connectOverCDP(cdpUrl) as unknown as Promise<Browser>;
 }
-/** Opens a fresh page in the attached human session when one exists. */
 export async function openCdpPageInDefaultContext<Page extends CdpPageLike>(browser: CdpBrowserLike<Page>): Promise<Page> {
-  const defaultContext = browser.contexts()[0]; return defaultContext ? defaultContext.newPage() : browser.newPage();
-}
+  const defaultContext = browser.contexts()[0];
+  if (defaultContext) return defaultContext.newPage();
 
+  return browser.newPage();
+}
 // ---------------------------------------------------------------------------
 // Runtime types
 // ---------------------------------------------------------------------------

--- a/src/worker/scraper/browser-runtime.ts
+++ b/src/worker/scraper/browser-runtime.ts
@@ -79,7 +79,29 @@ export function getSafeCdpErrorSummary(error: unknown): string {
 }
 
 // ---------------------------------------------------------------------------
-// Types
+// Shared CDP adapter seam
+// ---------------------------------------------------------------------------
+
+export interface CdpPageLike {
+  url(): string; goto(url: string, options?: { waitUntil?: string; timeout?: number }): Promise<unknown>; close(): Promise<void>;
+}
+export interface CdpContextLike<Page extends CdpPageLike = CdpPageLike> { newPage(): Promise<Page>; }
+export interface CdpBrowserLike<Page extends CdpPageLike = CdpPageLike> {
+  /** Existing contexts of the attached browser; contexts()[0] holds the human session. */
+  contexts(): CdpContextLike<Page>[]; newPage(): Promise<Page>; close(): Promise<void>;
+}
+/** Lazily attaches Playwright so browser code stays safe to import in test/build paths. */
+export async function connectPlaywrightOverCdp<Browser extends CdpBrowserLike>(cdpUrl: string): Promise<Browser> {
+  assertCdpLoopback(cdpUrl); const { chromium } = await import("playwright-core");
+  return chromium.connectOverCDP(cdpUrl) as unknown as Promise<Browser>;
+}
+/** Opens a fresh page in the attached human session when one exists. */
+export async function openCdpPageInDefaultContext<Page extends CdpPageLike>(browser: CdpBrowserLike<Page>): Promise<Page> {
+  const defaultContext = browser.contexts()[0]; return defaultContext ? defaultContext.newPage() : browser.newPage();
+}
+
+// ---------------------------------------------------------------------------
+// Runtime types
 // ---------------------------------------------------------------------------
 
 /**

--- a/src/worker/scraper/navigation/popular-cdp.ts
+++ b/src/worker/scraper/navigation/popular-cdp.ts
@@ -4,10 +4,15 @@ import {
 } from "../../../modules/bank-adapters/popular";
 import {
   assertCdpLoopback,
+  connectPlaywrightOverCdp,
   DEFAULT_CDP_URL,
   getSafeCdpErrorSummary,
+  openCdpPageInDefaultContext,
   SAFE_SUMMARY_BROWSER_CAPACITY_THROTTLED,
   type AcquireBrowserSlot,
+  type CdpBrowserLike as SharedCdpBrowserLike,
+  type CdpContextLike as SharedCdpContextLike,
+  type CdpPageLike as SharedCdpPageLike,
 } from "../browser-runtime";
 import type { IngestionScraper } from "../../queues";
 import type { ScrapeCollectionResult } from "../../scraper";
@@ -25,25 +30,14 @@ import {
 // the seam. This mirrors the PlaywrightPageLike pattern in src/worker/scraper/index.ts.
 // ---------------------------------------------------------------------------
 
-export interface CdpPageLike {
-  url(): string;
-  goto(url: string, options?: { waitUntil?: string; timeout?: number }): Promise<unknown>;
+export interface CdpPageLike extends SharedCdpPageLike {
   waitForSelector(selector: string, options?: { timeout?: number; state?: string }): Promise<unknown>;
   waitForTimeout(ms: number): Promise<void>;
   evaluate<T>(fn: (arg?: unknown) => T, arg?: unknown): Promise<T>;
-  close(): Promise<void>;
 }
 
-export interface CdpContextLike {
-  newPage(): Promise<CdpPageLike>;
-}
-
-export interface CdpBrowserLike {
-  /** Existing contexts of the attached browser; contexts()[0] holds the human session. */
-  contexts(): CdpContextLike[];
-  newPage(): Promise<CdpPageLike>;
-  close(): Promise<void>;
-}
+export type CdpContextLike = SharedCdpContextLike<CdpPageLike>;
+export type CdpBrowserLike = SharedCdpBrowserLike<CdpPageLike>;
 
 // ---------------------------------------------------------------------------
 // extractResultsTableFromDocument — pure DOM extraction (exported for testing)
@@ -331,14 +325,7 @@ export function createPopularCdpScraper(options: PopularCdpScraperOptions = {}):
           };
         }
 
-        // The page MUST come from the browser's default context: that context
-        // holds the human's logged-in session cookies. browser.newPage() would
-        // create a fresh (incognito-like) context that the bank treats as an
-        // unauthenticated visitor.
-        const defaultContext = browser.contexts()[0];
-        cdpPage = defaultContext !== undefined
-          ? await defaultContext.newPage()
-          : await browser.newPage();
+        cdpPage = await openCdpPageInDefaultContext(browser);
         const portalPage = new CdpPopularPortalPage(cdpPage);
 
         const today = clock();
@@ -401,9 +388,4 @@ export function createPopularCdpScraper(options: PopularCdpScraperOptions = {}):
 // This keeps vitest and the Next.js build safe.
 // ---------------------------------------------------------------------------
 
-async function lazyPlaywrightConnect(cdpUrl: string): Promise<CdpBrowserLike> {
-  assertCdpLoopback(cdpUrl);
-  const { chromium } = await import("playwright-core");
-  // connectOverCDP returns a Browser — it is structurally compatible with CdpBrowserLike.
-  return chromium.connectOverCDP(cdpUrl) as Promise<CdpBrowserLike>;
-}
+const lazyPlaywrightConnect = connectPlaywrightOverCdp<CdpBrowserLike>;


### PR DESCRIPTION
## Summary

- Adds a dormant CDP-backed browser opener with explicit owned-resource lifecycle for scrape-time auto-login.
- Consolidates generic Playwright-over-CDP connection and default-context page selection across auto-login, Popular scraping, and bank-session checks.
- Keeps production fail-closed: the ingestion worker still uses the unavailable opener; mutation guard hardening and activation move to PR4.5e.

## Scope

- src/modules/bank-sessions/index.ts
- src/worker/scraper/auto-login.ts
- src/worker/scraper/auto-login.test.ts
- src/worker/scraper/browser-runtime.ts
- src/worker/scraper/navigation/popular-cdp.ts

## Safety boundaries

- No production auto-login activation in this slice.
- No mutation-boundary or LoginMutationGuard changes.
- No MFA/CAPTCHA/Imperva/OneSpan/security-question/anti-bot bypass.
- Unknown banks fail closed; no Popular fallback.
- CDP remains loopback-only; trusted login URL is explicit and never derived from attached page state.
- Owned browser results require idempotent cleanup; setup and teardown are independently bounded.
- Immediate and late setup failures use bounded page cleanup with fixed safe telemetry categories.
- Cleanup telemetry never exposes raw CDP endpoints, errors, tokens, or internal host details.

## Verification

- pnpm test — passed: 95 files passed, 1 skipped; 1011 tests passed, 38 skipped.
- pnpm lint — passed.
- pnpm typecheck — passed.
- git diff --check — passed with LF/CRLF warnings only.
- Final PR-level 4R — R1/R2/R3/R4 passed.
- Judgment Day — APPROVED after focused adjudication; legacy cleanup/monitor debt is pre-existing follow-up scope.

## Review budget

- 5 files, 384 insertions / 66 deletions = 450 changed lines.
- Maintainer-approved size:exception up to 450 lines, used for lifecycle clarity and complete failure-path tests.

## Chain context

- Base: feature/multi-bank-auto-login.
- PR4.5c default runner landed in #30.
- This is PR4.5d: dormant opener/shared-CDP lifecycle only.
- Follow-up PR4.5e: LoginMutationGuard single-authority mutation checks plus production opener wiring.
- Task 4.5 remains unchecked until the canonical production trigger is complete.

## Follow-up debt

- Bound legacy Popular/bank-session cleanup and document slot policy.
- Prevent overlapping bank-session/browser-capacity monitor ticks.

## Rollback

Revert commits d7a615c and 7d5c8fd. Production auto-login remains disabled because the opener is not wired.