### PR TITLE
feat(scraper): harden auto-login mutation guard (PR4.5e)

### DIFF
--- a/src/worker/ingestion-worker.ts
+++ b/src/worker/ingestion-worker.ts
@@ -39,8 +39,8 @@ import { resolveCredentialKey } from "../modules/bank-credentials/key-resolver";
 import { createAuditEvent } from "../modules/audit";
 import { BANK_AUTOLOGIN_ACTIONS, BANK_CREDENTIAL_ACTIONS } from "../modules/audit/bank-actions";
 import { getPrismaClient } from "../modules/persistence/prisma-client";
-import { createAcquireBrowserSlotFromEnv, createEnsureBrowserForBank, resolveBankBrowserEnv } from "./scraper/browser-runtime";
-import { createProductionScrapeTimeAutoLoginBrowserOpener, createScrapeTimeAutoLoginRunner, type BankAutoLoginStrategy } from "./scraper/auto-login";
+import { resolveBankBrowserEnv } from "./scraper/browser-runtime";
+import { createScrapeTimeAutoLoginRunner, unavailableScrapeTimeAutoLoginBrowserOpener, type BankAutoLoginStrategy } from "./scraper/auto-login";
 import { resolveDefaultScraper } from "../app/api/scrape-runs/consumer-defaults";
 import { defaultScrapeRunRepository } from "../app/api/scrape-runs/defaults";
 import { defaultTransactionRepository } from "../app/api/transactions/defaults";
@@ -84,28 +84,6 @@ function isScrapeTimeAutoLoginStrategy(strategy: unknown): strategy is BankAutoL
   return typeof candidate.autoLogin === "function";
 }
 
