### PR TITLE
feat(adapters): add verified Popular auto-login strategy (PR4.5f)

### DIFF
--- a/src/modules/bank-adapters/popular-portal.ts
+++ b/src/modules/bank-adapters/popular-portal.ts
@@ -1,0 +1,18 @@
+import { popularBankCode } from "./popular";
+
+/**
+ * Selector evidence comes from an operator-captured, sanitized live DOM. It is
+ * empirical, best-effort behavior for the trusted Popular profile and may drift.
+ * This runtime-free configuration does not activate production auto-login.
+ */
+export const popularPortalConfig = {
+  bankCode: popularBankCode,
+  baseUrl: "https://ib.bpd.com.do",
+  loginPathAllowlist: ["/"],
+  usernameSelector: "input[name=\"username\"]",
+  passwordSelector: "input[name=\"password\"]",
+  submitSelector: "button[type=\"submit\"]",
+  mfaIndicatorSelector: "input[name=\"token\"]",
+  incompatibleFlowSelector: "[aria-modal=\"true\"]",
+  dashboardPathIndicator: "/dashboard",
+} as const;

--- a/src/modules/bank-adapters/popular.test.ts
+++ b/src/modules/bank-adapters/popular.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 
 import type { IngestionScraper } from "../../worker/queues";
 import {
-  createPopularAutoLoginStrategy,
   createPopularBankAdapter,
   parsePopularTransactionRows,
   popularBankCode,
@@ -89,9 +88,16 @@ describe("createPopularBankAdapter", () => {
   const stubScraper: IngestionScraper = {
     collect: async () => ({ status: "collected", movements: [] }),
   };
+  const stubAutoLoginStrategy = {
+    bankCode: "popular",
+    autoLogin: async () => ({ status: "succeeded" as const }),
+  };
 
   it("exposes Popular as a BankAdapter keyed by the canonical bankCode", () => {
-    const adapter = createPopularBankAdapter({ createScraper: () => stubScraper });
+    const adapter = createPopularBankAdapter({
+      createScraper: () => stubScraper,
+      createAutoLoginStrategy: () => stubAutoLoginStrategy,
+    });
 
     expect(adapter.bankCode).toBe("popular");
   });
@@ -103,6 +109,7 @@ describe("createPopularBankAdapter", () => {
         called += 1;
         return stubScraper;
       },
+      createAutoLoginStrategy: () => stubAutoLoginStrategy,
     });
 
     const scraper = adapter.createScraper();
@@ -110,15 +117,12 @@ describe("createPopularBankAdapter", () => {
     expect(called).toBe(1);
   });
 
-  it("createAutoLoginStrategy is a not-implemented stub in PR1 (no auto-login surface yet)", () => {
-    const adapter = createPopularBankAdapter({ createScraper: () => stubScraper });
+  it("delegates auto-login strategy construction to the injected server factory", () => {
+    const adapter = createPopularBankAdapter({
+      createScraper: () => stubScraper,
+      createAutoLoginStrategy: () => stubAutoLoginStrategy,
+    });
 
-    expect(() => adapter.createAutoLoginStrategy()).toThrow(/not implemented/i);
-  });
-});
-
-describe("createPopularAutoLoginStrategy", () => {
-  it("throws a not-implemented error directly (PR1 has no auto-login)", () => {
-    expect(() => createPopularAutoLoginStrategy()).toThrow(/not implemented/i);
+    expect(adapter.createAutoLoginStrategy()).toBe(stubAutoLoginStrategy);
   });
 });

--- a/src/modules/bank-adapters/popular.ts
+++ b/src/modules/bank-adapters/popular.ts
@@ -1,6 +1,5 @@
 import type { BankMovement, TransactionDirection } from "../transactions";
-import type { IngestionScraper } from "../../worker/queues";
-import type { BankAdapter, BankAutoLoginStrategy } from "./registry";
+import type { BankAdapter } from "./registry";
 
 const POPULAR_BANK_ID = "popular";
 
@@ -169,33 +168,21 @@ function normalizeOptionalText(value: string | null | undefined): string | null 
 // ---------------------------------------------------------------------------
 // Bank adapter — exposes Popular as a `BankAdapter` keyed by `bankCode`.
 //
-// The domain module stays free of worker/runtime coupling: the heavyweight
-// scraper factory (env wiring, CDP attach) is INJECTED by the server wiring
-// layer (the registry in `registry.ts`). PR1 only wires routing; there is NO
-// auto-login surface, so `createAutoLoginStrategy` is a not-implemented stub.
+// The domain module stays free of worker/runtime coupling. Both factories are
+// injected by the server wiring layer, which owns CDP and login state machines.
 // ---------------------------------------------------------------------------
 
 /**
- * PR1 stub: Popular auto-login is not implemented yet. PR4 introduces the real
- * `BankAutoLoginStrategy` state machine, `LoginMutationGuard`, and Redis lock.
- * Calling this before PR4 is a programmer error, not a runtime scrape path.
- */
-export function createPopularAutoLoginStrategy(): BankAutoLoginStrategy {
-  throw new Error("Popular auto-login strategy is not implemented yet (PR4)");
-}
-
-/**
- * Builds the Popular `BankAdapter`. The `createScraper` factory is injected by
- * the server wiring layer so this domain module never imports the worker CDP
- * runtime (avoids a domain -> worker dependency and a circular import with
- * `popular-cdp.ts`, which imports this module's profile/parser).
+ * Builds the Popular `BankAdapter` from server-owned factories. This module
+ * deliberately imports no worker module, avoiding a domain-to-worker cycle.
  */
 export function createPopularBankAdapter(options: {
-  createScraper: () => IngestionScraper;
+  createScraper: BankAdapter["createScraper"];
+  createAutoLoginStrategy: BankAdapter["createAutoLoginStrategy"];
 }): BankAdapter {
   return {
     bankCode: popularBankCode,
     createScraper: options.createScraper,
-    createAutoLoginStrategy: createPopularAutoLoginStrategy,
+    createAutoLoginStrategy: options.createAutoLoginStrategy,
   };
 }

--- a/src/modules/bank-adapters/registry.test.ts
+++ b/src/modules/bank-adapters/registry.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import type { IngestionScraper } from "../../worker/queues";
 import {
@@ -7,6 +7,7 @@ import {
   createBankAdapterRegistry,
   type BankAdapter,
 } from "./registry";
+import { popularPortalConfig } from "./popular-portal";
 
 const stubScraper: IngestionScraper = {
   collect: async () => ({ status: "collected", movements: [] }),
@@ -19,6 +20,32 @@ function fakeAdapter(bankCode: string): BankAdapter {
     createAutoLoginStrategy: () => {
       throw new Error("not implemented");
     },
+  };
+}
+
+function makePopularLoginPage(unsafeSelector?: string) {
+  let url: string = popularPortalConfig.baseUrl;
+  const visible = new Set<string>([
+    popularPortalConfig.usernameSelector,
+    popularPortalConfig.passwordSelector,
+    popularPortalConfig.submitSelector,
+  ]);
+  if (unsafeSelector) visible.add(unsafeSelector);
+
+  const fill = vi.fn();
+  const click = vi.fn(async () => {
+    url = `${popularPortalConfig.baseUrl}${popularPortalConfig.dashboardPathIndicator}`;
+  });
+
+  return {
+    page: {
+      currentUrl: async () => url,
+      hasVisibleSelector: async (selector: string) => visible.has(selector),
+      fill,
+      click,
+    },
+    fill,
+    click,
   };
 }
 
@@ -91,7 +118,7 @@ describe("createBankAdapterRegistry — CDP endpoint uniqueness guard (MEDIUM-2)
   });
 });
 
