### PR TITLE
feat(scraper): persist deferred auto-login throttling

### DIFF
--- a/prisma/migrations/20260712000000_add_scrape_run_throttled_status/migration.sql
+++ b/prisma/migrations/20260712000000_add_scrape_run_throttled_status/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "ScrapeRunStatus" ADD VALUE IF NOT EXISTS 'throttled';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -37,6 +37,7 @@ enum ScrapeRunStatus {
   SUCCEEDED          @map("succeeded")
   FAILED             @map("failed")
   NEEDS_ADMIN_ACTION @map("needs_admin_action")
+  THROTTLED          @map("throttled")
 }
 
 // BankSessionStatus is not referenced by any Prisma model field.

--- a/src/app/admin/scrape-runs/page.test.tsx
+++ b/src/app/admin/scrape-runs/page.test.tsx
@@ -120,6 +120,18 @@ describe("AdminScrapeRunsDashboard", () => {
     expect(html).not.toContain("password=");
   });
 
+  it("renders a throttled run with the explicit deferred warning badge", () => {
+    const html = renderToStaticMarkup(
+      <AdminScrapeRunsDashboard
+        principal={{ id: "admin-1", role: "admin" }}
+        runs={[{ ...runs[0], id: "run-throttled", status: "throttled" }]}
+      />,
+    );
+
+    expect(html).toContain("Pospuesta temporalmente");
+    expect(html).toContain("bg-warning");
+  });
+
   it("denies non-admin users with a Spanish denial page and without leaking run details", () => {
     const html = renderToStaticMarkup(
       <AdminScrapeRunsDashboard principal={{ id: "viewer-1", role: "viewer" }} runs={runs} />,

--- a/src/app/admin/scrape-runs/page.tsx
+++ b/src/app/admin/scrape-runs/page.tsx
@@ -419,6 +419,12 @@ function statusToBadge(status: ScrapeRunStatus): {
         label: scrapeRunStatusLabel(status),
         icon: <AlertTriangle className="h-3 w-3" aria-hidden />,
       };
+    case "throttled":
+      return {
+        variant: "warning",
+        label: scrapeRunStatusLabel(status),
+        icon: <Clock className="h-3 w-3" aria-hidden />,
+      };
     case "running":
       return {
         variant: "secondary",

--- a/src/app/api/scrape-runs/[runId]/route.test.ts
+++ b/src/app/api/scrape-runs/[runId]/route.test.ts
@@ -52,6 +52,35 @@ describe("GET /api/scrape-runs/[runId] — single-run status", () => {
     });
   });
 
+  it("exposes throttled as a terminal status without exposing its safe summary", async () => {
+    const repo = new InMemoryScrapeRunRepository();
+    await repo.createQueued({ id: "run-throttled", bankId: "popular" });
+    await repo.markThrottled(
+      "run-throttled",
+      "Bank browser capacity is temporarily unavailable token=secret",
+      new Date("2026-06-09T12:01:15.000Z"),
+    );
+    const handler = createGetScrapeRunStatusHandler({ scrapeRuns: repo });
+
+    const response = await handler(
+      new Request("https://rd-sync.test/api/scrape-runs/run-throttled", {
+        method: "GET",
+        headers: { "x-rd-sync-user-id": "viewer-1", "x-rd-sync-role": "viewer" },
+      }),
+      { params: Promise.resolve({ runId: "run-throttled" }) },
+    );
+
+    expect(await response.json()).toEqual({
+      run: {
+        id: "run-throttled",
+        bankId: "popular",
+        status: "throttled",
+        insertedCount: 0,
+        skippedCount: 0,
+      },
+    });
+  });
+
   it("also admits reviewer and admin roles", async () => {
     const repo = new InMemoryScrapeRunRepository();
     await seedSucceededRun(repo, "run-x");

--- a/src/app/api/scrape-runs/consumer-env-switch.test.ts
+++ b/src/app/api/scrape-runs/consumer-env-switch.test.ts
@@ -33,6 +33,7 @@ function resolveConsumerForEnv(options?: {
       markRunning: async () => {},
       markSucceeded: async () => {},
       markNeedsAdminAction: async () => {},
+      markThrottled: async () => {},
       markFailed: async () => {},
     },
     transactions: { upsertMany: async () => ({ inserted: 0, skipped: 0 }) },

--- a/src/components/transactions/refresh-button.test.tsx
+++ b/src/components/transactions/refresh-button.test.tsx
@@ -195,6 +195,24 @@ describe("refreshTransactions — 202 polling contract", () => {
     expect(onRefresh).toHaveBeenCalledTimes(1);
   });
 
+  it("on throttled stops polling, shows the deferred-result toast, and refreshes", async () => {
+    const fetchImpl = vi.fn<typeof fetch>();
+    fetchImpl.mockResolvedValue(statusResponse("throttled"));
+    fetchImpl.mockResolvedValueOnce(post202Response("run-throttled"));
+
+    const onRefresh = vi.fn();
+
+    await refreshTransactions({ fetchImpl, onRefresh, sleep: instantSleep });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(toast.info).toHaveBeenCalledWith(
+      "La actualización se pospuso temporalmente por capacidad del sistema. Intente nuevamente en unos momentos.",
+      expect.objectContaining({ duration: REFRESH_RESULT_TOAST_DURATION_MS }),
+    );
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+
   it("on failed shows the failure toast and refreshes", async () => {
     const fetchImpl = vi.fn<typeof fetch>();
     fetchImpl.mockResolvedValue(statusResponse("failed"));
@@ -692,7 +710,7 @@ describe("refreshTransactions — visible result messages", () => {
     );
   });
 
-  it("terminal failure states map to error tone (still safe Spanish, no leak)", async () => {
+  it("terminal states map to safe Spanish copy and an appropriate tone", async () => {
     // `describePollOutcome` is the single source of truth for tone, so
     // pin it directly for every non-succeeded terminal state.
     expect(describePollOutcome({ status: "failed" })).toEqual({
@@ -712,6 +730,11 @@ describe("refreshTransactions — visible result messages", () => {
       message:
         "La corrida sigue procesándose. Actualice nuevamente en unos momentos.",
       tone: "error",
+    });
+    expect(describePollOutcome({ status: "throttled" })).toEqual({
+      message:
+        "La actualización se pospuso temporalmente por capacidad del sistema. Intente nuevamente en unos momentos.",
+      tone: "info",
     });
   });
 

--- a/src/components/transactions/refresh-button.tsx
+++ b/src/components/transactions/refresh-button.tsx
@@ -19,6 +19,7 @@ import { Button } from "../ui/button";
 //   needs_admin -> admin-action result toast (12s) + refresh
 //   unverified  -> could-not-verify result toast (12s) + refresh (404/401/403 mid-poll)
 //   timeout     -> still-processing result toast (12s) + refresh (deadline / hung GET)
+//   throttled   -> deferred-result toast (12s) + refresh (browser capacity)
 //
 // Terminal results surface as a Sonner toast (longer 12s duration, larger
 // text) — NOT an inline banner. An inline banner shifted the Refresh button's
@@ -36,6 +37,8 @@ const USER_SAFE_REFRESH_IMPORTED_SINGULAR =
 const USER_SAFE_REFRESH_FAILED = "No se pudo completar la actualización. Intente nuevamente.";
 const USER_SAFE_REFRESH_NEEDS_ADMIN = "La sesión del banco requiere acción del administrador.";
 const USER_SAFE_REFRESH_TIMEOUT = "La corrida sigue procesándose. Actualice nuevamente en unos momentos.";
+const USER_SAFE_REFRESH_THROTTLED =
+  "La actualización se pospuso temporalmente por capacidad del sistema. Intente nuevamente en unos momentos.";
 const USER_SAFE_REFRESH_UNVERIFIED =
   "No se pudo verificar el resultado de la corrida. Actualice nuevamente en unos momentos.";
 const USER_SAFE_RUN_CONFLICT = "Ya hay una corrida en proceso. Espere a que termine.";
@@ -49,13 +52,13 @@ const USER_SAFE_NETWORK_ERROR =
 const DEFAULT_REFRESH_TIMEOUT_MS = 15_000;
 
 // Polling defaults. The client polls the single-run status endpoint until the
-// run reaches a terminal state (succeeded/failed/needs_admin_action) or the
+// run reaches a terminal state (succeeded/failed/needs_admin_action/throttled) or the
 // polling deadline elapses. Defaults are conservative — a scrape run can take
 // tens of seconds on the worker, so 60s gives it room without hanging forever.
 const DEFAULT_POLL_INTERVAL_MS = 1_500;
 const DEFAULT_POLL_TIMEOUT_MS = 60_000;
 
-// Terminal refresh results (succeeded / failed / needs_admin_action /
+// Terminal refresh results (succeeded / failed / needs_admin_action / throttled /
 // unverified / timeout) are important enough to stay visible longer than
 // Sonner's default toast. Centralized as a named, exported constant so every
 // terminal outcome shares one duration and tests can assert on it without
@@ -138,6 +141,7 @@ export type PollScrapeRunStatusOutcome =
   | { status: "succeeded"; insertedCount: number }
   | { status: "failed" }
   | { status: "needs_admin_action" }
+  | { status: "throttled" }
   | { status: "unverified" }
   | { status: "timeout" };
 
@@ -182,6 +186,8 @@ export function describePollOutcome(
       return { message: USER_SAFE_REFRESH_FAILED, tone: "error" };
     case "needs_admin_action":
       return { message: USER_SAFE_REFRESH_NEEDS_ADMIN, tone: "error" };
+    case "throttled":
+      return { message: USER_SAFE_REFRESH_THROTTLED, tone: "info" };
     case "unverified":
       return { message: USER_SAFE_REFRESH_UNVERIFIED, tone: "error" };
     case "timeout":
@@ -214,7 +220,7 @@ export interface PollScrapeRunStatusOptions {
 
 /**
  * Poll `GET /api/scrape-runs/[runId]` until the run reaches a terminal state
- * (`succeeded` / `failed` / `needs_admin_action`) or the deadline elapses.
+ * (`succeeded` / `failed` / `needs_admin_action` / `throttled`) or the deadline elapses.
  *
  * The first check is delayed by `pollIntervalMs` — the run was JUST created as
  * `queued`, so an immediate poll would almost certainly return `queued` and
@@ -332,6 +338,7 @@ export async function pollScrapeRunStatus({
       }
       if (runStatus === "failed") return { status: "failed" };
       if (runStatus === "needs_admin_action") return { status: "needs_admin_action" };
+      if (runStatus === "throttled") return { status: "throttled" };
       // queued / running / unknown — keep polling.
     } finally {
       // Always clear the timer once the fetch + body parse for this poll are
@@ -443,7 +450,7 @@ interface RefreshTransactionsOptions {
   bankId?: string;
   fetchImpl: typeof fetch;
   /**
-   * Fires only on terminal states (succeeded/failed/needs_admin_action) and
+   * Fires only on terminal states (succeeded/failed/needs_admin_action/throttled) and
    * on polling timeout — NOT on the initial 202. Renamed from `onSuccess`
    * because "success" now means "the worker finished", not "the run was
    * queued".

--- a/src/lib/banks.test.ts
+++ b/src/lib/banks.test.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_RUN_NOW_BANK_CODE,
   SUPPORTED_RUN_NOW_BANK_CODES,
   isSupportedRunNowBankCode,
+  scrapeRunStatusLabel,
 } from "./banks";
 
 describe("SUPPORTED_RUN_NOW_BANK_CODES — canonical bankCode whitelist", () => {
@@ -31,5 +32,12 @@ describe("SUPPORTED_RUN_NOW_BANK_CODES — registry parity (derived from registr
     expect([...SUPPORTED_RUN_NOW_BANK_CODES]).toEqual([
       ...bankAdapterRegistry.supportedBankCodes(),
     ]);
+  });
+});
+
+describe("scrapeRunStatusLabel", () => {
+  it("labels throttled runs as deferred instead of requiring admin action", () => {
+    expect(scrapeRunStatusLabel("throttled")).toBe("Pospuesta temporalmente");
+    expect(scrapeRunStatusLabel("needs_admin_action")).toBe("Necesita acción administrativa");
   });
 });

--- a/src/lib/banks.ts
+++ b/src/lib/banks.ts
@@ -98,6 +98,7 @@ const SCRAPE_RUN_STATUS_LABELS: Record<ScrapeRunStatus, string> = {
   succeeded: "Completada",
   failed: "Fallida",
   needs_admin_action: "Necesita acción administrativa",
+  throttled: "Pospuesta temporalmente",
 };
 
 export function scrapeRunStatusLabel(status: ScrapeRunStatus): string {

--- a/src/modules/persistence/contracts/scrape-run-repository.contract.ts
+++ b/src/modules/persistence/contracts/scrape-run-repository.contract.ts
@@ -17,6 +17,7 @@ export interface ScrapeRunRepoHandle {
     markRunning(runId: string, startedAt?: Date): Promise<void>;
     markSucceeded(runId: string, counts: { insertedCount: number; skippedCount: number }, endedAt?: Date): Promise<void>;
     markNeedsAdminAction(runId: string, safeErrorSummary: string, endedAt?: Date): Promise<void>;
+    markThrottled(runId: string, safeErrorSummary: string, endedAt?: Date): Promise<void>;
     markFailed(runId: string, safeErrorSummary: string, endedAt?: Date): Promise<void>;
   };
   cleanup(): Promise<void>;
@@ -169,6 +170,28 @@ export function runScrapeRunRepositoryContract(
 
       expect(run.status).toBe("needs_admin_action");
       expect(run.safeErrorSummary).toBe("Bank session requires admin MFA action");
+    });
+
+    // -------------------------------------------------------------------------
+    // markThrottled
+    // -------------------------------------------------------------------------
+    it("transitions to throttled and filters the deferred run by status", async () => {
+      const endedAt = new Date("2026-06-08T12:03:00.000Z");
+      await handle.repo.createQueued({ id: "run-throttled", bankId: "popular" });
+      await handle.repo.markThrottled(
+        "run-throttled",
+        "Bank browser capacity is temporarily unavailable",
+        endedAt,
+      );
+
+      const [run] = await handle.repo.list({ status: "throttled" });
+
+      expect(run).toMatchObject({
+        id: "run-throttled",
+        status: "throttled",
+        safeErrorSummary: "Bank browser capacity is temporarily unavailable",
+        endedAt,
+      });
     });
 
     // -------------------------------------------------------------------------

--- a/src/modules/persistence/prisma-client.ts
+++ b/src/modules/persistence/prisma-client.ts
@@ -113,7 +113,7 @@ export function fromDbReviewState(
  * Map domain ScrapeRunStatus string to Prisma enum key.
  */
 export function toDbScrapeRunStatus(
-  status: "queued" | "running" | "succeeded" | "failed" | "needs_admin_action",
+  status: "queued" | "running" | "succeeded" | "failed" | "needs_admin_action" | "throttled",
 ): PrismaScrapeRunStatus {
   const map: Record<string, PrismaScrapeRunStatus> = {
     queued: ScrapeRunStatus.QUEUED,
@@ -121,6 +121,7 @@ export function toDbScrapeRunStatus(
     succeeded: ScrapeRunStatus.SUCCEEDED,
     failed: ScrapeRunStatus.FAILED,
     needs_admin_action: ScrapeRunStatus.NEEDS_ADMIN_ACTION,
+    throttled: ScrapeRunStatus.THROTTLED,
   };
   const result = map[status];
   if (result === undefined) throw new Error(`Unknown scrape run status: ${status}`);
@@ -132,16 +133,17 @@ export function toDbScrapeRunStatus(
  */
 export function fromDbScrapeRunStatus(
   status: PrismaScrapeRunStatus,
-): "queued" | "running" | "succeeded" | "failed" | "needs_admin_action" {
+): "queued" | "running" | "succeeded" | "failed" | "needs_admin_action" | "throttled" {
   const map: Record<
     string,
-    "queued" | "running" | "succeeded" | "failed" | "needs_admin_action"
+    "queued" | "running" | "succeeded" | "failed" | "needs_admin_action" | "throttled"
   > = {
     [ScrapeRunStatus.QUEUED]: "queued",
     [ScrapeRunStatus.RUNNING]: "running",
     [ScrapeRunStatus.SUCCEEDED]: "succeeded",
     [ScrapeRunStatus.FAILED]: "failed",
     [ScrapeRunStatus.NEEDS_ADMIN_ACTION]: "needs_admin_action",
+    [ScrapeRunStatus.THROTTLED]: "throttled",
   };
   const result = map[status];
   if (result === undefined) throw new Error(`Unknown DB scrape run status: ${status}`);

--- a/src/modules/persistence/prisma-scrape-run-repository.ts
+++ b/src/modules/persistence/prisma-scrape-run-repository.ts
@@ -177,6 +177,19 @@ export class PrismaScrapeRunRepository {
     });
   }
 
+  async markThrottled(
+    runId: string,
+    safeErrorSummary: string,
+    endedAt = new Date(),
+  ): Promise<void> {
+    await this.updateOrThrow(runId, {
+      status: toDbScrapeRunStatus("throttled"),
+      endedAt,
+      safeErrorSummary,
+      updatedAt: endedAt,
+    });
+  }
+
   async markFailed(
     runId: string,
     safeErrorSummary: string,

--- a/src/modules/scrape-runs/index.ts
+++ b/src/modules/scrape-runs/index.ts
@@ -158,6 +158,15 @@ export class InMemoryScrapeRunRepository implements WorkerScrapeRunRepository {
     });
   }
 
+  async markThrottled(runId: string, safeErrorSummary: string, endedAt = new Date()): Promise<void> {
+    this.update(runId, {
+      status: "throttled",
+      endedAt,
+      safeErrorSummary,
+      updatedAt: endedAt,
+    });
+  }
+
   async markFailed(runId: string, safeErrorSummary: string, endedAt = new Date()): Promise<void> {
     this.update(runId, {
       status: "failed",

--- a/src/modules/scrape-runs/scrape-runs.test.ts
+++ b/src/modules/scrape-runs/scrape-runs.test.ts
@@ -6,6 +6,7 @@ import {
   toDashboardScrapeRun,
 } from "./index";
 import type { ScrapeRunRecord } from "./index";
+import { runScrapeRunRepositoryContract } from "../persistence/contracts/scrape-run-repository.contract";
 
 const baseRun: ScrapeRunRecord = {
   id: "run-1",
@@ -220,4 +221,30 @@ describe("InMemoryScrapeRunRepository", () => {
       ["run-mfa", "needs_admin_action", "Bank session requires admin MFA action"],
     ]);
   });
+
+  it("persists browser throttling as a distinct deferred outcome", async () => {
+    const repository = new InMemoryScrapeRunRepository();
+
+    await repository.createQueued({ id: "run-throttled", bankId: "popular" });
+    await repository.markThrottled(
+      "run-throttled",
+      "Bank browser capacity is temporarily unavailable",
+      new Date("2026-06-08T12:05:00.000Z"),
+    );
+
+    expect(await repository.list({ status: "throttled" })).toMatchObject([
+      {
+        id: "run-throttled",
+        status: "throttled",
+        safeErrorSummary: "Bank browser capacity is temporarily unavailable",
+        endedAt: new Date("2026-06-08T12:05:00.000Z"),
+      },
+    ]);
+    expect(await repository.list({ status: "needs_admin_action" })).toEqual([]);
+  });
 });
+
+runScrapeRunRepositoryContract(async () => ({
+  repo: new InMemoryScrapeRunRepository(),
+  cleanup: async () => undefined,
+}));

--- a/src/worker/ingestion-consumer.test.ts
+++ b/src/worker/ingestion-consumer.test.ts
@@ -34,6 +34,10 @@ class FakeScrapeRunRepository {
     this.records.set(runId, { status: "needs_admin_action", safeErrorSummary });
   }
 
+  async markThrottled(runId: string, safeErrorSummary: string): Promise<void> {
+    this.records.set(runId, { status: "throttled", safeErrorSummary });
+  }
+
   async markFailed(runId: string, safeErrorSummary: string): Promise<void> {
     this.records.set(runId, { status: "failed", safeErrorSummary });
   }

--- a/src/worker/queues/index.ts
+++ b/src/worker/queues/index.ts
@@ -1,11 +1,12 @@
 import type { JobsOptions } from "bullmq";
 
 import { createAuditEvent, type AuditSink } from "../../modules/audit";
+import { BANK_AUTOLOGIN_ACTIONS } from "../../modules/audit/bank-actions";
 import { type BankMovement, type TransactionRecord, normalizeBankMovement } from "../../modules/transactions";
 import type { ScrapeTimeAutoLoginOutcome } from "../scraper/auto-login";
 import { redactDiagnosticText, type ScrapeCollectionResult } from "../scraper";
 
-export type ScrapeRunStatus = "queued" | "running" | "succeeded" | "failed" | "needs_admin_action";
+export type ScrapeRunStatus = "queued" | "running" | "succeeded" | "failed" | "needs_admin_action" | "throttled";
 
 export interface IngestionJobData {
   runId: string;
@@ -46,6 +47,7 @@ export interface ScrapeRunRepository {
   markRunning(runId: string, startedAt?: Date): Promise<void>;
   markSucceeded(runId: string, counts: { insertedCount: number; skippedCount: number }, endedAt?: Date): Promise<void>;
   markNeedsAdminAction(runId: string, safeErrorSummary: string, endedAt?: Date): Promise<void>;
+  markThrottled(runId: string, safeErrorSummary: string, endedAt?: Date): Promise<void>;
   markFailed(runId: string, safeErrorSummary: string, endedAt?: Date): Promise<void>;
 }
 
@@ -108,6 +110,7 @@ export interface QueueLike {
 
 const ingestionJobName = "bank-transaction-ingestion";
 const SYSTEM_INGESTION_ACTOR = "system:ingestion-worker";
+const SYSTEM_AUTOLOGIN_ACTOR = "system:auto-login";
 
 export function createIngestionProcessor(dependencies: IngestionProcessorDependencies) {
   const now = dependencies.now ?? (() => new Date());
@@ -135,8 +138,18 @@ export function createIngestionProcessor(dependencies: IngestionProcessorDepende
 
     try {
       const autoLoginOutcome = await runScrapeTimeAutoLoginIfNeeded(job, dependencies.runScrapeTimeAutoLogin);
-      if (autoLoginOutcome && shouldStopAfterAutoLogin(autoLoginOutcome)) {
+      if (autoLoginOutcome?.status === "needs_admin_action") {
         return markNeedsAdminActionTerminal(
+          dependencies,
+          job.data,
+          requestedBankCode,
+          autoLoginOutcome.safeSummary,
+          now,
+        );
+      }
+
+      if (autoLoginOutcome?.status === "throttled") {
+        return markThrottledDeferred(
           dependencies,
           job.data,
           requestedBankCode,
@@ -205,10 +218,6 @@ async function runScrapeTimeAutoLoginIfNeeded(
   }
 }
 
-function shouldStopAfterAutoLogin(outcome: ScrapeTimeAutoLoginOutcome): outcome is Extract<ScrapeTimeAutoLoginOutcome, { status: "needs_admin_action" | "throttled" }> {
-  return outcome.status === "needs_admin_action" || outcome.status === "throttled";
-}
-
 async function markNeedsAdminActionTerminal(
   dependencies: Pick<IngestionProcessorDependencies, "scrapeRuns" | "adminAlerts" | "auditSink">,
   jobData: IngestionJobData,
@@ -230,6 +239,29 @@ async function markNeedsAdminActionTerminal(
   });
 
   return { status: "needs_admin_action", inserted: 0, skipped: 0 };
+}
+
+async function markThrottledDeferred(
+  dependencies: Pick<IngestionProcessorDependencies, "scrapeRuns" | "auditSink">,
+  jobData: IngestionJobData,
+  requestedBankCode: string,
+  safeErrorSummary: string,
+  now: () => Date,
+): Promise<IngestionResult> {
+  await dependencies.scrapeRuns.markThrottled(jobData.runId, safeErrorSummary, now());
+  await emitAuditEvent(dependencies.auditSink, {
+    action: "scrape_run.throttled",
+    runId: jobData.runId,
+    bankId: requestedBankCode,
+    metadata: { safeErrorSummary },
+  });
+  await emitAutoLoginThrottledAuditEvent(
+    dependencies.auditSink,
+    jobData.runId,
+    requestedBankCode,
+  );
+
+  return { status: "throttled", inserted: 0, skipped: 0 };
 }
 
 export function createIngestionQueueOptions(runId: string): JobsOptions {
@@ -285,5 +317,27 @@ async function emitAuditEvent(
     );
   } catch {
     // Audit failures must never disrupt ingestion
+  }
+}
+
+async function emitAutoLoginThrottledAuditEvent(
+  auditSink: Pick<AuditSink, "record"> | undefined,
+  runId: string,
+  bankCode: string,
+): Promise<void> {
+  if (!auditSink) return;
+  try {
+    await auditSink.record(
+      createAuditEvent({
+        actorId: SYSTEM_AUTOLOGIN_ACTOR,
+        actorRole: null,
+        action: BANK_AUTOLOGIN_ACTIONS.SKIPPED,
+        target: "scrape_run",
+        targetId: runId,
+        metadata: { bankCode, reason: "throttled" },
+      }),
+    );
+  } catch {
+    // Audit failures must never disrupt ingestion.
   }
 }

--- a/src/worker/queues/queues.test.ts
+++ b/src/worker/queues/queues.test.ts
@@ -614,7 +614,7 @@ describe("ingestion processor — scrape-time auto-login trigger", () => {
     expect(transactions.received).toEqual([]);
   });
 
-  it("maps throttled auto-login to safe admin action without collecting", async () => {
+  it("persists throttled auto-login as deferred without collecting or alerting admins", async () => {
     const scrapeRuns = new FakeScrapeRunRepository();
     const transactions = new FakeTransactionRepository({ inserted: 0, skipped: 0 });
     const adminAlerts = new FakeAdminAlertSink();
@@ -636,33 +636,36 @@ describe("ingestion processor — scrape-time auto-login trigger", () => {
 
     const result = await processor({ data: { ...jobData, expiredEventId: "expired-throttled" } });
 
-    expect(result).toEqual({ status: "needs_admin_action", inserted: 0, skipped: 0 });
+    expect(result).toEqual({ status: "throttled", inserted: 0, skipped: 0 });
     expect(collect).not.toHaveBeenCalled();
     expect(scrapeRuns.transitions).toEqual([
       { runId: "run-1", status: "running" },
       {
         runId: "run-1",
-        status: "needs_admin_action",
+        status: "throttled",
         safeErrorSummary: "Bank browser capacity is temporarily unavailable",
       },
     ]);
     expect(transactions.received).toEqual([]);
-    expect(adminAlerts.events).toEqual([
-      {
-        runId: "run-1",
-        bankId: "popular",
-        status: "needs_admin_action",
-        safeErrorSummary: "Bank browser capacity is temporarily unavailable",
-      },
-    ]);
+    expect(adminAlerts.events).toEqual([]);
     const events = await auditSink.list();
-    expect(events.find((e) => e.action === "scrape_run.needs_admin_action")).toMatchObject({
+    expect(events.find((e) => e.action === "scrape_run.throttled")).toMatchObject({
       targetId: "run-1",
       metadata: {
         bankId: "popular",
         safeErrorSummary: "Bank browser capacity is temporarily unavailable",
       },
     });
+    expect(events.find((e) => e.action === "bank_autologin.skipped")).toMatchObject({
+      actorId: "system:auto-login",
+      actorRole: null,
+      target: "scrape_run",
+      targetId: "run-1",
+      metadata: { bankCode: "popular", reason: "throttled" },
+    });
+    const canonicalThrottledEvent = events.find((e) => e.action === "bank_autologin.skipped");
+    expect(JSON.stringify(canonicalThrottledEvent?.metadata)).not.toContain("capacity");
+    expect(events.find((e) => e.action === "scrape_run.needs_admin_action")).toBeUndefined();
   });
 
   it("maps thrown auto-login to safe admin action without leaking raw errors or collecting", async () => {
@@ -764,6 +767,10 @@ class FakeScrapeRunRepository {
 
   async markNeedsAdminAction(runId: string, safeErrorSummary: string): Promise<void> {
     this.transitions.push({ runId, status: "needs_admin_action", safeErrorSummary });
+  }
+
+  async markThrottled(runId: string, safeErrorSummary: string): Promise<void> {
+    this.transitions.push({ runId, status: "throttled", safeErrorSummary });
   }
 
   async markFailed(runId: string, safeErrorSummary: string): Promise<void> {


### PR DESCRIPTION
## Slice A — Deferred Browser-Capacity Throttling

This is the first reviewed child PR in the `feature/multi-bank-auto-login` feature-branch chain. It is ready for review and targets the tracker branch, not `main`.

### Chain Context

```text
main
  └─ #34 feature/multi-bank-auto-login (draft tracker; base 0a9fb7e)
       ├─ #30–#33 prior reviewed chain work (#33 at 0a9fb7e)
       └─ 📍 Slice A: feature/multi-bank-auto-login-pr4l-throttled-deferred (this PR)
            ├─ Slice B (follow-up, separate review)
            ├─ Slice C (follow-up, separate review)
            ├─ Slice D (follow-up, separate review)
            ├─ Slice E (follow-up, separate review)
            └─ Slice F (follow-up, separate review)
```

**Dependencies:** #33 / tracker baseline `0a9fb7e`. This PR must land on `feature/multi-bank-auto-login` before subsequent child slices build on it.

### Boundary

- **Start:** browser-capacity backpressure already introduced by prior reviewed chain work at `0a9fb7e`.
- **End:** persist a terminal, deferred `throttled` scrape-run outcome through the Prisma migration/domain contract, queue and audit behavior, API/polling consumers, and operator status UI, with tests in the same work unit.
- **Out of scope:** production browser-opener activation, broader auto-login orchestration, retry/re-enqueue behavior, duplicated status-union cleanup, and follow-up Slices B–F. No `.playwright-mcp/` artifacts are included.

### Review Budget and Diff

- **281 changed lines:** 255 additions, 26 deletions across 18 intended files, including the Prisma migration.
- The child diff was checked against `feature/multi-bank-auto-login`; it contains only this work unit.

### Migration / Rollback

Deploy the Prisma migration **before** application code so the new `throttled` enum value is accepted. PostgreSQL enum values are fix-forward once rows exist; rollback after a throttled row is written requires a forward compatibility migration rather than a destructive enum rollback.

### Verification and Review

- Final gates: **1037 passed, 39 skipped**; `pnpm lint`, `pnpm typecheck`, `pnpm prisma validate`, and `git diff --check` passed.
- Fresh 4R review completed.
- Judgment Day Round 2: both judges **APPROVED**.

### Rollback Boundary

Revert this single commit before rollout if needed. After migration/code rollout, use a forward-compatible fix for enum handling; do not destructively roll back persisted `throttled` values.