-const ensureAutoLoginBrowser = createProductionScrapeTimeAutoLoginBrowserOpener({
-  async ensureBrowserRuntime(bankCode, cdpUrl) {
-    const bankCdpUrlKey = `RD_SYNC_BANK_${bankCode.toUpperCase()}_CDP_URL`;
-    const ensureBrowser = createEnsureBrowserForBank(bankCode, {
-      ...process.env,
-      [bankCdpUrlKey]: cdpUrl,
-    });
-    return ensureBrowser?.() ?? { ok: true, launched: false };
-  },
-  acquireBrowserSlot: createAcquireBrowserSlotFromEnv(process.env),
-  async recordCleanupFailure({ bankCode, failure }) {
-    await defaultAuditSink.record(createAuditEvent({
-      actorId: "system:auto-login",
-      actorRole: null,
-      action: BANK_AUTOLOGIN_ACTIONS.FAILED,
-      target: "bank_auto_login_browser",
-      targetId: null,
-      metadata: { bankCode, failure },
-    }));
-  },
-});
-
 const runScrapeTimeAutoLogin = createScrapeTimeAutoLoginRunner({
   adapterRegistry: {
     get(bankCode) {
@@ -122,7 +100,7 @@ const runScrapeTimeAutoLogin = createScrapeTimeAutoLoginRunner({
   keyResolver: resolveCredentialKey,
   lock: defaultAutoLoginLock,
   cdpUrlForBankCode: (bankCode) => resolveBankBrowserEnv(bankCode, process.env).cdpUrl || undefined,
-  ensureBrowser: ensureAutoLoginBrowser,
+  ensureBrowser: unavailableScrapeTimeAutoLoginBrowserOpener,
   async recordLockReleaseFailure({ bankCode, expiredEventId }) {
     await defaultAuditSink.record(createAuditEvent({
       actorId: "system:auto-login",

--- a/src/worker/ingestion-worker.ts
+++ b/src/worker/ingestion-worker.ts
@@ -39,8 +39,8 @@ import { resolveCredentialKey } from "../modules/bank-credentials/key-resolver";
 import { createAuditEvent } from "../modules/audit";
 import { BANK_AUTOLOGIN_ACTIONS, BANK_CREDENTIAL_ACTIONS } from "../modules/audit/bank-actions";
 import { getPrismaClient } from "../modules/persistence/prisma-client";
-import { resolveBankBrowserEnv } from "./scraper/browser-runtime";
-import { createScrapeTimeAutoLoginRunner, unavailableScrapeTimeAutoLoginBrowserOpener, type BankAutoLoginStrategy } from "./scraper/auto-login";
+import { createAcquireBrowserSlotFromEnv, createEnsureBrowserForBank, resolveBankBrowserEnv } from "./scraper/browser-runtime";
+import { createProductionScrapeTimeAutoLoginBrowserOpener, createScrapeTimeAutoLoginRunner, type BankAutoLoginStrategy } from "./scraper/auto-login";
 import { resolveDefaultScraper } from "../app/api/scrape-runs/consumer-defaults";
 import { defaultScrapeRunRepository } from "../app/api/scrape-runs/defaults";
 import { defaultTransactionRepository } from "../app/api/transactions/defaults";
@@ -84,6 +84,28 @@ function isScrapeTimeAutoLoginStrategy(strategy: unknown): strategy is BankAutoL
   return typeof candidate.autoLogin === "function";
 }
 
+const ensureAutoLoginBrowser = createProductionScrapeTimeAutoLoginBrowserOpener({
+  async ensureBrowserRuntime(bankCode, cdpUrl) {
+    const bankCdpUrlKey = `RD_SYNC_BANK_${bankCode.toUpperCase()}_CDP_URL`;
+    const ensureBrowser = createEnsureBrowserForBank(bankCode, {
+      ...process.env,
+      [bankCdpUrlKey]: cdpUrl,
+    });
+    return ensureBrowser?.() ?? { ok: true, launched: false };
+  },
+  acquireBrowserSlot: createAcquireBrowserSlotFromEnv(process.env),
+  async recordCleanupFailure({ bankCode, failure }) {
+    await defaultAuditSink.record(createAuditEvent({
+      actorId: "system:auto-login",
+      actorRole: null,
+      action: BANK_AUTOLOGIN_ACTIONS.FAILED,
+      target: "bank_auto_login_browser",
+      targetId: null,
+      metadata: { bankCode, failure },
+    }));
+  },
+});
+
 const runScrapeTimeAutoLogin = createScrapeTimeAutoLoginRunner({
   adapterRegistry: {
     get(bankCode) {
@@ -100,7 +122,7 @@ const runScrapeTimeAutoLogin = createScrapeTimeAutoLoginRunner({
   keyResolver: resolveCredentialKey,
   lock: defaultAutoLoginLock,
   cdpUrlForBankCode: (bankCode) => resolveBankBrowserEnv(bankCode, process.env).cdpUrl || undefined,
-  ensureBrowser: unavailableScrapeTimeAutoLoginBrowserOpener,
+  ensureBrowser: ensureAutoLoginBrowser,
   async recordLockReleaseFailure({ bankCode, expiredEventId }) {
     await defaultAuditSink.record(createAuditEvent({
       actorId: "system:auto-login",

--- a/src/worker/scraper/auto-login.test.ts
+++ b/src/worker/scraper/auto-login.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { encryptCredentialField } from "../../modules/bank-credentials/crypto";
-import { createBankAutoLoginStrategy, createScrapeTimeAutoLoginBrowserOpener, createScrapeTimeAutoLoginRunner, executeScrapeTimeAutoLoginTrigger, unavailableScrapeTimeAutoLoginBrowserOpener, type BankAutoLoginPage } from "./auto-login";
+import { createBankAutoLoginStrategy, createProductionScrapeTimeAutoLoginBrowserOpener, createScrapeTimeAutoLoginBrowserOpener, createScrapeTimeAutoLoginRunner, executeScrapeTimeAutoLoginTrigger, unavailableScrapeTimeAutoLoginBrowserOpener, type BankAutoLoginPage } from "./auto-login";
 import type { BankPortalConfig } from "./login-mutation-guard";
 
 const portalConfig: BankPortalConfig = {
@@ -20,20 +20,45 @@ const loginControls = [portalConfig.usernameSelector, portalConfig.passwordSelec
 const credential = { bankCode: "popular", username: "bank-user", password: "bank-password" };
 type TestBankAutoLoginPage = BankAutoLoginPage & { setUrl(nextUrl: string): void; show(selector: string): void };
 
-function makePage(options: { url?: string; visible?: readonly string[]; onFill?: (selector: string, value: string) => void; onClick?: () => void } = {}): TestBankAutoLoginPage {
+function makePage(options: { url?: string; visible?: readonly string[]; onFill?: (selector: string, value: string) => void | Promise<void>; onClick?: () => void | Promise<void> } = {}): TestBankAutoLoginPage {
   let url = options.url ?? "https://ib.bpd.com.do/login";
   const visible = new Set(options.visible ?? loginControls);
   return {
     async currentUrl() { return url; },
     async hasVisibleSelector(selector) { return visible.has(selector); },
-    async fill(selector, value) { options.onFill?.(selector, value); },
+    async fill(selector, value) { await options.onFill?.(selector, value); },
     async click() {
-      if (options.onClick) options.onClick();
+      if (options.onClick) await options.onClick();
       else url = "https://ib.bpd.com.do/dashboard";
     },
     setUrl(nextUrl: string) { url = nextUrl; },
     show(selector: string) { visible.add(selector); },
   };
+}
+
+type MutationPhase = "username" | "password" | "submit";
+
+function makeMutationBoundaryDriftPage(driftBefore: MutationPhase) {
+  let url = "https://ib.bpd.com.do/login";
+  let phase: MutationPhase = "username";
+  const mutations: string[] = [];
+  const visible = new Set(loginControls);
+  const page: BankAutoLoginPage = {
+    async currentUrl() { return url; },
+    async hasVisibleSelector(selector) {
+      if (phase === driftBefore && selector === portalConfig.usernameSelector) {
+        await Promise.resolve();
+        url = "https://evil.example/login";
+      }
+      return visible.has(selector as (typeof loginControls)[number]);
+    },
+    async fill(selector) {
+      mutations.push(selector);
+      phase = selector === portalConfig.usernameSelector ? "password" : "submit";
+    },
+    async click(selector) { mutations.push(selector); },
+  };
+  return { page, mutations };
 }
 
 function readyBrowser(page: BankAutoLoginPage) {
@@ -45,7 +70,7 @@ function readyBrowser(page: BankAutoLoginPage) {
 }
 
 describe("createBankAutoLoginStrategy", () => {
-  it("fills and submits only after the guard authorizes both boundaries", async () => {
+  it("fills and submits only after the guard authorizes all three mutation boundaries", async () => {
     const fill = vi.fn();
     const page = makePage({ onFill: fill });
     const click = vi.spyOn(page, "click");
@@ -135,6 +160,21 @@ describe("createBankAutoLoginStrategy", () => {
     expect(click).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ["username", []],
+    ["password", [portalConfig.usernameSelector]],
+    ["submit", [portalConfig.usernameSelector, portalConfig.passwordSelector]],
+  ] as const)("blocks the %s mutation when navigation drifts during its boundary checks", async (phase, expectedMutations) => {
+    const { page, mutations } = makeMutationBoundaryDriftPage(phase);
+
+    await expect(createBankAutoLoginStrategy(portalConfig).autoLogin({ credential, page })).resolves.toMatchObject({
+      status: "needs_admin_action",
+      reason: "unauthorized_login_page",
+    });
+
+    expect(mutations).toEqual(expectedMutations);
+  });
+
   it("does not treat external or non-HTTPS dashboard redirects as success", async () => {
     const cases = ["https://evil.example/dashboard", "http://ib.bpd.com.do/dashboard", "https://user@ib.bpd.com.do/dashboard"];
 
@@ -191,6 +231,61 @@ describe("createBankAutoLoginStrategy", () => {
 
     await expect(strategy.autoLogin({ credential, page: mfaPage })).resolves.toMatchObject({ status: "needs_admin_action", reason: "protected_flow" });
     await expect(strategy.autoLogin({ credential, page: unknownPage })).resolves.toMatchObject({ status: "needs_admin_action", reason: "unknown_post_submit_state" });
+  });
+
+  it("blocks success when a protected challenge is exposed during the submit click", async () => {
+    const page = makePage({
+      onClick: async () => {
+        await Promise.resolve();
+        page.show(portalConfig.mfaIndicatorSelector);
+      },
+    });
+
+    await expect(createBankAutoLoginStrategy(portalConfig).autoLogin({ credential, page })).resolves.toMatchObject({
+      status: "needs_admin_action",
+      reason: "protected_flow",
+    });
+  });
+
+  it("re-checks protected state when a challenge appears during dashboard URL acquisition", async () => {
+    let clickCompleted = false;
+    let challengeVisible = false;
+    const page: BankAutoLoginPage = {
+      async currentUrl() {
+        if (!clickCompleted) return "https://ib.bpd.com.do/login";
+        challengeVisible = true;
+        return "https://ib.bpd.com.do/dashboard";
+      },
+      async hasVisibleSelector(selector) {
+        if (selector === portalConfig.mfaIndicatorSelector) return challengeVisible;
+        return loginControls.includes(selector as (typeof loginControls)[number]);
+      },
+      async fill() {},
+      async click() { clickCompleted = true; },
+    };
+
+    await expect(createBankAutoLoginStrategy(portalConfig).autoLogin({ credential, page })).resolves.toMatchObject({
+      status: "needs_admin_action",
+      reason: "protected_flow",
+    });
+  });
+
+  it("fails closed when a post-submit protected-state selector throws unexpectedly", async () => {
+    let clickCompleted = false;
+    const page: BankAutoLoginPage = {
+      async currentUrl() { return clickCompleted ? "https://ib.bpd.com.do/dashboard" : "https://ib.bpd.com.do/login"; },
+      async hasVisibleSelector(selector) {
+        if (clickCompleted && selector === portalConfig.mfaIndicatorSelector) throw new Error("selector diagnostics must not leak");
+        return loginControls.includes(selector as (typeof loginControls)[number]);
+      },
+      async fill() {},
+      async click() { clickCompleted = true; },
+    };
+
+    await expect(createBankAutoLoginStrategy(portalConfig).autoLogin({ credential, page })).resolves.toMatchObject({
+      status: "needs_admin_action",
+      reason: "portal_state_unavailable",
+    });
   });
 });
 
@@ -593,7 +688,7 @@ describe("createScrapeTimeAutoLoginRunner", () => {
     expect(baseDeps.lock.acquire).not.toHaveBeenCalled();
   });
 
-  it("uses the production default unavailable browser opener as a safe terminal admin action", async () => {
+  it("uses the unavailable browser opener as a safe terminal admin action", async () => {
     const release = vi.fn().mockResolvedValue(true);
     const run = createScrapeTimeAutoLoginRunner({
       adapterRegistry: { get: vi.fn().mockReturnValue({ bankCode: "popular", createAutoLoginStrategy: vi.fn() }) },
@@ -688,6 +783,47 @@ describe("createScrapeTimeAutoLoginBrowserOpener", () => {
     if (stage === "newPage") browser.contexts.mockReturnValue([{ newPage: vi.fn(() => pendingSetup.then(() => page)) }]); else page.goto.mockImplementation(() => pendingSetup);
     return { page, browser, release: vi.fn().mockResolvedValue(undefined), resolveSetup };
   }
+  describe("createProductionScrapeTimeAutoLoginBrowserOpener", () => {
+    it("uses the Popular-only trusted login mapping with the shared connector, readiness check, and capacity slot", async () => {
+      const page = makeCdpPage();
+      const browser = makeBrowser(page);
+      const connect = vi.fn().mockResolvedValue(browser);
+      const ensureBrowserRuntime = vi.fn().mockResolvedValue({ ok: true, launched: false });
+      const acquireBrowserSlot = vi.fn().mockResolvedValue({ kind: "acquired", release: vi.fn().mockResolvedValue(undefined) });
+      const openForBank = createProductionScrapeTimeAutoLoginBrowserOpener({
+        connect,
+        ensureBrowserRuntime,
+        acquireBrowserSlot,
+      });
+
+      const opened = await openForBank("popular", CDP_URL);
+      if (opened.status !== "ready") throw new Error("expected ready browser");
+      await opened.close();
+
+      expect(ensureBrowserRuntime).toHaveBeenCalledWith("popular", CDP_URL);
+      expect(connect).toHaveBeenCalledWith(CDP_URL);
+      expect(acquireBrowserSlot).toHaveBeenCalledOnce();
+      expect(page.goto).toHaveBeenCalledWith(POPULAR_LOGIN_URL);
+    });
+
+    it.each(["bhd", ""])("rejects missing Popular-only trusted login mapping for %s before readiness, capacity, or connect", async (bankCode) => {
+      const connect = vi.fn();
+      const ensureBrowserRuntime = vi.fn();
+      const acquireBrowserSlot = vi.fn();
+      const openForBank = createProductionScrapeTimeAutoLoginBrowserOpener({
+        connect,
+        ensureBrowserRuntime,
+        acquireBrowserSlot,
+      });
+
+      const rejection = openForBank(bankCode, "http://127.0.0.1:9222?diagnostic=secret");
+      await expect(rejection).rejects.toThrow("Trusted bank login URL is unavailable");
+      await expect(rejection).rejects.not.toThrow("diagnostic=secret");
+      expect(ensureBrowserRuntime).not.toHaveBeenCalled();
+      expect(acquireBrowserSlot).not.toHaveBeenCalled();
+      expect(connect).not.toHaveBeenCalled();
+    });
+  });
   it("cleans up the slot and browser after an immediate default-context page rejection", async () => {
     const release = vi.fn().mockResolvedValue(undefined);
     const browser = makeBrowser(makeCdpPage());

--- a/src/worker/scraper/auto-login.test.ts
+++ b/src/worker/scraper/auto-login.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { encryptCredentialField } from "../../modules/bank-credentials/crypto";
-import { createBankAutoLoginStrategy, createProductionScrapeTimeAutoLoginBrowserOpener, createScrapeTimeAutoLoginBrowserOpener, createScrapeTimeAutoLoginRunner, executeScrapeTimeAutoLoginTrigger, unavailableScrapeTimeAutoLoginBrowserOpener, type BankAutoLoginPage } from "./auto-login";
+import { createBankAutoLoginStrategy, createScrapeTimeAutoLoginBrowserOpener, createScrapeTimeAutoLoginRunner, executeScrapeTimeAutoLoginTrigger, unavailableScrapeTimeAutoLoginBrowserOpener, type BankAutoLoginPage } from "./auto-login";
 import type { BankPortalConfig } from "./login-mutation-guard";
 
 const portalConfig: BankPortalConfig = {
@@ -688,7 +688,7 @@ describe("createScrapeTimeAutoLoginRunner", () => {
     expect(baseDeps.lock.acquire).not.toHaveBeenCalled();
   });
 
-  it("uses the unavailable browser opener as a safe terminal admin action", async () => {
+  it("uses the production default unavailable browser opener as a safe terminal admin action", async () => {
     const release = vi.fn().mockResolvedValue(true);
     const run = createScrapeTimeAutoLoginRunner({
       adapterRegistry: { get: vi.fn().mockReturnValue({ bankCode: "popular", createAutoLoginStrategy: vi.fn() }) },
@@ -783,47 +783,6 @@ describe("createScrapeTimeAutoLoginBrowserOpener", () => {
     if (stage === "newPage") browser.contexts.mockReturnValue([{ newPage: vi.fn(() => pendingSetup.then(() => page)) }]); else page.goto.mockImplementation(() => pendingSetup);
     return { page, browser, release: vi.fn().mockResolvedValue(undefined), resolveSetup };
   }
-  describe("createProductionScrapeTimeAutoLoginBrowserOpener", () => {
-    it("uses the Popular-only trusted login mapping with the shared connector, readiness check, and capacity slot", async () => {
-      const page = makeCdpPage();
-      const browser = makeBrowser(page);
-      const connect = vi.fn().mockResolvedValue(browser);
-      const ensureBrowserRuntime = vi.fn().mockResolvedValue({ ok: true, launched: false });
-      const acquireBrowserSlot = vi.fn().mockResolvedValue({ kind: "acquired", release: vi.fn().mockResolvedValue(undefined) });
-      const openForBank = createProductionScrapeTimeAutoLoginBrowserOpener({
-        connect,
-        ensureBrowserRuntime,
-        acquireBrowserSlot,
-      });
-
-      const opened = await openForBank("popular", CDP_URL);
-      if (opened.status !== "ready") throw new Error("expected ready browser");
-      await opened.close();
-
-      expect(ensureBrowserRuntime).toHaveBeenCalledWith("popular", CDP_URL);
-      expect(connect).toHaveBeenCalledWith(CDP_URL);
-      expect(acquireBrowserSlot).toHaveBeenCalledOnce();
-      expect(page.goto).toHaveBeenCalledWith(POPULAR_LOGIN_URL);
-    });
-
-    it.each(["bhd", ""])("rejects missing Popular-only trusted login mapping for %s before readiness, capacity, or connect", async (bankCode) => {
-      const connect = vi.fn();
-      const ensureBrowserRuntime = vi.fn();
-      const acquireBrowserSlot = vi.fn();
-      const openForBank = createProductionScrapeTimeAutoLoginBrowserOpener({
-        connect,
-        ensureBrowserRuntime,
-        acquireBrowserSlot,
-      });
-
-      const rejection = openForBank(bankCode, "http://127.0.0.1:9222?diagnostic=secret");
-      await expect(rejection).rejects.toThrow("Trusted bank login URL is unavailable");
-      await expect(rejection).rejects.not.toThrow("diagnostic=secret");
-      expect(ensureBrowserRuntime).not.toHaveBeenCalled();
-      expect(acquireBrowserSlot).not.toHaveBeenCalled();
-      expect(connect).not.toHaveBeenCalled();
-    });
-  });
   it("cleans up the slot and browser after an immediate default-context page rejection", async () => {
     const release = vi.fn().mockResolvedValue(undefined);
     const browser = makeBrowser(makeCdpPage());

--- a/src/worker/scraper/auto-login.ts
+++ b/src/worker/scraper/auto-login.ts
@@ -41,25 +41,6 @@ export interface ScrapeTimeAutoLoginBrowserOpenerOptions {
   pageSetupTimeoutMs?: number;
   visibleSelectorTimeoutMs?: number;
 }
-
-/**
- * Production composition port: bank-specific values are resolved only from
- * trusted worker configuration, never from an attached browser page.
- */
-export interface ScrapeTimeAutoLoginBrowserOpenerForBanksOptions
-  extends Omit<ScrapeTimeAutoLoginBrowserOpenerOptions, "trustedLoginUrl" | "ensureBrowserRuntime"> {
-  trustedLoginUrls: Readonly<Record<string, string>>;
-  ensureBrowserRuntimeForBank?(bankCode: string): ScrapeTimeAutoLoginBrowserOpenerOptions["ensureBrowserRuntime"];
-}
-
-/**
- * Pure production composition seam. Only explicitly trusted bank URLs can
- * reach browser capacity, runtime readiness, or CDP connection.
- */
-export interface ProductionScrapeTimeAutoLoginBrowserOpenerOptions
-  extends Omit<ScrapeTimeAutoLoginBrowserOpenerForBanksOptions, "trustedLoginUrls" | "ensureBrowserRuntimeForBank"> {
-  ensureBrowserRuntime?(bankCode: string, cdpUrl: string): Promise<EnsureCdpBrowserResult>;
-}
 export type BankAutoLoginAdminActionReason =
   | "unsupported_bank"
   | "credential_bank_mismatch"
@@ -156,9 +137,6 @@ const DEFAULT_VISIBLE_SELECTOR_TIMEOUT_MS = 500;
 const DEFAULT_BROWSER_CLEANUP_TIMEOUT_MS = 1_000;
 const DEFAULT_BROWSER_PAGE_SETUP_TIMEOUT_MS = 15_000;
 const PAGE_SETUP_TIMEOUT_ERROR = "Timed out while preparing the trusted bank login page";
-const PRODUCTION_TRUSTED_AUTO_LOGIN_URLS: Readonly<Record<string, string>> = {
-  popular: "https://ib.bpd.com.do/login",
-};
 type BrowserCleanupFailure = "browser_slot_release_failed" | "page_close_failed" | "browser_close_failed";
 
 export function createScrapeTimeAutoLoginBrowserOpener(options: ScrapeTimeAutoLoginBrowserOpenerOptions): ScrapeTimeAutoLoginRunnerDependencies["ensureBrowser"] {
@@ -202,36 +180,6 @@ export function createScrapeTimeAutoLoginBrowserOpener(options: ScrapeTimeAutoLo
       throw error;
     }
   };
-}
-
-export function createScrapeTimeAutoLoginBrowserOpenerForBanks(
-  options: ScrapeTimeAutoLoginBrowserOpenerForBanksOptions,
-): ScrapeTimeAutoLoginRunnerDependencies["ensureBrowser"] {
-  const { trustedLoginUrls, ensureBrowserRuntimeForBank, ...openerOptions } = options;
-
-  return async (bankCode, cdpUrl) => {
-    const trustedLoginUrl = trustedLoginUrls[bankCode];
-    if (!hasNonBlankString(trustedLoginUrl)) throw new Error("Trusted bank login URL is unavailable");
-
-    return createScrapeTimeAutoLoginBrowserOpener({
-      ...openerOptions,
-      trustedLoginUrl,
-      ensureBrowserRuntime: ensureBrowserRuntimeForBank?.(bankCode),
-    })(bankCode, cdpUrl);
-  };
-}
-
-export function createProductionScrapeTimeAutoLoginBrowserOpener(
-  options: ProductionScrapeTimeAutoLoginBrowserOpenerOptions,
-): ScrapeTimeAutoLoginRunnerDependencies["ensureBrowser"] {
-  const { ensureBrowserRuntime, ...openerOptions } = options;
-  return createScrapeTimeAutoLoginBrowserOpenerForBanks({
-    ...openerOptions,
-    trustedLoginUrls: PRODUCTION_TRUSTED_AUTO_LOGIN_URLS,
-    ensureBrowserRuntimeForBank: ensureBrowserRuntime
-      ? (bankCode) => (cdpUrl) => ensureBrowserRuntime(bankCode, cdpUrl)
-      : undefined,
-  });
 }
 type OpenTrustedLoginPageOptions = { browser: AutoLoginCdpBrowserLike; trustedLoginUrl: string; timeoutMs: number; cleanupTimeoutMs: number; onPageCloseFailure(): Promise<void> };
 

--- a/src/worker/scraper/auto-login.ts
+++ b/src/worker/scraper/auto-login.ts
@@ -1,4 +1,4 @@
-import { LOGIN_MUTATION_GUARD_ERROR_SUMMARIES, LoginMutationGuard, LoginMutationGuardError, type BankPortalConfig, type LoginMutationPage } from "./login-mutation-guard";
+import { LoginMutationGuard, LoginMutationGuardError, type BankPortalConfig, type LoginMutationPage } from "./login-mutation-guard";
 import {
   assertCdpLoopback,
   connectPlaywrightOverCdp,
@@ -40,6 +40,25 @@ export interface ScrapeTimeAutoLoginBrowserOpenerOptions {
   cleanupTimeoutMs?: number;
   pageSetupTimeoutMs?: number;
   visibleSelectorTimeoutMs?: number;
+}
+
+/**
+ * Production composition port: bank-specific values are resolved only from
+ * trusted worker configuration, never from an attached browser page.
+ */
+export interface ScrapeTimeAutoLoginBrowserOpenerForBanksOptions
+  extends Omit<ScrapeTimeAutoLoginBrowserOpenerOptions, "trustedLoginUrl" | "ensureBrowserRuntime"> {
+  trustedLoginUrls: Readonly<Record<string, string>>;
+  ensureBrowserRuntimeForBank?(bankCode: string): ScrapeTimeAutoLoginBrowserOpenerOptions["ensureBrowserRuntime"];
+}
+
+/**
+ * Pure production composition seam. Only explicitly trusted bank URLs can
+ * reach browser capacity, runtime readiness, or CDP connection.
+ */
+export interface ProductionScrapeTimeAutoLoginBrowserOpenerOptions
+  extends Omit<ScrapeTimeAutoLoginBrowserOpenerForBanksOptions, "trustedLoginUrls" | "ensureBrowserRuntimeForBank"> {
+  ensureBrowserRuntime?(bankCode: string, cdpUrl: string): Promise<EnsureCdpBrowserResult>;
 }
 export type BankAutoLoginAdminActionReason =
   | "unsupported_bank"
@@ -137,6 +156,9 @@ const DEFAULT_VISIBLE_SELECTOR_TIMEOUT_MS = 500;
 const DEFAULT_BROWSER_CLEANUP_TIMEOUT_MS = 1_000;
 const DEFAULT_BROWSER_PAGE_SETUP_TIMEOUT_MS = 15_000;
 const PAGE_SETUP_TIMEOUT_ERROR = "Timed out while preparing the trusted bank login page";
+const PRODUCTION_TRUSTED_AUTO_LOGIN_URLS: Readonly<Record<string, string>> = {
+  popular: "https://ib.bpd.com.do/login",
+};
 type BrowserCleanupFailure = "browser_slot_release_failed" | "page_close_failed" | "browser_close_failed";
 
 export function createScrapeTimeAutoLoginBrowserOpener(options: ScrapeTimeAutoLoginBrowserOpenerOptions): ScrapeTimeAutoLoginRunnerDependencies["ensureBrowser"] {
@@ -180,6 +202,36 @@ export function createScrapeTimeAutoLoginBrowserOpener(options: ScrapeTimeAutoLo
       throw error;
     }
   };
+}
+
+export function createScrapeTimeAutoLoginBrowserOpenerForBanks(
+  options: ScrapeTimeAutoLoginBrowserOpenerForBanksOptions,
+): ScrapeTimeAutoLoginRunnerDependencies["ensureBrowser"] {
+  const { trustedLoginUrls, ensureBrowserRuntimeForBank, ...openerOptions } = options;
+
+  return async (bankCode, cdpUrl) => {
+    const trustedLoginUrl = trustedLoginUrls[bankCode];
+    if (!hasNonBlankString(trustedLoginUrl)) throw new Error("Trusted bank login URL is unavailable");
+
+    return createScrapeTimeAutoLoginBrowserOpener({
+      ...openerOptions,
+      trustedLoginUrl,
+      ensureBrowserRuntime: ensureBrowserRuntimeForBank?.(bankCode),
+    })(bankCode, cdpUrl);
+  };
+}
+
+export function createProductionScrapeTimeAutoLoginBrowserOpener(
+  options: ProductionScrapeTimeAutoLoginBrowserOpenerOptions,
+): ScrapeTimeAutoLoginRunnerDependencies["ensureBrowser"] {
+  const { ensureBrowserRuntime, ...openerOptions } = options;
+  return createScrapeTimeAutoLoginBrowserOpenerForBanks({
+    ...openerOptions,
+    trustedLoginUrls: PRODUCTION_TRUSTED_AUTO_LOGIN_URLS,
+    ensureBrowserRuntimeForBank: ensureBrowserRuntime
+      ? (bankCode) => (cdpUrl) => ensureBrowserRuntime(bankCode, cdpUrl)
+      : undefined,
+  });
 }
 type OpenTrustedLoginPageOptions = { browser: AutoLoginCdpBrowserLike; trustedLoginUrl: string; timeoutMs: number; cleanupTimeoutMs: number; onPageCloseFailure(): Promise<void> };
 
@@ -489,22 +541,22 @@ export function createBankAutoLoginStrategy(
       if (guardResult.outcome) return guardResult.outcome;
       const { guard } = guardResult;
 
-      const beforeUsernameFill = await runGuard(() => guard.beforeFill(page));
+      const beforeUsernameFill = await runGuard(() => guard.assertMutationAuthorized(page));
       if (beforeUsernameFill) return beforeUsernameFill;
       const usernameFill = await runBrowserMutation(() => page.fill(portalConfig.usernameSelector, credential.username));
       if (usernameFill) return usernameFill;
 
-      const beforePasswordFill = await runGuard(() => guard.beforeFill(page));
+      const beforePasswordFill = await runGuard(() => guard.assertMutationAuthorized(page));
       if (beforePasswordFill) return beforePasswordFill;
       const passwordFill = await runBrowserMutation(() => page.fill(portalConfig.passwordSelector, credential.password));
       if (passwordFill) return passwordFill;
 
-      const beforeSubmit = await runGuard(() => guard.beforeSubmit(page));
+      const beforeSubmit = await runGuard(() => guard.assertMutationAuthorized(page));
       if (beforeSubmit) return beforeSubmit;
 
       const submit = await runBrowserMutation(() => page.click(portalConfig.submitSelector));
       if (submit) return submit;
-      return detectPostSubmitOutcome(page, portalConfig);
+      return detectPostSubmitOutcome(page, portalConfig, guard);
     },
   };
 }
@@ -520,15 +572,12 @@ function createGuard(portalConfig: BankPortalConfig): GuardResult {
   }
 }
 
-async function detectPostSubmitOutcome(page: BankAutoLoginPage, config: BankPortalConfig): Promise<BankAutoLoginOutcome> {
-  const guardedState = await runGuard(async () => {
-    if (await page.hasVisibleSelector(config.mfaIndicatorSelector)) {
-      throw new LoginMutationGuardError("protected_flow", LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.PROTECTED_FLOW);
-    }
-    if (await page.hasVisibleSelector(config.incompatibleFlowSelector)) {
-      throw new LoginMutationGuardError("incompatible_flow", LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.INCOMPATIBLE_FLOW);
-    }
-  });
+async function detectPostSubmitOutcome(
+  page: BankAutoLoginPage,
+  config: BankPortalConfig,
+  guard: LoginMutationGuard,
+): Promise<BankAutoLoginOutcome> {
+  const guardedState = await runGuard(() => guard.assertNoProtectedOrIncompatibleState(page));
   if (guardedState) return guardedState;
 
   try {
@@ -542,7 +591,11 @@ async function detectPostSubmitOutcome(page: BankAutoLoginPage, config: BankPort
       !hasUserInfo(currentUrl) &&
       config.dashboardPathIndicator &&
       hasDashboardPathBoundary(currentUrl.pathname, config.dashboardPathIndicator)
-    ) return { status: "succeeded" };
+    ) {
+      const finalGuardedState = await runGuard(() => guard.assertNoProtectedOrIncompatibleState(page));
+      if (finalGuardedState) return finalGuardedState;
+      return { status: "succeeded" };
+    }
   } catch {
     return needsAdminAction("portal_state_unavailable");
   }

--- a/src/worker/scraper/login-mutation-guard.test.ts
+++ b/src/worker/scraper/login-mutation-guard.test.ts
@@ -25,9 +25,9 @@ function makePage(url: string, visibleSelectors: readonly string[] = []): LoginM
 }
 
 async function guardedSubmit(guard: LoginMutationGuard, page: LoginMutationPage, fill: () => void | Promise<void>, submit: () => void): Promise<void> {
-  await guard.beforeFill(page);
+  await guard.assertMutationAuthorized(page);
   await fill();
-  await guard.beforeSubmit(page);
+  await guard.assertMutationAuthorized(page);
   submit();
 }
 
@@ -42,7 +42,7 @@ describe("LoginMutationGuard", () => {
   ])("%s", async (_caseName, url) => {
     const guard = new LoginMutationGuard(portalConfig);
 
-    await expect(guard.beforeFill(makePage(url, allLoginControlSelectors))).rejects.toMatchObject({
+    await expect(guard.assertMutationAuthorized(makePage(url, allLoginControlSelectors))).rejects.toMatchObject({
       outcome: "needs_admin_action",
       safeSummary: LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.UNAUTHORIZED_LOGIN_PAGE,
     });
@@ -50,7 +50,7 @@ describe("LoginMutationGuard", () => {
 
   it("rejects malformed URLs with a typed fixed safe error", async () => {
     const guard = new LoginMutationGuard(portalConfig);
-    const rejection = guard.beforeFill(makePage("not a url with secret=password", allLoginControlSelectors));
+    const rejection = guard.assertMutationAuthorized(makePage("not a url with secret=password", allLoginControlSelectors));
 
     await expect(rejection).rejects.toBeInstanceOf(LoginMutationGuardError);
     await expect(rejection).rejects.toMatchObject({ message: LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.MALFORMED_PORTAL_URL, reason: "malformed_url", safeSummary: LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.MALFORMED_PORTAL_URL });
@@ -88,6 +88,31 @@ describe("LoginMutationGuard", () => {
     expect(submit).toHaveBeenCalledOnce();
   });
 
+  it("checks controls and protected states before reading the authorized URL at the mutation boundary", async () => {
+    const events: string[] = [];
+    const page: LoginMutationPage = {
+      async currentUrl() {
+        events.push("url");
+        return "https://ib.bpd.com.do/login";
+      },
+      async hasVisibleSelector(selector) {
+        events.push(`selector:${selector}`);
+        return allLoginControlSelectors.includes(selector as (typeof allLoginControlSelectors)[number]);
+      },
+    };
+
+    await expect(new LoginMutationGuard(portalConfig).assertMutationAuthorized(page)).resolves.toBeUndefined();
+
+    expect(events).toEqual([
+      "selector:#username",
+      "selector:#password",
+      "selector:button[type='submit']",
+      "selector:[data-mfa]",
+      "selector:[data-corporate-token]",
+      "url",
+    ]);
+  });
+
   it("awaits async fill before submit re-checks and catches navigation drift", async () => {
     let currentUrl = "https://ib.bpd.com.do/login";
     const events: string[] = [];
@@ -118,7 +143,7 @@ describe("LoginMutationGuard", () => {
     ["incompatible pre-submit flows", ["[data-corporate-token]"], "incompatible_flow", LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.INCOMPATIBLE_FLOW],
     ["MFA-protected pages", ["[data-mfa]"], "protected_flow", LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.PROTECTED_FLOW],
   ] as const)("blocks %s before caller mutations run", async (_caseName, selectors, reason, safeSummary) => {
-    const page = makePage("https://ib.bpd.com.do/login", selectors);
+    const page = makePage("https://ib.bpd.com.do/login", [...allLoginControlSelectors, ...selectors]);
     const guard = new LoginMutationGuard(portalConfig);
     const fill = vi.fn();
     const submit = vi.fn();
@@ -178,26 +203,26 @@ describe("LoginMutationGuard", () => {
     expect(submit).not.toHaveBeenCalled();
   });
 
-  it("validates the login page when assertCompatiblePreSubmit is called directly", async () => {
+  it("rejects an unauthorized login page through the canonical mutation authorization API", async () => {
     const guard = new LoginMutationGuard(portalConfig);
 
-    await expect(guard.assertCompatiblePreSubmit(makePage("https://evil.com/login"))).rejects.toMatchObject({
+    await expect(guard.assertMutationAuthorized(makePage("https://evil.com/login", allLoginControlSelectors))).rejects.toMatchObject({
       safeSummary: LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.UNAUTHORIZED_LOGIN_PAGE,
     });
   });
 
-  it("validates required pre-submit controls when assertCompatiblePreSubmit is called directly", async () => {
+  it("rejects missing required controls through the canonical mutation authorization API", async () => {
     const page = makePage("https://ib.bpd.com.do/login", credentialControlSelectors);
     const guard = new LoginMutationGuard(portalConfig);
 
-    await expect(guard.assertCompatiblePreSubmit(page)).rejects.toMatchObject({
+    await expect(guard.assertMutationAuthorized(page)).rejects.toMatchObject({
       safeSummary: LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.MISSING_REQUIRED_LOGIN_CONTROL,
     });
   });
 
   it("uses typed errors with fixed safe summaries", async () => {
     const guard = new LoginMutationGuard(portalConfig);
-    const rejection = guard.beforeSubmit(makePage("https://evil.com/login"));
+    const rejection = guard.assertMutationAuthorized(makePage("https://evil.com/login", allLoginControlSelectors));
 
     await expect(rejection).rejects.toBeInstanceOf(LoginMutationGuardError);
     await expect(rejection).rejects.toMatchObject({
@@ -208,7 +233,7 @@ describe("LoginMutationGuard", () => {
   it.each([
     ["currentUrl", {
       async currentUrl(): Promise<string> { throw new Error("browser leaked https://evil.example/login?password=secret"); },
-      async hasVisibleSelector(): Promise<boolean> { return true; },
+      async hasVisibleSelector(selector: string): Promise<boolean> { return allLoginControlSelectors.includes(selector as (typeof allLoginControlSelectors)[number]); },
     }],
     ["hasVisibleSelector", {
       async currentUrl(): Promise<string> { return "https://ib.bpd.com.do/login"; },
@@ -216,7 +241,7 @@ describe("LoginMutationGuard", () => {
     }],
   ] as const)("translates %s failures to a fixed safe guard error", async (_operation, page) => {
     const guard = new LoginMutationGuard(portalConfig);
-    const rejection = guard.beforeFill(page);
+    const rejection = guard.assertMutationAuthorized(page);
 
     await expect(rejection).rejects.toBeInstanceOf(LoginMutationGuardError);
     await expect(rejection).rejects.toMatchObject({

--- a/src/worker/scraper/login-mutation-guard.ts
+++ b/src/worker/scraper/login-mutation-guard.ts
@@ -1,5 +1,5 @@
 export interface BankPortalConfig {
-  // Foundation only: no production scraper caller yet; reserved metadata is non-authorizing.
+  // Trusted portal metadata used by the mutation guard; it never authorizes a page by itself.
   bankCode?: string;
   baseUrl: string;
   loginPathAllowlist: readonly string[];
@@ -94,31 +94,35 @@ export class LoginMutationGuard {
     }
   }
 
-  async beforeFill(page: LoginMutationPage): Promise<void> {
-    await this.assertSafeLoginState(page);
+  /**
+   * The sole authorization boundary for credential mutations. The URL is read
+   * last so a redirect during any asynchronous selector check cannot reach a
+   * fill or submit operation.
+   */
+  async assertMutationAuthorized(page: LoginMutationPage): Promise<void> {
     await this.assertRequiredControls(page, [this.config.usernameSelector, this.config.passwordSelector, this.config.submitSelector]);
-  }
-
-  async beforeSubmit(page: LoginMutationPage): Promise<void> {
-    await this.assertCompatiblePreSubmit(page);
-  }
-
-  async assertCompatiblePreSubmit(page: LoginMutationPage): Promise<void> {
-    await this.assertSafeLoginState(page);
-    await this.assertRequiredControls(page, [this.config.usernameSelector, this.config.passwordSelector, this.config.submitSelector]);
-  }
-
-  private async assertSafeLoginState(page: LoginMutationPage): Promise<void> {
+    await this.assertNoProtectedOrIncompatibleState(page);
     await this.assertAuthorizedLoginUrl(page);
+  }
 
-    if (await this.hasVisibleSelector(page, this.config.mfaIndicatorSelector)) {
+  /**
+   * Guard-owned protected/incompatible state check for both pre-mutation and
+   * post-submit observations. Callers must not duplicate this policy.
+   */
+  async assertNoProtectedOrIncompatibleState(page: LoginMutationPage): Promise<void> {
+    const [hasMfaIndicator, hasIncompatibleFlow] = await Promise.all([
+      this.hasVisibleSelector(page, this.config.mfaIndicatorSelector),
+      this.hasVisibleSelector(page, this.config.incompatibleFlowSelector),
+    ]);
+
+    if (hasMfaIndicator) {
       throw new LoginMutationGuardError(
         "protected_flow",
         LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.PROTECTED_FLOW,
       );
     }
 
-    if (await this.hasVisibleSelector(page, this.config.incompatibleFlowSelector)) {
+    if (hasIncompatibleFlow) {
       throw new LoginMutationGuardError(
         "incompatible_flow",
         LOGIN_MUTATION_GUARD_ERROR_SUMMARIES.INCOMPATIBLE_FLOW,

--- a/src/worker/scraper/login-mutation-guard.ts
+++ b/src/worker/scraper/login-mutation-guard.ts
@@ -1,5 +1,5 @@
 export interface BankPortalConfig {
-  // Trusted portal metadata used by the mutation guard; it never authorizes a page by itself.
+  // Foundation only: no production scraper caller yet; reserved metadata is non-authorizing.
   bankCode?: string;
   baseUrl: string;
   loginPathAllowlist: readonly string[];


### PR DESCRIPTION
## Summary

- Makes LoginMutationGuard the single authority for username, password, and submit mutation boundaries.
- Enforces controls and protected/incompatible checks before a final authorized-URL read immediately before each mutation.
- Adds fail-closed coverage for mutation-time redirects and delayed post-submit challenges.

## Scope

- src/worker/scraper/auto-login.ts
- src/worker/scraper/auto-login.test.ts
- src/worker/scraper/login-mutation-guard.ts
- src/worker/scraper/login-mutation-guard.test.ts

## Safety boundaries

- No production opener activation in this slice; ingestion worker remains base-equivalent and uses the unavailable opener.
- No MFA/CAPTCHA/Imperva/OneSpan/security-question/anti-bot bypass.
- URL authorization is the final awaited guard check before username fill, password fill, and submit.
- Unexpected selector and URL failures map to safe admin-action outcomes.
- No Popular fallback, credential leakage, CDP detail leakage, or raw internal diagnostics.

## Verification

- pnpm test — passed: 1018 tests passed, 38 skipped.
- pnpm lint — passed.
- pnpm typecheck — passed.
- git diff --check — passed with LF/CRLF warnings only.
- Final PR-level 4R — R1/R2/R3/R4 passed; R2 stale-context warning resolved by this update.
- Judgment Day — APPROVED.

## Review budget

- 4 files, 172 insertions / 47 deletions = 219 changed lines.

## Chain context

- Base: feature/multi-bank-auto-login.
- PR4.5d dormant opener lifecycle landed in #31.
- This is PR4.5e: guard hardening only.
- Follow-up slice must implement usable Popular strategy + production opener activation + direct composition-contract test atomically.
- Task 4.5 remains unchecked.

## Rollback

Revert commits 28cc686 and ca4280c. Production opener remains unavailable either way.