-describe("bankAdapterRegistry — default instance (Popular registered in PR1)", () => {
+describe("bankAdapterRegistry — default instance", () => {
   it("resolves the Popular adapter by its canonical bankCode", () => {
     const adapter = bankAdapterRegistry.get("popular");
 
@@ -99,7 +126,7 @@ describe("bankAdapterRegistry — default instance (Popular registered in PR1)",
     expect(adapter?.bankCode).toBe("popular");
   });
 
-  it("exposes only Popular as supported in PR1 (Banreservas/BHD land in PR5)", () => {
+  it("exposes only the currently registered Popular adapter", () => {
     expect(bankAdapterRegistry.supportedBankCodes()).toEqual(["popular"]);
   });
 
@@ -125,5 +152,40 @@ describe("buildPopularCdpScraperOptionsFromEnv — production backpressure wirin
     });
 
     expect(typeof options?.acquireBrowserSlot).toBe("function");
+  });
+
+});
+
+describe("bankAdapterRegistry — Popular auto-login strategy", () => {
+  it("uses configured selectors and outcomes in an offline fixture, not as independent live-surface proof", async () => {
+    const strategy = bankAdapterRegistry.get("popular")!.createAutoLoginStrategy();
+    const { page, fill, click } = makePopularLoginPage();
+
+    await expect(strategy.autoLogin({
+      credential: { bankCode: "popular", username: "bank-user", password: "bank-password" },
+      page,
+    })).resolves.toEqual({ status: "succeeded" });
+
+    expect(fill.mock.calls).toEqual([
+      [popularPortalConfig.usernameSelector, "bank-user"],
+      [popularPortalConfig.passwordSelector, "bank-password"],
+    ]);
+    expect(click).toHaveBeenCalledWith(popularPortalConfig.submitSelector);
+  });
+
+  it.each([
+    ["token challenge", popularPortalConfig.mfaIndicatorSelector, "protected_flow"],
+    ["modal", popularPortalConfig.incompatibleFlowSelector, "incompatible_flow"],
+  ] as const)("fails closed for a visible Popular %s without submitting credentials", async (_name, unsafeSelector, reason) => {
+    const strategy = bankAdapterRegistry.get("popular")!.createAutoLoginStrategy();
+    const { page, fill, click } = makePopularLoginPage(unsafeSelector);
+
+    await expect(strategy.autoLogin({
+      credential: { bankCode: "popular", username: "bank-user", password: "bank-password" },
+      page,
+    })).resolves.toMatchObject({ status: "needs_admin_action", reason });
+
+    expect(fill).not.toHaveBeenCalled();
+    expect(click).not.toHaveBeenCalled();
   });
 });

--- a/src/modules/bank-adapters/registry.ts
+++ b/src/modules/bank-adapters/registry.ts
@@ -1,17 +1,12 @@
 /**
- * Bank adapter registry — the canonical routing surface keyed by `bankCode`
- * (`Bank.code`, the immutable domain code), replacing the Popular-hardcoded
- * `resolveDefaultScraper`/`run-now`/`bank-sessions` resolution.
+ * Bank adapter registry — runtime composition keyed by `bankCode`
+ * (`Bank.code`, the immutable domain code). It registers each bank's scraper
+ * factory and injectable auto-login strategy for server-side resolution.
  *
  * `Bank.id` (cuid) remains the internal DB PK for existing relations
  * (`ScrapeRun`); `Bank.code` is the canonical adapter/job/API/credential
  * identity. Adapters are registered by `bankCode` and resolved by `bankCode`.
  *
- * PR1 scope: interface + factory + a Popular adapter instance. The full design
- * interface also exposes `portalConfig` and `createSessionChecker`; those are
- * intentionally added in PR2/PR5 when per-bank browser isolation and the
- * Banreservas/BHD read-only scrapers land, so PR1 stays a focused,
- * no-behavior-change routing refactor.
  */
 
 import type { IngestionScraper } from "../../worker/queues";
@@ -26,33 +21,30 @@ import {
   type EnsureBrowserSeam,
 } from "../../worker/scraper/browser-runtime";
 import {
+  createBankAutoLoginStrategy,
+  type BankAutoLoginStrategy as RuntimeBankAutoLoginStrategy,
+} from "../../worker/scraper/auto-login";
+import {
   createPopularBankAdapter,
   parsePopularTransactionRows,
   popularBankCode,
   popularPortalFixture,
 } from "./popular";
+import { popularPortalConfig } from "./popular-portal";
 
-/**
- * Placeholder for the auto-login strategy contract. PR4 fleshes this out into
- * the state machine + `LoginMutationGuard` + Redis `AutoLoginLock` wiring.
- * In PR1 every adapter's `createAutoLoginStrategy()` is a not-implemented stub
- * — there is NO auto-login surface in PR1.
- */
-export interface BankAutoLoginStrategy {
-  readonly bankCode: string;
-}
+export type BankAutoLoginStrategy = RuntimeBankAutoLoginStrategy;
 
 /**
  * A bank adapter. Each bank exposes its canonical `bankCode` plus the
  * factories the runtime needs. `createScraper` produces the read-only
- * `IngestionScraper`; `createAutoLoginStrategy` is stubbed in PR1.
+ * `IngestionScraper`; `createAutoLoginStrategy` is injected at server wiring.
  */
 export interface BankAdapter {
   /** Canonical immutable domain code (`Bank.code`), e.g. `popular`. */
   readonly bankCode: string;
   /** Builds the read-only ingestion scraper for this bank. */
   createScraper(): IngestionScraper;
-  /** PR1 stub — throws not-implemented. PR4 implements the real strategy. */
+  /** Builds the bank-specific credential-mutation strategy. */
   createAutoLoginStrategy(): BankAutoLoginStrategy;
 }
 
@@ -223,12 +215,19 @@ export function createPopularScraperFromEnv(
 
 const popularAdapter: BankAdapter = createPopularBankAdapter({
   createScraper: () => createPopularScraperFromEnv(),
+  createAutoLoginStrategy: () => createBankAutoLoginStrategy(popularPortalConfig, {
+    supportedBankCodes: [popularBankCode],
+  }),
 });
 
+// This composition makes the Popular strategy usable when a caller supplies
+// its page seam; registry construction does not execute it. Production
+// execution remains dormant: the opener is unavailable by default and
+// auto-launch is default-off. Event-source activation is deferred to PR4.5g/4.6.
+
 /**
- * Default bank adapter registry. PR1 registers only Popular; Banreservas and
- * BHD adapters are added in PR5. Routing and run-now validation resolve
- * through this instance so an explicit unknown `bankCode` fails closed.
+ * Default bank adapter registry. Routing and run-now validation resolve through
+ * this instance so an explicit unknown `bankCode` fails closed.
  */
 export const bankAdapterRegistry: BankAdapterRegistry = createBankAdapterRegistry([
   popularAdapter,


### PR DESCRIPTION
## Summary

- Adds operator-verified Banco Popular login portal configuration from sanitized live DOM evidence.
- Replaces the throwing Popular strategy stub with an injected real strategy built by the existing guarded state machine.
- Keeps production execution dormant; activation, credential-caching controls, throttled semantics, and expired-event sourcing remain follow-up work.

## Scope

- src/modules/bank-adapters/popular-portal.ts
- src/modules/bank-adapters/popular.ts
- src/modules/bank-adapters/popular.test.ts
- src/modules/bank-adapters/registry.ts
- src/modules/bank-adapters/registry.test.ts

## Verified selectors

- Login path: /
- Username: input[name=username]
- Password: input[name=password]
- Submit: button[type=submit]
- MFA/token: input[name=token]
- Incompatible/error modal: [aria-modal=true]
- Dashboard: /dashboard

## Safety boundaries

- Evidence was captured manually by an operator; no credentials, token values, or account data are stored.
- No bot/Parval/CAPTCHA/MFA bypass.
- Token and modal states stop before credential mutation and return needs_admin_action.
- Domain adapter remains worker-runtime-free; strategy factory is injected by registry wiring.
- Unknown banks do not fall back to Popular.
- Production worker still uses the unavailable opener; default-off/dormant posture is preserved.

## Verification

- pnpm test — passed: 1020 tests passed, 38 skipped.
- pnpm lint — passed.
- pnpm typecheck — passed.
- git diff --check — passed with LF/CRLF warnings only.
- Final 4R — R1/R2/R3/R4 passed.
- Judgment Day — APPROVED.

## Review budget

- 5 files, 127 insertions / 57 deletions = 184 changed lines.

## Chain context

- Base: feature/multi-bank-auto-login.
- PR4.5d opener lifecycle landed in #31.
- PR4.5e guard hardening landed in #32.
- This is PR4.5f: verified Popular strategy only.
- Follow-up PR4.5g must atomically solve deferred throttling, no credential caching, worker composition contract, opener activation, and expired-event source wiring.
- Task 4.5 remains unchecked.

## Local tooling

- .playwright-mcp/ is user-local capture state and is intentionally excluded from this PR.

## Rollback

Revert c30b8e3; production login remains dormant either way.