### PR TITLE
feat(bank-sessions): add durable expiry episode source

### DIFF
--- a/docs/fable5-scraper-completion-roadmap.md
+++ b/docs/fable5-scraper-completion-roadmap.md
@@ -115,17 +115,19 @@ Do **not** merge PR4.5 and PR4.6 into one PR to "solve" this — they touch diff
 
 1. **Purpose.** Give each expired-session episode a single stable identity (UUID) that persists from the expired transition until the session is restored, so locks and breaker attempts de-duplicate across runs, retries, and processes.
 2. **Exact scope.**
-   - `src/modules/bank-sessions/expired-event-store.ts`: `ExpiredEventStore` interface — `getOrAssign(bankCode): Promise<string>` (idempotent: returns existing id or assigns a fresh UUID) and `clear(bankCode)` (on restore). Redis-backed implementation (key `autologin:expired-event:{bankCode}`, no TTL or generous TTL — cleared explicitly on restore) + in-memory implementation for tests/dev.
-   - `src/modules/bank-sessions/index.ts`: extend `BankSessionCheckResult` handling in the monitor tick — on transition to `expired`, `getOrAssign`; on transition back to `active`, `clear` + audit `bank_session.restored`. Monitor keeps doing ONLY record/alert/schedule — absolutely no credential logic here (the monitor is not the trigger; design decision "ONE scrape-time trigger").
-3. **Out of scope.** The scrape-time trigger itself (PR4.5), any auto-login invocation, DB schema changes (Redis keys, not Prisma — see Open Questions Q2 for the fallback decision).
-4. **Files.** Create the store + tests; modify `src/modules/bank-sessions/index.ts` (monitor) and possibly `src/app/api/bank-sessions/defaults.ts` (wiring the store into the default monitor). Inspect: `src/modules/bank-auto-login-lock/defaults.ts` (reuse its fail-closed Redis client conventions — bounded retries, lazyConnect, no URL logging).
-5. **Contracts.** Event id format must satisfy the lock's `EVENT_ID_RE` (`^[a-zA-Z0-9-]{1,64}$`) — plain `crypto.randomUUID()` complies. `getOrAssign` must be atomic (`SET NX GET` or Lua) so two concurrent probes agree on one id.
-6. **Safety invariants.** Redis unavailable → `getOrAssign` rejects and callers treat it as "no event id" → auto-login skips to manual (fail closed); the id itself is non-sensitive but keys the lock — never accept caller-supplied ids from HTTP surfaces.
-7. **Test plan.** Idempotency (two `getOrAssign` → same id); restore clears; expired→active→expired yields a NEW id; concurrent assign race returns a single winner (fake Redis with scripted interleaving, following `redis-store.test.ts` shim style); monitor transition wiring: expired tick assigns + audits `bank_session.expired` with the eventId in metadata, restore tick clears + audits `bank_session.restored`.
-8. **Review risks.** Transition detection (the monitor currently just stores `lastResult` — the diff must define what counts as a transition when checks error or report `browser_unavailable`: unavailable is NOT restore and must NOT clear the id); cross-process agreement (worker and monitor may be different processes — Redis is the shared truth).
+   - `src/modules/bank-sessions/expiry-episodes.ts`: a durable per-bank PostgreSQL episode record with stable expiry/run identity, idempotent audit-delivery markers, and identity-safe close.
+   - No DB-to-queue publication, scrape-run claim, or consumer work belongs in this slice.
+3. **Out of scope.** The scrape-time trigger itself (PR4.5), any auto-login invocation, and producer startup. The API process remains dormant.
+4. **Files.** `src/modules/bank-sessions/index.ts`, `src/modules/persistence/prisma-bank-session-expiry-episode-repository.ts`, and PostgreSQL contract tests.
+5. **Contracts.** `getOrCreate` elects one durable expiry-episode creation winner; canonical expiry/restoration audits use deterministic episode IDs and are acknowledged durably before restoration close. The creation winner makes one best-effort expiry-notification attempt, while the identity-safe close winner makes one best-effort restoration-notification attempt. Notification delivery and retry are not durable or exactly-once.
+6. **Safety invariants.** Identity-safe close cannot remove a replacement episode. The episode identity is not caller-supplied.
+7. **Test plan.** In-memory replica and retry contracts plus PostgreSQL winner, audit acknowledgement, identity-safe close, and cleanup/repeatability coverage.
+8. **Review risks.** The monitor remains dormant until a dedicated lifecycle owner exists; publication is explicitly deferred. If PostgreSQL is unavailable and the process is lost before an episode is persisted, B1 cannot recover that observation; no publication or outbox mechanism is added to close this limit.
 9. **Dependencies.** None on 4.3/4.4 (parallelizable), but PR4.5 depends on it.
 10. **Estimate.** ~220–320 lines. Fits.
-11. **Acceptance.** Store contract green on in-memory + fake-Redis; monitor emits canonical session audit actions with stable ids; `browser_unavailable` does not clear an active event id.
+11. **Acceptance.** The completed B1 store contract is green on in-memory and PostgreSQL implementations; the monitor emits canonical session audit actions with stable ids; `browser_unavailable` does not clear an active event id. B2 publication/outbox/queue/consumer work remains explicitly deferred and unchecked.
+
+**B1 review-unit note.** B1 is an approved size exception because the durable episode schema, atomic election, canonical audit acknowledgement, identity-safe retry/close behavior, PostgreSQL isolation evidence, and dormant composition form one correctness boundary. Splitting those pieces would prevent a reviewer from validating the exactly-once audit guarantee end to end. Its actual impact is limited to durable audit source state; it does not publish, enqueue, claim, lease, or consume work. Notifications remain best-effort winner attempts. B2 owns every publication/outbox/queue/consumer concern and is excluded from B1.
 
 ### PR4.5 — Expired-session trigger wiring during bank sync runs
 
@@ -254,7 +256,7 @@ Three small slices that de-risk PR5 before the adapters land. Each ≤300 lines,
 
 ## 5. Global Risks
 
-1. **Redis as a correctness dependency.** Lock, and (per this plan) `expiredEventId`, live in Redis. The fail-closed posture (no Redis → manual-only) is correct but means a Redis outage silently disables session recovery — PR4.8b's `skipped`-rate visibility is the mitigation. Also: current lock keys are NOT Redis-Cluster-safe (documented in `defaults.ts` — `key` and `key:fence` need shared hash tags before any cluster migration).
+1. **Redis and PostgreSQL correctness boundaries.** Redis remains the auto-login lock backing store. Expiry episode identity and audit acknowledgement live in PostgreSQL, so monitor replicas do not rely on Redis or process memory for those facts. Current lock keys are NOT Redis-Cluster-safe (documented in `defaults.ts` — `key` and `key:fence` need shared hash tags before any cluster migration).
 2. **Design/code interface drift.** design.md's `BankAdapter` includes `portalConfig` + `createSessionChecker`; the shipped interface (`registry.ts`) has neither. PR4.7 must reconcile additively (optional field) — reviewers should reject any slice that rewrites the adapter interface broadly.
 3. **Monitor vs worker process split.** The session monitor and the ingestion worker may run in different processes; any state they share (event ids, breaker views) must go through Redis/DB, never module-level memory. This bit PR4.6/4.5 hardest.
 4. **Test overclaim recurrence.** PR4.2's 4R flagged partially no-op static tests. Every PR4.x reviewer should spot-check that new tests can fail.
@@ -267,7 +269,7 @@ Three small slices that de-risk PR5 before the adapters land. Each ≤300 lines,
 | # | Question | Options | Recommendation |
 |---|---|---|---|
 | Q1 | PR4.5/PR4.6 order | (a) reorder 4.6 first; (b) 4.5 inert-first | (a) — see §3 |
-| Q2 | `expiredEventId` persistence | (a) Redis key per bank; (b) Prisma column/table | (a): Redis already carries the lock and fails closed; a DB column adds a migration for state that is inherently ephemeral. Revisit if audit needs long-term event history (audit metadata already records ids). |
+| Q2 | `expiredEventId` persistence | (a) Redis key per bank; (b) Prisma episode table | Resolved as (b): PostgreSQL episode rows preserve identity and audit delivery acknowledgement. |
 | Q3 | Lock TTL default (5 min) + renewal cadence vs real login duration | keep 5 min / renew at half-life; or raise default | Keep 5 min, renew at ~50% TTL from the state machine; measure p95 login latency via PR4.8b before changing. |
 | Q4 | Fencing on Prisma breaker writes — models have no `fencingToken` column | (a) optimistic concurrency (conditional `updateMany` on expected count/window) + fencing token in audit metadata; (b) add column | (a): matches "state writes carry fencingToken/CAS" intent without schema churn; document in PR4.3. |
 | Q5 | Breaker-reset success copy | "Interruptor restablecido" vs product-approved alternative | Confirm with product before PR4.8a; keep fixed-string either way. |

--- a/docs/runbooks/bank-session.md
+++ b/docs/runbooks/bank-session.md
@@ -94,7 +94,9 @@ Because the profile is persistent, cookies survive browser restarts. After the i
 
 ## What the session monitor does
 
-When `RD_SYNC_SESSION_MONITOR=enabled`, RD-Sync polls the bank portal dashboard at the configured interval (default every 5 minutes). It detects three states:
+The API-process monitor is deliberately dormant. `RD_SYNC_SESSION_MONITOR=enabled` does not start polling; a dedicated always-on producer bootstrap is required before background monitoring can be activated. The status endpoint still performs a live, read-only session check and reports these three states:
+
+The dormant B1 implementation stores one durable expiry episode per bank and guarantees canonical expiry and restoration audit records exactly once when a future lifecycle owner activates it. The creation winner makes one best-effort expiry-notification attempt, and the identity-safe close winner makes one best-effort restoration-notification attempt. Notification delivery and retry are not durable and have no exactly-once guarantee. If PostgreSQL is unavailable and the process is lost before an episode is persisted, B1 cannot recover that observation. It has no publication, outbox, queue, or consumer path.
 
 | Status | Meaning |
 |--------|---------|
@@ -102,7 +104,7 @@ When `RD_SYNC_SESSION_MONITOR=enabled`, RD-Sync polls the bank portal dashboard 
 | `expired` | The portal redirected away from the dashboard, or the dashboard did not render |
 | `browser_unavailable` | CDP could not attach (Brave is not running or the port is wrong) |
 
-Alerts are sent only on **transitions**:
+When a future lifecycle owner activates the monitor, the durable winner may attempt alerts only on **transitions**:
 - `active → expired` → attention required email
 - `active → browser_unavailable` → attention required email
 - `expired → active` → recovery email
@@ -135,14 +137,14 @@ Response shape:
     "safeSummary": "Bank session is active"
   },
   "monitor": {
-    "enabled": true,
-    "lastResult": { ... }
+    "enabled": false,
+    "lastResult": null
   }
 }
 ```
 
 `session` reflects a **live check** performed at request time.
-`monitor.lastResult` reflects the most recent background check (null if the monitor has not run yet).
+`monitor.lastResult` is `null` while the API-process monitor remains deliberately dormant.
 
 ## Environment variables
 
@@ -150,7 +152,7 @@ Response shape:
 |----------|---------|-------------|
 | `RD_SYNC_SCRAPER` | — | Set to `popular-cdp` to enable the CDP-backed scraper and session checker |
 | `RD_SYNC_CDP_URL` | `http://127.0.0.1:9222` | Global CDP endpoint for the running Brave session (bind to 127.0.0.1 only). Single-bank-only fallback — with 2+ registered banks each must set a distinct `RD_SYNC_BANK_<BANK>_CDP_URL` |
-| `RD_SYNC_SESSION_MONITOR` | — | Set to `enabled` to start the background session monitor |
+| `RD_SYNC_SESSION_MONITOR` | — | Reserved for a future dedicated monitor bootstrap; it does not activate API-process polling |
 | `RD_SYNC_SESSION_CHECK_INTERVAL_MS` | `300000` (5 min) | Poll interval in milliseconds; minimum 60000 (1 min) |
 | `RD_SYNC_ALERT_SMTP_URL` | — | SMTP URL for alert emails; falls back to console.warn if absent |
 | `RD_SYNC_ADMIN_EMAIL` | — | Recipient address for alert emails |

--- a/openspec/changes/multi-bank-auto-login/tasks.md
+++ b/openspec/changes/multi-bank-auto-login/tasks.md
@@ -96,11 +96,30 @@ Gate: full gates + FRESH 4R review + Judgment Day before merge; PR3B1 <=400 line
 - [x] 4.3 Create `src/modules/bank-auto-login-config/` + `src/modules/bank-adapter-config/`: repos + conservative breaker policy (3 failures/30min->open, NO half-open, manual admin reset only clears window, alert on open + <=every 30min).
 - [x] 4.4 Create `src/worker/scraper/auto-login.ts`: `BankAutoLoginStrategy` state machine + `LoginMutationGuard` (HTTPS + exact origin + login-path allowlist, re-check before fill AND submit, `assertCompatiblePreSubmit`).
 - [ ] 4.5 Wire scrape-time canonical trigger: expired->assert `adapter.bankCode===credential.bankCode`->`assertCdpLoopback`->acquire lock (or skip->manual)->ensureBrowser (or throttled)->login->detect(dashboard|mfa|unknown|redirect|incompatible)->success|needs_admin_action->owner release.
-- [ ] 4.6 Modify `src/modules/bank-sessions/index.ts`: `expired` assigns/retains `expiredEventId` (UUID until restore), records/alerts/schedules only (NO credential submission).
+- [x] 4.6 B1 completed: durable `BankSessionExpiryEpisode` identity, atomic winner election, canonical exactly-once expiry/restoration audits, identity-safe close/retry, and a production-dormant monitor. Winner notifications are best-effort attempts only, not durable or exactly-once delivery.
+- [ ] 4.6 B2 deferred: publication/outbox state, queue handoff, consumer revalidation, and all related concurrency proof remain unchecked in Slice B2; no B2 code belongs in this child.
 - [ ] 4.7 Enable Popular: register `createAutoLoginStrategy`, set `autoLoginEnabled=true` (gated); Popular portal-drift fixture (incompatible pre-submit asserts NO fill/submit + post-submit unknown).
 - [ ] 4.8 Admin endpoints: `PATCH .../auto-login` ("Auto-login desactivado"), `POST .../reset-breaker`, `PATCH .../adapter` ("Adaptador desactivado"); audit `bank_autologin.*`/`bank_breaker.*`/`bank_killswitch.*`/`bank_adapter.*`/`bank_credential.decrypt_use`; extend `bank-metrics.ts` with auto-login failure rate/latency/launch-failures/backlog + CONCRETE alert thresholds.
 - [ ] 4.9 Tests (TDD): lock acquire/owner-only-release/renew/stale-release-fails/fencing-CAS; distinct expired events distinct locks; concurrent same-event->only holder submits; breaker open (no half-open)/manual-reset/alert-rate-limit; LoginMutationGuard HTTPS/origin/allowlist/redirect-reject/incompatible-pre-submit; MFA stop; read-only block holds off login page; kill-switch disables auto-login not scraping; adapter toggle disables scraping safely; throttled run.
 - Gate: full gates + FRESH 4R review + Judgment Day before merge; <=400 lines.
+
+## Slice B1: Durable expiry episode source (current child PR)
+
+- [x] B1.1 Persist one `BankSessionExpiryEpisode` per bank with `getOrCreate` winner election, durable audit acknowledgement, and identity-safe close.
+- [x] B1.2 Emit exactly one deterministic expiry audit and one deterministic restoration audit. The creation winner makes one best-effort expiry-notification attempt; the identity-safe close winner makes one best-effort restoration-notification attempt. Notification delivery and retry are neither durable nor exactly-once. Keep the monitor production-dormant. If PostgreSQL is unavailable and the process is lost before persistence, B1 cannot recover that observation.
+- [x] B1.3 Remove all DB-to-queue publication, scrape-run claim/lease, consumer payload, and publication-test behavior from the active slice.
+- [x] B1.4 Isolate the PostgreSQL expiry-episode contract per test and run the complete contract file twice.
+- Gate: full gates; approved `size:exception` for this atomic B1 child because durable identity, election, audit acknowledgement, retry/close safety, PostgreSQL contracts, and documentation must be reviewed together. B2 publication/outbox/queue/consumer work is explicitly excluded and remains unchecked; target PR #35 head `feature/multi-bank-auto-login-pr4l-throttled-deferred`.
+
+## Slice B2: Deferred durable expiry publication (future child PR, ≤400 changed lines)
+
+- [ ] B2.1 Add the outbox state machine `pending -> publishing(token) -> published/cancelled` with compare-and-set transitions.
+- [ ] B2.2 Add deterministic real-PostgreSQL two-connection tests that hold one transaction mid-flight and force both interleavings: restoration wins so the publisher cannot enqueue; publication wins so restoration waits then closes.
+- [ ] B2.3 Require consumer revalidation: each job carries `bankCode + expiredEventId + token`; the consumer rereads PostgreSQL and no-ops with audit `skipped` when the episode is closed/restored. PostgreSQL is authority; the queue is a hint.
+- [ ] B2.4 Deduplicate jobs deterministically by episode `runId`.
+- [ ] B2.5 Prove two-replica disabled/config-missing behavior: one episode, one expiry audit, and one restoration audit.
+- [ ] B2.6 Run fresh 4R and Judgment Day before review.
+- Gate: ≤400 changed lines; no B2 implementation in B1.
 
 ## PR5: Banreservas/BHD read-only adapters + portal drift fixtures (NO auto-login)
 

--- a/prisma/migrations/20260712120000_add_bank_session_expiry_episodes/migration.sql
+++ b/prisma/migrations/20260712120000_add_bank_session_expiry_episodes/migration.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "BankSessionExpiryEpisode" (
+  "bankCode" TEXT NOT NULL,
+  "expiredEventId" TEXT NOT NULL,
+  "runId" TEXT NOT NULL,
+  "expiredAuditDeliveredAt" TIMESTAMP(3),
+  "restoredAuditDeliveredAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "BankSessionExpiryEpisode_pkey" PRIMARY KEY ("bankCode")
+);
+
+CREATE UNIQUE INDEX "BankSessionExpiryEpisode_expiredEventId_key"
+  ON "BankSessionExpiryEpisode"("expiredEventId");
+CREATE UNIQUE INDEX "BankSessionExpiryEpisode_runId_key"
+  ON "BankSessionExpiryEpisode"("runId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -167,6 +167,18 @@ model ScrapeRun {
   @@index([status])
 }
 
+// One unresolved expiry episode per bank code. It gives monitor replicas and
+// restarts a stable event/run identity without ever storing credential material.
+model BankSessionExpiryEpisode {
+  bankCode                     String   @id
+  expiredEventId               String   @unique
+  runId                        String   @unique
+  expiredAuditDeliveredAt      DateTime?
+  restoredAuditDeliveredAt     DateTime?
+  createdAt                    DateTime @default(now())
+  updatedAt                    DateTime @updatedAt
+}
+
 // Change 4: EncryptedSessionRef model DROPPED entirely.
 
 // Change 3: Remove actor User relation from AuditEvent; actorId/actorRole remain as plain String?.

--- a/src/app/api/bank-sessions/defaults.test.ts
+++ b/src/app/api/bank-sessions/defaults.test.ts
@@ -1,13 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-
-// ---------------------------------------------------------------------------
-// resolveDefaultSessionChecker env resolution
-//
-// We cannot import defaults.ts directly because it reads env at module-load
-// time. We test the resolution functions by calling them after setting env vars
-// in each test, then importing the module freshly via dynamic import with cache
-// busting (resetModules). Each test group calls the isolated factory directly.
-// ---------------------------------------------------------------------------
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 const BANK_SESSIONS_MODULE = "../../../modules/bank-sessions";
 
@@ -22,49 +13,38 @@ describe("resolveDefaultSessionChecker — env branches", () => {
 
   it("returns browser_unavailable stub when RD_SYNC_SCRAPER is not set", async () => {
     delete process.env.RD_SYNC_SCRAPER;
-
-    // Import the factory fresh (but it reads env at call time — we call inline)
     const { resolveDefaultSessionChecker } = await import("./defaults");
-    const checker = resolveDefaultSessionChecker();
-    const result = await checker.check();
 
-    expect(result.status).toBe("browser_unavailable");
-    expect(result.safeSummary).toBe("Bank browser session is not available");
+    await expect(resolveDefaultSessionChecker().check()).resolves.toMatchObject({
+      status: "browser_unavailable",
+      safeSummary: "Bank browser session is not available",
+    });
   });
 
-  // Real behavior test (not just a seam): the per-bank Popular CDP URL must win
-  // over the global one, and that exact URL must reach createCdpSessionChecker.
   it("constructs the CDP checker with the per-bank URL when both per-bank and global are set", async () => {
     process.env.RD_SYNC_SCRAPER = "popular-cdp";
     process.env.RD_SYNC_BANK_POPULAR_CDP_URL = "http://127.0.0.1:9333";
     process.env.RD_SYNC_CDP_URL = "http://127.0.0.1:9222";
-
     const createSpy = vi.fn(() => ({ check: vi.fn() }));
     vi.doMock(BANK_SESSIONS_MODULE, async (importOriginal) => ({
-      ...(await importOriginal<
-        typeof import("../../../modules/bank-sessions")
-      >()),
+      ...(await importOriginal<typeof import("../../../modules/bank-sessions")>()),
       createCdpSessionChecker: createSpy,
     }));
     vi.resetModules();
 
     const { resolveDefaultSessionChecker } = await import("./defaults");
-    createSpy.mockClear(); // drop the module-load-time construction, if any
+    createSpy.mockClear();
     resolveDefaultSessionChecker();
 
-    expect(createSpy).toHaveBeenCalledTimes(1);
     expect(createSpy).toHaveBeenCalledWith({ cdpUrl: "http://127.0.0.1:9333" });
   });
 
   it("falls back to the global CDP URL when only the global is set", async () => {
     process.env.RD_SYNC_SCRAPER = "popular-cdp";
     process.env.RD_SYNC_CDP_URL = "http://127.0.0.1:9222";
-
     const createSpy = vi.fn(() => ({ check: vi.fn() }));
     vi.doMock(BANK_SESSIONS_MODULE, async (importOriginal) => ({
-      ...(await importOriginal<
-        typeof import("../../../modules/bank-sessions")
-      >()),
+      ...(await importOriginal<typeof import("../../../modules/bank-sessions")>()),
       createCdpSessionChecker: createSpy,
     }));
     vi.resetModules();
@@ -77,55 +57,16 @@ describe("resolveDefaultSessionChecker — env branches", () => {
   });
 });
 
-describe("resolveDefaultSessionMonitor — env branches", () => {
+describe("resolveDefaultSessionMonitor — dormant production seam", () => {
   afterEach(() => {
     delete process.env.RD_SYNC_SESSION_MONITOR;
     delete process.env.RD_SYNC_SESSION_CHECK_INTERVAL_MS;
   });
 
-  it("returns null when RD_SYNC_SESSION_MONITOR is not set", async () => {
-    delete process.env.RD_SYNC_SESSION_MONITOR;
-
-    const { resolveDefaultSessionMonitor } = await import("./defaults");
-    const monitor = resolveDefaultSessionMonitor();
-
-    expect(monitor).toBeNull();
-  });
-
-  it("returns null when RD_SYNC_SESSION_MONITOR=disabled", async () => {
-    process.env.RD_SYNC_SESSION_MONITOR = "disabled";
-
-    const { resolveDefaultSessionMonitor } = await import("./defaults");
-    const monitor = resolveDefaultSessionMonitor();
-
-    expect(monitor).toBeNull();
-  });
-
-  it("returns a monitor with start/stop/tick/lastResult when RD_SYNC_SESSION_MONITOR=enabled", async () => {
+  it("remains dormant even when the legacy monitor flag is enabled", async () => {
     process.env.RD_SYNC_SESSION_MONITOR = "enabled";
-
     const { resolveDefaultSessionMonitor } = await import("./defaults");
-    const monitor = resolveDefaultSessionMonitor();
 
-    expect(monitor).not.toBeNull();
-    expect(typeof monitor?.start).toBe("function");
-    expect(typeof monitor?.stop).toBe("function");
-    expect(typeof monitor?.tick).toBe("function");
-    expect(typeof monitor?.lastResult).toBe("function");
-  });
-});
-
-describe("startDefaultSessionMonitorIfEnabled — does not throw", () => {
-  beforeEach(() => {
-    delete process.env.RD_SYNC_SESSION_MONITOR;
-  });
-
-  afterEach(() => {
-    delete process.env.RD_SYNC_SESSION_MONITOR;
-  });
-
-  it("does not throw when monitor is disabled", async () => {
-    const { startDefaultSessionMonitorIfEnabled } = await import("./defaults");
-    expect(() => startDefaultSessionMonitorIfEnabled()).not.toThrow();
+    expect(resolveDefaultSessionMonitor()).toBeNull();
   });
 });

--- a/src/app/api/bank-sessions/defaults.ts
+++ b/src/app/api/bank-sessions/defaults.ts
@@ -8,21 +8,17 @@
  * Relevant env vars:
  *   RD_SYNC_SCRAPER            — "popular-cdp" enables the CDP-backed checker
  *   RD_SYNC_BANK_POPULAR_CDP_URL — Popular CDP endpoint (fallback RD_SYNC_CDP_URL)
- *   RD_SYNC_SESSION_MONITOR    — "enabled" activates the background monitor
  *   RD_SYNC_SESSION_CHECK_INTERVAL_MS — poll interval in ms (default 300000, min 60000)
  */
 
 import {
   createCdpSessionChecker,
-  createBankSessionMonitor,
   type CdpSessionChecker,
   type BankSessionCheckResult,
   type BankSessionMonitor,
 } from "../../../modules/bank-sessions";
 import { popularBankCode } from "../../../modules/bank-adapters/popular";
 import { resolveBankBrowserEnv } from "../../../worker/scraper/browser-runtime";
-import { resolveDefaultAlertSink } from "../../../worker/alerts/email-alert-sink";
-import { defaultAuditSink } from "../audit/defaults";
 
 // ---------------------------------------------------------------------------
 // resolveDefaultSessionChecker
@@ -64,68 +60,26 @@ export function resolveDefaultSessionChecker(): CdpSessionChecker {
 // resolveDefaultSessionMonitor
 // ---------------------------------------------------------------------------
 
-const MIN_INTERVAL_MS = 60_000;
-const DEFAULT_INTERVAL_MS = 300_000;
-
-function resolveIntervalMs(): number {
-  const raw = process.env.RD_SYNC_SESSION_CHECK_INTERVAL_MS;
-  if (!raw) return DEFAULT_INTERVAL_MS;
-  const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_INTERVAL_MS;
-  return Math.max(parsed, MIN_INTERVAL_MS);
-}
-
 /**
- * Returns a bank session monitor wired with the default checker, alert sink,
- * and audit sink — or null when RD_SYNC_SESSION_MONITOR !== "enabled".
+ * The API process has no always-on lifecycle owner. Keeping this producer
+ * dormant prevents status-route traffic from becoming production scheduling.
+ * A dedicated worker bootstrap must own activation before this can be enabled.
  */
 export function resolveDefaultSessionMonitor(): BankSessionMonitor | null {
-  if (process.env.RD_SYNC_SESSION_MONITOR !== "enabled") {
-    return null;
-  }
-
-  return createBankSessionMonitor({
-    check: () => defaultSessionChecker.check(),
-    alertSink: resolveDefaultAlertSink(),
-    auditSink: defaultAuditSink,
-    intervalMs: resolveIntervalMs(),
-  });
+  return null;
 }
 
 // ---------------------------------------------------------------------------
-// globalThis anchors
-//
-// Both the checker and the monitor are anchored on globalThis so every Next.js
-// module graph (RSC page, API route handler) shares a single instance.
-// Anchoring the monitor prevents two separate setInterval timers being started
-// when Turbopack creates multiple module graphs in dev.
+// globalThis checker anchor
 // ---------------------------------------------------------------------------
 
 const globalRegistry = globalThis as typeof globalThis & {
   __rdSyncSessionChecker?: CdpSessionChecker;
-  __rdSyncSessionMonitor?: BankSessionMonitor | null;
 };
 
 const defaultSessionChecker =
   (globalRegistry.__rdSyncSessionChecker ??= resolveDefaultSessionChecker());
 
-// Use a sentinel to distinguish "not yet initialised" from "null (disabled)".
-if (!("__rdSyncSessionMonitor" in globalRegistry)) {
-  globalRegistry.__rdSyncSessionMonitor = resolveDefaultSessionMonitor();
-}
-const defaultSessionMonitor = globalRegistry.__rdSyncSessionMonitor ?? null;
-
-// ---------------------------------------------------------------------------
-// startDefaultSessionMonitorIfEnabled
-//
-// Call from the route module to start the background monitor on first import.
-// Idempotent — BankSessionMonitor.start() is already idempotent (internal
-// handle guard), and the monitor itself is now a global singleton so multiple
-// call sites all reach the same instance.
-// ---------------------------------------------------------------------------
-
-export function startDefaultSessionMonitorIfEnabled(): void {
-  defaultSessionMonitor?.start();
-}
+const defaultSessionMonitor = resolveDefaultSessionMonitor();
 
 export { defaultSessionChecker, defaultSessionMonitor };

--- a/src/app/api/bank-sessions/status/route.ts
+++ b/src/app/api/bank-sessions/status/route.ts
@@ -3,11 +3,7 @@ import type { CdpSessionChecker, BankSessionCheckResult, BankSessionMonitor } fr
 import {
   defaultSessionChecker,
   defaultSessionMonitor,
-  startDefaultSessionMonitorIfEnabled,
 } from "../defaults";
-
-// Start the background monitor when this module is first imported.
-startDefaultSessionMonitorIfEnabled();
 
 // ---------------------------------------------------------------------------
 // Handler factory (injectable dependencies for testing)

--- a/src/app/api/defaults-global-sharing.test.ts
+++ b/src/app/api/defaults-global-sharing.test.ts
@@ -272,36 +272,19 @@ describe("defaultSessionMonitor — globalThis sharing and single-start guard", 
     expect(monitorB).toBeNull();
   });
 
-  it("startDefaultSessionMonitorIfEnabled is idempotent across two module graphs (no double timer)", async () => {
+  it("keeps the monitor dormant across module graphs even when the legacy env flag is enabled", async () => {
     process.env.RD_SYNC_SESSION_MONITOR = "enabled";
 
-    // We cannot inject the scheduler into the module-level singleton created at
-    // import time, so we test the guard via the globalThis anchor: a second
-    // import after resetModules must return THE SAME monitor instance (already
-    // started), meaning start() is a no-op on the second call.
-
-    // Import graph A — monitor instance is created and stored on globalThis
     const { defaultSessionMonitor: monitorA } =
       await import("./bank-sessions/defaults");
 
-    expect(monitorA).not.toBeNull();
-
-    // Manually start once using the real start() — which uses setInterval
-    // We'll observe idempotency by calling start twice on the same instance
-    // (the BankSessionMonitor.start() is already idempotent via handle guard)
-    monitorA?.start();
-    monitorA?.start(); // second call must be a no-op
-
     vi.resetModules();
 
-    // Graph B must reuse the same monitor from globalThis
     const { defaultSessionMonitor: monitorB } =
       await import("./bank-sessions/defaults");
 
     expect(monitorB).toBe(monitorA);
-
-    // Clean up the timer started above
-    monitorA?.stop();
+    expect(monitorA).toBeNull();
   });
 });
 

--- a/src/modules/audit/index.ts
+++ b/src/modules/audit/index.ts
@@ -1,4 +1,6 @@
 export interface AuditEventInput {
+  /** Optional stable delivery key for idempotent operational events. */
+  id?: string;
   actorId: string | null;
   actorRole: string | null;
   action: string;
@@ -7,7 +9,7 @@ export interface AuditEventInput {
   metadata?: Record<string, unknown> | null;
 }
 
-export interface AuditEvent extends Required<Omit<AuditEventInput, "metadata" | "targetId">> {
+export interface AuditEvent extends Required<Omit<AuditEventInput, "id" | "metadata" | "targetId">> {
   id: string;
   targetId: string | null;
   metadata: Record<string, unknown> | null;
@@ -31,7 +33,7 @@ const sensitiveKeys = new Set([
 
 export function createAuditEvent(input: AuditEventInput): AuditEvent {
   return {
-    id: crypto.randomUUID(),
+    id: input.id ?? crypto.randomUUID(),
     actorId: input.actorId,
     actorRole: input.actorRole,
     action: input.action,
@@ -60,8 +62,11 @@ export interface AuditSink {
 
 export class InMemoryAuditSink implements AuditSink {
   private readonly events: AuditEvent[] = [];
+  private readonly eventIds = new Set<string>();
 
   async record(event: AuditEvent): Promise<void> {
+    if (this.eventIds.has(event.id)) return;
+    this.eventIds.add(event.id);
     this.events.push(event);
   }
 

--- a/src/modules/bank-sessions/expiry-episodes.test.ts
+++ b/src/modules/bank-sessions/expiry-episodes.test.ts
@@ -1,0 +1,320 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { InMemoryAuditSink, type AuditSink } from "../audit";
+import {
+  InMemoryBankSessionExpiryEpisodeRepository,
+  type BankSessionExpiryEpisodeRepository,
+} from "./expiry-episodes";
+import { createBankSessionMonitor, type BankSessionMonitorDeps } from "./index";
+
+function createMonitor(
+  episodes: BankSessionExpiryEpisodeRepository,
+  statuses: Array<"expired" | "active">,
+  alerts: string[],
+  auditSink: Pick<AuditSink, "record"> = new InMemoryAuditSink(),
+  createExpiredEventId: () => string,
+) {
+  let index = 0;
+  const deps: BankSessionMonitorDeps = {
+    check: async () => {
+      const status = statuses[index] ?? statuses[statuses.length - 1] ?? "active";
+      index += 1;
+      return {
+        status,
+        checkedAt: "2026-07-12T00:00:00.000Z",
+        safeSummary: status === "expired" ? "Bank session expired" : "Bank session is active",
+      };
+    },
+    alertSink: { notifySessionAttention: async ({ status }) => { alerts.push(status); } },
+    auditSink,
+    intervalMs: 1_000,
+    monitorMode: {
+      mode: "expiry_events",
+      bankCode: "popular",
+      episodes,
+      createExpiredEventId,
+    },
+  };
+  return createBankSessionMonitor(deps);
+}
+
+function auditIdentities(audit: InMemoryAuditSink) {
+  return audit.list().then((events) => events
+    .map(({ id, action }) => ({ id, action }))
+    .sort((left, right) => left.id.localeCompare(right.id)));
+}
+
+describe("Bank session expiry episodes", () => {
+  it("fails closed during a two-replica durable-election outage, then elects one recovered winner", async () => {
+    const episodes = new InMemoryBankSessionExpiryEpisodeRepository();
+    const alerts: string[] = [];
+    const audit = new InMemoryAuditSink();
+    const originalGetOrCreate = episodes.getOrCreate.bind(episodes);
+    let unavailableCalls = 2;
+    vi.spyOn(episodes, "getOrCreate").mockImplementation(async (input) => {
+      if (unavailableCalls > 0) {
+        unavailableCalls -= 1;
+        throw new Error("durable repository unavailable");
+      }
+      return originalGetOrCreate(input);
+    });
+    const first = createMonitor(episodes, ["expired", "expired", "active"], alerts, audit, () => "candidate-a");
+    const second = createMonitor(episodes, ["expired", "expired", "active"], alerts, audit, () => "candidate-b");
+
+    await Promise.all([first.tick(), second.tick()]);
+    expect(alerts).toEqual([]);
+    await expect(auditIdentities(audit)).resolves.toEqual([]);
+    await expect(episodes.findByBankCode("popular")).resolves.toBeNull();
+
+    await Promise.all([first.tick(), second.tick()]);
+    const winner = await episodes.findByBankCode("popular");
+    expect(winner).toMatchObject({
+      expiredEventId: expect.stringMatching(/^candidate-[ab]$/),
+      runId: expect.stringMatching(/^popular-expiry-candidate-[ab]$/),
+    });
+    expect(alerts).toEqual(["expired"]);
+
+    await Promise.all([first.tick(), second.tick()]);
+
+    expect(alerts).toEqual(["expired", "active"]);
+    expect(await auditIdentities(audit)).toEqual([
+      { id: `bank-session-bank_session.expired:popular:${winner?.expiredEventId}`, action: "bank_session.expired" },
+      { id: `bank-session-bank_session.restored:popular:${winner?.expiredEventId}`, action: "bank_session.restored" },
+    ]);
+    await expect(episodes.findByBankCode("popular")).resolves.toBeNull();
+  });
+
+  it("retains one local candidate across an outage until active recovery can durably elect and close it", async () => {
+    const episodes = new InMemoryBankSessionExpiryEpisodeRepository();
+    const audit = new InMemoryAuditSink();
+    const alerts: string[] = [];
+    const originalGetOrCreate = episodes.getOrCreate.bind(episodes);
+    const attemptedCandidates: Array<{ bankCode: string; expiredEventId: string; runId: string }> = [];
+    let persistenceAvailable = false;
+    vi.spyOn(episodes, "getOrCreate").mockImplementation(async (input) => {
+      attemptedCandidates.push(input);
+      if (!persistenceAvailable) throw new Error("durable repository unavailable");
+      return originalGetOrCreate(input);
+    });
+    const monitor = createMonitor(
+      episodes,
+      ["active", "expired", "active", "active"],
+      alerts,
+      audit,
+      () => "event-outage-recovery",
+    );
+
+    await monitor.tick();
+    await monitor.tick();
+    await monitor.tick();
+
+    expect(attemptedCandidates).toEqual([
+      { bankCode: "popular", expiredEventId: "event-outage-recovery", runId: "popular-expiry-event-outage-recovery" },
+      { bankCode: "popular", expiredEventId: "event-outage-recovery", runId: "popular-expiry-event-outage-recovery" },
+    ]);
+    expect(alerts).toEqual([]);
+    expect(await auditIdentities(audit)).toEqual([]);
+    await expect(episodes.findByBankCode("popular")).resolves.toBeNull();
+
+    persistenceAvailable = true;
+    await monitor.tick();
+
+    expect(attemptedCandidates).toEqual([
+      { bankCode: "popular", expiredEventId: "event-outage-recovery", runId: "popular-expiry-event-outage-recovery" },
+      { bankCode: "popular", expiredEventId: "event-outage-recovery", runId: "popular-expiry-event-outage-recovery" },
+      { bankCode: "popular", expiredEventId: "event-outage-recovery", runId: "popular-expiry-event-outage-recovery" },
+    ]);
+    expect(alerts).toEqual(["expired", "active"]);
+    expect(await auditIdentities(audit)).toEqual([
+      { id: "bank-session-bank_session.expired:popular:event-outage-recovery", action: "bank_session.expired" },
+      { id: "bank-session-bank_session.restored:popular:event-outage-recovery", action: "bank_session.restored" },
+    ]);
+    await expect(episodes.findByBankCode("popular")).resolves.toBeNull();
+  });
+
+  it("retries a failed expiry audit with its deterministic ID after one independent best-effort winner notification", async () => {
+    const episodes = new InMemoryBankSessionExpiryEpisodeRepository();
+    const audit = new InMemoryAuditSink();
+    let failFirstRecord = true;
+    const failingAudit: Pick<AuditSink, "record"> = {
+      record: async (event) => {
+        if (failFirstRecord) {
+          failFirstRecord = false;
+          throw new Error("audit unavailable");
+        }
+        await audit.record(event);
+      },
+    };
+    const alerts: string[] = [];
+    const monitor = createMonitor(episodes, ["expired", "expired"], alerts, failingAudit, () => "event-audit-retry");
+
+    await monitor.tick();
+    await monitor.tick();
+
+    expect(alerts).toEqual(["expired"]);
+    expect(await auditIdentities(audit)).toEqual([
+      { id: "bank-session-bank_session.expired:popular:event-audit-retry", action: "bank_session.expired" },
+    ]);
+    await expect(episodes.findByBankCode("popular")).resolves.toMatchObject({
+      expiredEventId: "event-audit-retry",
+      expiredAuditDelivered: true,
+    });
+  });
+
+  it("does not restore or close an unacknowledged expiry episode observed after restart", async () => {
+    const episodes = new InMemoryBankSessionExpiryEpisodeRepository();
+    const episode = (await episodes.getOrCreate({
+      bankCode: "popular", expiredEventId: "event-restart-unacknowledged", runId: "popular-expiry-event-restart-unacknowledged",
+    })).episode;
+    const audit = new InMemoryAuditSink();
+    let failExpiryOnce = true;
+    const failingAudit: Pick<AuditSink, "record"> = {
+      record: async (event) => {
+        if (event.action === "bank_session.expired" && failExpiryOnce) {
+          failExpiryOnce = false;
+          throw new Error("expiry audit unavailable");
+        }
+        await audit.record(event);
+      },
+    };
+    const alerts: string[] = [];
+    const restartedMonitor = createMonitor(episodes, ["active", "active"], alerts, failingAudit, () => "unused-candidate");
+
+    await restartedMonitor.tick();
+    await expect(episodes.findByBankCode("popular")).resolves.toEqual(episode);
+    expect(alerts).toEqual([]);
+    expect(await auditIdentities(audit)).toEqual([]);
+
+    await restartedMonitor.tick();
+    expect(await auditIdentities(audit)).toEqual([
+      { id: "bank-session-bank_session.expired:popular:event-restart-unacknowledged", action: "bank_session.expired" },
+      { id: "bank-session-bank_session.restored:popular:event-restart-unacknowledged", action: "bank_session.restored" },
+    ]);
+    expect(alerts).toEqual(["active"]);
+    await expect(episodes.findByBankCode("popular")).resolves.toBeNull();
+  });
+
+  it("retries a failed restoration audit before closing or attempting its notification", async () => {
+    const episodes = new InMemoryBankSessionExpiryEpisodeRepository();
+    const audit = new InMemoryAuditSink();
+    let failRestorationOnce = true;
+    const failingAudit: Pick<AuditSink, "record"> = {
+      record: async (event) => {
+        if (event.action === "bank_session.restored" && failRestorationOnce) {
+          failRestorationOnce = false;
+          throw new Error("restoration audit unavailable");
+        }
+        await audit.record(event);
+      },
+    };
+    const alerts: string[] = [];
+    const monitor = createMonitor(episodes, ["expired", "active", "active"], alerts, failingAudit, () => "event-restoration-retry");
+
+    await monitor.tick();
+    await monitor.tick();
+    await expect(episodes.findByBankCode("popular")).resolves.toMatchObject({
+      expiredEventId: "event-restoration-retry",
+      expiredAuditDelivered: true,
+      restoredAuditDelivered: false,
+    });
+    expect(alerts).toEqual(["expired"]);
+
+    await monitor.tick();
+    expect(await auditIdentities(audit)).toEqual([
+      { id: "bank-session-bank_session.expired:popular:event-restoration-retry", action: "bank_session.expired" },
+      { id: "bank-session-bank_session.restored:popular:event-restoration-retry", action: "bank_session.restored" },
+    ]);
+    expect(alerts).toEqual(["expired", "active"]);
+    await expect(episodes.findByBankCode("popular")).resolves.toBeNull();
+  });
+
+  it("retries an active close and lets only the closing winner attempt the best-effort restoration notification", async () => {
+    const episodes = new InMemoryBankSessionExpiryEpisodeRepository();
+    const audit = new InMemoryAuditSink();
+    const alerts: string[] = [];
+    vi.spyOn(episodes, "close").mockRejectedValueOnce(new Error("close unavailable"));
+    const monitor = createMonitor(episodes, ["expired", "active", "active"], alerts, audit, () => "event-close-retry");
+
+    await monitor.tick();
+    await monitor.tick();
+    await expect(episodes.findByBankCode("popular")).resolves.toMatchObject({ expiredEventId: "event-close-retry" });
+    await monitor.tick();
+
+    expect(alerts).toEqual(["expired", "active"]);
+    expect(await auditIdentities(audit)).toEqual([
+      { id: "bank-session-bank_session.expired:popular:event-close-retry", action: "bank_session.expired" },
+      { id: "bank-session-bank_session.restored:popular:event-close-retry", action: "bank_session.restored" },
+    ]);
+    await expect(episodes.findByBankCode("popular")).resolves.toBeNull();
+  });
+
+  it("lets a restarted active monitor close the durable episode with canonical audits", async () => {
+    const episodes = new InMemoryBankSessionExpiryEpisodeRepository();
+    const audit = new InMemoryAuditSink();
+    const alerts: string[] = [];
+    const expiredMonitor = createMonitor(episodes, ["expired"], alerts, audit, () => "event-restart");
+
+    await expiredMonitor.tick();
+    const restartedActiveMonitor = createMonitor(episodes, ["active"], alerts, audit, () => "unused-candidate");
+    await restartedActiveMonitor.tick();
+
+    expect(alerts).toEqual(["expired", "active"]);
+    expect(await auditIdentities(audit)).toEqual([
+      { id: "bank-session-bank_session.expired:popular:event-restart", action: "bank_session.expired" },
+      { id: "bank-session-bank_session.restored:popular:event-restart", action: "bank_session.restored" },
+    ]);
+    await expect(episodes.findByBankCode("popular")).resolves.toBeNull();
+  });
+
+  it("clears delayed E1 after a stale close and only reconciles E2 on a later active tick", async () => {
+    const base = new InMemoryBankSessionExpiryEpisodeRepository();
+    const e1 = (await base.getOrCreate({
+      bankCode: "popular", expiredEventId: "event-e1", runId: "popular-expiry-event-e1",
+    })).episode;
+    const e2 = { bankCode: "popular", expiredEventId: "event-e2", runId: "popular-expiry-event-e2" };
+    const closeCalls: string[] = [];
+    let replaceOnFirstClose = true;
+    const delayedReplica: BankSessionExpiryEpisodeRepository = {
+      getOrCreate: (input) => base.getOrCreate(input),
+      findByBankCode: (bankCode) => base.findByBankCode(bankCode),
+      isAuditDelivered: (episode, kind) => base.isAuditDelivered(episode, kind),
+      markAuditDelivered: (episode, kind) => base.markAuditDelivered(episode, kind),
+      close: async (episode) => {
+        closeCalls.push(episode.expiredEventId);
+        if (replaceOnFirstClose) {
+          replaceOnFirstClose = false;
+          await base.close(e1);
+          await base.getOrCreate(e2);
+          return "missing_or_stale";
+        }
+        return base.close(episode);
+      },
+    };
+    const audit = new InMemoryAuditSink();
+    const monitor = createMonitor(delayedReplica, ["active", "active"], [], audit, () => "unused-candidate");
+
+    await monitor.tick();
+    await expect(base.findByBankCode("popular")).resolves.toMatchObject(e2);
+    expect(closeCalls).toEqual(["event-e1"]);
+
+    await monitor.tick();
+    expect(closeCalls).toEqual(["event-e1", "event-e2"]);
+    await expect(base.findByBankCode("popular")).resolves.toBeNull();
+  });
+
+  it("does not let an identity-safe repository close a replacement episode", async () => {
+    const episodes = new InMemoryBankSessionExpiryEpisodeRepository();
+    const original = (await episodes.getOrCreate({
+      bankCode: "popular", expiredEventId: "event-1", runId: "popular-expiry-event-1",
+    })).episode;
+
+    await expect(episodes.close(original)).resolves.toBe("closed");
+    const replacement = (await episodes.getOrCreate({
+      bankCode: "popular", expiredEventId: "event-2", runId: "popular-expiry-event-2",
+    })).episode;
+
+    await expect(episodes.close(original)).resolves.toBe("missing_or_stale");
+    await expect(episodes.close(replacement)).resolves.toBe("closed");
+    await expect(episodes.close(replacement)).resolves.toBe("missing_or_stale");
+  });
+});

--- a/src/modules/bank-sessions/expiry-episodes.ts
+++ b/src/modules/bank-sessions/expiry-episodes.ts
@@ -1,0 +1,87 @@
+export type SessionEpisodeAuditKind = "expired" | "restored";
+
+export interface BankSessionExpiryEpisode {
+  bankCode: string;
+  expiredEventId: string;
+  runId: string;
+  expiredAuditDelivered: boolean;
+  restoredAuditDelivered: boolean;
+}
+
+export type EpisodeCloseResult = "closed" | "missing_or_stale";
+
+export interface CreateBankSessionExpiryEpisodeInput {
+  bankCode: string;
+  expiredEventId: string;
+  runId: string;
+}
+
+export interface GetOrCreateBankSessionExpiryEpisodeResult {
+  episode: BankSessionExpiryEpisode;
+  created: boolean;
+}
+
+/** Persists one unresolved expiry episode per bank with atomic winner election. */
+export interface BankSessionExpiryEpisodeRepository {
+  getOrCreate(input: CreateBankSessionExpiryEpisodeInput): Promise<GetOrCreateBankSessionExpiryEpisodeResult>;
+  findByBankCode(bankCode: string): Promise<BankSessionExpiryEpisode | null>;
+  isAuditDelivered(
+    episode: Pick<BankSessionExpiryEpisode, "bankCode" | "runId">,
+    kind: SessionEpisodeAuditKind,
+  ): Promise<boolean>;
+  markAuditDelivered(
+    episode: Pick<BankSessionExpiryEpisode, "bankCode" | "runId">,
+    kind: SessionEpisodeAuditKind,
+  ): Promise<boolean>;
+  close(episode: Pick<BankSessionExpiryEpisode, "bankCode" | "expiredEventId" | "runId">): Promise<EpisodeCloseResult>;
+}
+
+export class InMemoryBankSessionExpiryEpisodeRepository implements BankSessionExpiryEpisodeRepository {
+  private readonly episodes = new Map<string, BankSessionExpiryEpisode>();
+
+  async getOrCreate(input: CreateBankSessionExpiryEpisodeInput): Promise<GetOrCreateBankSessionExpiryEpisodeResult> {
+    const existing = this.episodes.get(input.bankCode);
+    if (existing) return { episode: { ...existing }, created: false };
+
+    const episode: BankSessionExpiryEpisode = {
+      ...input,
+      expiredAuditDelivered: false,
+      restoredAuditDelivered: false,
+    };
+    this.episodes.set(input.bankCode, episode);
+    return { episode: { ...episode }, created: true };
+  }
+
+  async findByBankCode(bankCode: string): Promise<BankSessionExpiryEpisode | null> {
+    const episode = this.episodes.get(bankCode);
+    return episode ? { ...episode } : null;
+  }
+
+  async isAuditDelivered(
+    episode: Pick<BankSessionExpiryEpisode, "bankCode" | "runId">,
+    kind: SessionEpisodeAuditKind,
+  ): Promise<boolean> {
+    const current = this.episodes.get(episode.bankCode);
+    return Boolean(current && current.runId === episode.runId && current[`${kind}AuditDelivered`]);
+  }
+
+  async markAuditDelivered(
+    episode: Pick<BankSessionExpiryEpisode, "bankCode" | "runId">,
+    kind: SessionEpisodeAuditKind,
+  ): Promise<boolean> {
+    const current = this.episodes.get(episode.bankCode);
+    const field = `${kind}AuditDelivered` as const;
+    if (!current || current.runId !== episode.runId || current[field]) return false;
+    this.episodes.set(episode.bankCode, { ...current, [field]: true });
+    return true;
+  }
+
+  async close(episode: Pick<BankSessionExpiryEpisode, "bankCode" | "expiredEventId" | "runId">): Promise<EpisodeCloseResult> {
+    const current = this.episodes.get(episode.bankCode);
+    if (!current || current.runId !== episode.runId || current.expiredEventId !== episode.expiredEventId) {
+      return "missing_or_stale";
+    }
+    this.episodes.delete(episode.bankCode);
+    return "closed";
+  }
+}

--- a/src/modules/bank-sessions/index.ts
+++ b/src/modules/bank-sessions/index.ts
@@ -1,6 +1,14 @@
 import type { AuditSink } from "../audit";
 import { createAuditEvent } from "../audit";
+import { BANK_SESSION_ACTIONS } from "../audit/bank-actions";
+import { randomUUID } from "node:crypto";
+
 import type { AdminAlertSink } from "../../worker/queues/index";
+import type {
+  BankSessionExpiryEpisode,
+  BankSessionExpiryEpisodeRepository,
+  CreateBankSessionExpiryEpisodeInput,
+} from "./expiry-episodes";
 import {
   CdpPopularPortalPage,
   type CdpBrowserLike,
@@ -202,7 +210,7 @@ export function createCdpSessionChecker(
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ScheduleHandle = any;
 
-export interface BankSessionMonitorDeps {
+interface BankSessionMonitorBaseDeps {
   check: () => Promise<BankSessionCheckResult>;
   alertSink: Pick<AdminAlertSink, "notifySessionAttention">;
   auditSink?: Pick<AuditSink, "record">;
@@ -213,11 +221,33 @@ export interface BankSessionMonitorDeps {
   clearSchedule?: (handle: ScheduleHandle) => void;
 }
 
+export type BankSessionMonitorMode =
+  | { mode: "alert_only" }
+  | {
+    mode: "expiry_events";
+    bankCode: string;
+    episodes: BankSessionExpiryEpisodeRepository;
+    createExpiredEventId?: () => string;
+  };
+
+/** Valid monitor modes prevent partially-wired durable producers. */
+export interface BankSessionMonitorDeps extends BankSessionMonitorBaseDeps {
+  /** Omitted mode preserves the established alert-only monitor contract. */
+  monitorMode?: BankSessionMonitorMode;
+}
+
 export interface BankSessionMonitor {
   tick(): Promise<BankSessionCheckResult>;
   start(): void;
   stop(): void;
   lastResult(): BankSessionCheckResult | null;
+}
+
+/**
+ * Derive the stable durable identity for one expiry episode.
+ */
+export function createExpiredSessionRunId(bankCode: string, expiredEventId: string): string {
+  return `${bankCode}-expiry-${expiredEventId}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -253,12 +283,43 @@ export function createBankSessionMonitor(
     clock = () => new Date(),
     schedule = setInterval,
     clearSchedule = clearInterval,
+    monitorMode = { mode: "alert_only" },
   } = deps;
+  const expiryEpisodes = monitorMode.mode === "expiry_events" ? monitorMode.episodes : undefined;
+  const expiryBankCode = monitorMode.mode === "expiry_events" ? monitorMode.bankCode : undefined;
+  const createEpisodeId = monitorMode.mode === "expiry_events"
+    ? (monitorMode.createExpiredEventId ?? randomUUID)
+    : null;
 
-  let previous: BankSessionCheckResult | null = null;
+  let previousTransition: BankSessionCheckResult | null = null;
+  let lastObservedResult: BankSessionCheckResult | null = null;
+  let tickInFlight: Promise<BankSessionCheckResult> | null = null;
+  let recoveryEpisode: BankSessionExpiryEpisode | null = null;
+  let pendingExpiryCandidate: {
+    input: CreateBankSessionExpiryEpisodeInput;
+    observedResult: BankSessionCheckResult;
+  } | null = null;
   let handle: ScheduleHandle | null = null;
 
-  async function tick(): Promise<BankSessionCheckResult> {
+  async function reconcileRecoveryEpisode(observedEpisode: BankSessionExpiryEpisode): Promise<boolean> {
+    try {
+      const currentEpisode = await expiryEpisodes?.findByBankCode(observedEpisode.bankCode);
+      if (
+        currentEpisode
+        && currentEpisode.runId === observedEpisode.runId
+        && currentEpisode.expiredEventId === observedEpisode.expiredEventId
+      ) {
+        recoveryEpisode = currentEpisode;
+        return false;
+      }
+      recoveryEpisode = null;
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async function tickOnce(): Promise<BankSessionCheckResult> {
     let result: BankSessionCheckResult;
     try {
       result = await check();
@@ -271,10 +332,9 @@ export function createBankSessionMonitor(
       };
     }
 
-    const prevStatus = previous?.status ?? null;
+    lastObservedResult = result;
+    const prevStatus = previousTransition?.status ?? null;
     const nextStatus = result.status;
-
-    previous = result;
 
     // Determine if this is a transition that warrants alerting/auditing.
     // isNewBad fires only when coming FROM a non-bad (null or active) state,
@@ -284,13 +344,124 @@ export function createBankSessionMonitor(
     const isNewBad = nextStatus !== "active" && !wasBad;
     const isRecovery =
       nextStatus === "active" && prevStatus !== null && prevStatus !== "active";
+    let createdEpisode = false;
+    let expiryAuditAcknowledged = false;
+    let expiryNotificationResult: BankSessionCheckResult | null = null;
+    let transitionReady = true;
 
-    if (isNewBad || isRecovery) {
+    if ((nextStatus === "expired" || pendingExpiryCandidate) && expiryEpisodes && expiryBankCode && createEpisodeId) {
+      const candidate = pendingExpiryCandidate ?? {
+        input: (() => {
+          const expiredEventId = createEpisodeId();
+          return {
+            bankCode: expiryBankCode,
+            expiredEventId,
+            runId: createExpiredSessionRunId(expiryBankCode, expiredEventId),
+          };
+        })(),
+        observedResult: result,
+      };
+      pendingExpiryCandidate = candidate;
+      try {
+        const episodeResult = await expiryEpisodes.getOrCreate(candidate.input);
+        const durableEpisode = episodeResult.episode;
+        createdEpisode = episodeResult.created;
+        recoveryEpisode = durableEpisode;
+        expiryAuditAcknowledged = await deliverEpisodeAudit(auditSink, expiryEpisodes, durableEpisode, "expired", result);
+        transitionReady = expiryAuditAcknowledged;
+        if (createdEpisode) expiryNotificationResult = candidate.observedResult;
+        pendingExpiryCandidate = null;
+      } catch {
+        // A durable election outage must not fall back to process-local side effects.
+        transitionReady = false;
+      }
+    }
+
+    if (nextStatus === "active" && expiryEpisodes && expiryBankCode && !recoveryEpisode) {
+      try {
+        recoveryEpisode = await expiryEpisodes.findByBankCode(expiryBankCode);
+      } catch {
+        // The next active tick safely retries the durable lookup without advancing state.
+        transitionReady = false;
+      }
+    }
+
+    let recoveryClosed = nextStatus !== "active" || !recoveryEpisode;
+    let recoveryWon = false;
+    if (nextStatus === "active" && expiryEpisodes && recoveryEpisode) {
+      const observedEpisode = recoveryEpisode;
+      const expiryAuditAcknowledged = await deliverEpisodeAudit(
+        auditSink,
+        expiryEpisodes,
+        observedEpisode,
+        "expired",
+        result,
+      );
+      if (!expiryAuditAcknowledged) {
+        recoveryClosed = await reconcileRecoveryEpisode(observedEpisode);
+      } else {
+        const restorationAuditAcknowledged = await deliverEpisodeAudit(
+          auditSink,
+          expiryEpisodes,
+          observedEpisode,
+          "restored",
+          result,
+        );
+        if (restorationAuditAcknowledged) {
+          try {
+            const closeResult = await expiryEpisodes.close(observedEpisode);
+            recoveryWon = closeResult === "closed";
+            if (recoveryWon) {
+              recoveryEpisode = null;
+              recoveryClosed = true;
+            } else {
+              recoveryClosed = await reconcileRecoveryEpisode(observedEpisode);
+            }
+          } catch {
+            recoveryClosed = await reconcileRecoveryEpisode(observedEpisode);
+          }
+        } else {
+          recoveryClosed = await reconcileRecoveryEpisode(observedEpisode);
+        }
+      }
+    }
+
+    const usesDurableExpiryEpisodes = expiryEpisodes !== undefined && expiryBankCode !== undefined;
+    if (expiryNotificationResult) {
+      await emitAlert(alertSink, expiryNotificationResult);
+    }
+    if (
+      (!usesDurableExpiryEpisodes && isNewBad) ||
+      (nextStatus !== "expired" && isNewBad) ||
+      (isRecovery && !usesDurableExpiryEpisodes) ||
+      recoveryWon
+    ) {
       await emitAlert(alertSink, result);
+    }
+
+    if (
+      (!usesDurableExpiryEpisodes || nextStatus === "browser_unavailable") &&
+      (isNewBad || isRecovery)
+    ) {
       await emitAudit(auditSink, result);
     }
 
+    // A failed durable close keeps the local state on the expired episode so a
+    // later tick retries the exact observed identity instead of forgetting it.
+    if (transitionReady && (recoveryClosed || nextStatus !== "active")) {
+      previousTransition = result;
+    }
     return result;
+  }
+
+  async function tick(): Promise<BankSessionCheckResult> {
+    if (tickInFlight) return tickInFlight;
+    const current = tickOnce();
+    tickInFlight = current;
+    void current.finally(() => {
+      if (tickInFlight === current) tickInFlight = null;
+    });
+    return current;
   }
 
   return {
@@ -310,7 +481,7 @@ export function createBankSessionMonitor(
     },
 
     lastResult() {
-      return previous;
+      return lastObservedResult;
     },
   };
 }
@@ -342,10 +513,10 @@ async function emitAudit(
   try {
     const action =
       result.status === "active"
-        ? "bank_session.restored"
+        ? BANK_SESSION_ACTIONS.RESTORED
         : result.status === "expired"
-          ? "bank_session.expired"
-          : "bank_session.unavailable";
+          ? BANK_SESSION_ACTIONS.EXPIRED
+          : BANK_SESSION_ACTIONS.UNAVAILABLE;
 
     const event = createAuditEvent({
       actorId: AUDIT_ACTOR,
@@ -358,5 +529,36 @@ async function emitAudit(
     await auditSink.record(event);
   } catch {
     // Audit failures must never propagate.
+  }
+}
+
+async function deliverEpisodeAudit(
+  auditSink: Pick<AuditSink, "record"> | undefined,
+  episodes: BankSessionExpiryEpisodeRepository,
+  episode: BankSessionExpiryEpisode,
+  kind: "expired" | "restored",
+  result: BankSessionCheckResult,
+): Promise<boolean> {
+  try {
+    if (await episodes.isAuditDelivered(episode, kind)) return true;
+    if (!auditSink) return false;
+    const action = kind === "expired" ? BANK_SESSION_ACTIONS.EXPIRED : BANK_SESSION_ACTIONS.RESTORED;
+    await auditSink.record(createAuditEvent({
+      id: `bank-session-${action}:${episode.bankCode}:${episode.expiredEventId}`,
+      actorId: AUDIT_ACTOR,
+      actorRole: "system",
+      action,
+      target: "bank_session",
+      targetId: null,
+      metadata: {
+        bankCode: episode.bankCode,
+        expiredEventId: episode.expiredEventId,
+        checkedAt: result.checkedAt,
+      },
+    }));
+    const marked = await episodes.markAuditDelivered(episode, kind);
+    return marked || await episodes.isAuditDelivered(episode, kind);
+  } catch {
+    return false;
   }
 }

--- a/src/modules/persistence/prisma-audit-sink.ts
+++ b/src/modules/persistence/prisma-audit-sink.ts
@@ -16,18 +16,22 @@ export class PrismaAuditSink implements AuditSink {
   }
 
   async record(event: AuditEvent): Promise<void> {
-    await this.prisma.auditEvent.create({
-      data: {
-        id: event.id,
-        actorId: event.actorId ?? null,
-        actorRole: event.actorRole ?? null,
-        action: event.action,
-        target: event.target,
-        targetId: event.targetId ?? null,
-        metadata: (event.metadata as Prisma.InputJsonValue | null) ?? undefined,
-        createdAt: event.createdAt,
-      },
-    });
+    try {
+      await this.prisma.auditEvent.create({
+        data: {
+          id: event.id,
+          actorId: event.actorId ?? null,
+          actorRole: event.actorRole ?? null,
+          action: event.action,
+          target: event.target,
+          targetId: event.targetId ?? null,
+          metadata: (event.metadata as Prisma.InputJsonValue | null) ?? undefined,
+          createdAt: event.createdAt,
+        },
+      });
+    } catch (error: unknown) {
+      if (!isPrismaUniqueViolation(error)) throw error;
+    }
   }
 
   /**
@@ -52,4 +56,9 @@ export class PrismaAuditSink implements AuditSink {
       createdAt: row.createdAt,
     }));
   }
+}
+
+function isPrismaUniqueViolation(error: unknown): boolean {
+  return typeof error === "object" && error !== null &&
+    "code" in error && (error as { code: unknown }).code === "P2002";
 }

--- a/src/modules/persistence/prisma-bank-session-expiry-episode-repository.ts
+++ b/src/modules/persistence/prisma-bank-session-expiry-episode-repository.ts
@@ -1,0 +1,99 @@
+import type { PrismaClient } from "../../generated/prisma/client";
+import type {
+  BankSessionExpiryEpisode,
+  BankSessionExpiryEpisodeRepository,
+  CreateBankSessionExpiryEpisodeInput,
+  EpisodeCloseResult,
+  GetOrCreateBankSessionExpiryEpisodeResult,
+  SessionEpisodeAuditKind,
+} from "../bank-sessions/expiry-episodes";
+
+type EpisodeRow = {
+  bankCode: string;
+  expiredEventId: string;
+  runId: string;
+  expiredAuditDeliveredAt: Date | null;
+  restoredAuditDeliveredAt: Date | null;
+};
+
+function mapRow(row: EpisodeRow): BankSessionExpiryEpisode {
+  return {
+    bankCode: row.bankCode,
+    expiredEventId: row.expiredEventId,
+    runId: row.runId,
+    expiredAuditDelivered: row.expiredAuditDeliveredAt !== null,
+    restoredAuditDelivered: row.restoredAuditDeliveredAt !== null,
+  };
+}
+
+/** Raw parameterized SQL keeps this repository independent of generated output. */
+export class PrismaBankSessionExpiryEpisodeRepository implements BankSessionExpiryEpisodeRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async getOrCreate(input: CreateBankSessionExpiryEpisodeInput): Promise<GetOrCreateBankSessionExpiryEpisodeResult> {
+    const inserted = await this.prisma.$queryRaw<EpisodeRow[]>`
+      INSERT INTO "BankSessionExpiryEpisode" ("bankCode", "expiredEventId", "runId", "updatedAt")
+      VALUES (${input.bankCode}, ${input.expiredEventId}, ${input.runId}, NOW())
+      ON CONFLICT ("bankCode") DO NOTHING
+      RETURNING "bankCode", "expiredEventId", "runId", "expiredAuditDeliveredAt", "restoredAuditDeliveredAt"
+    `;
+    if (inserted[0]) return { episode: mapRow(inserted[0]), created: true };
+
+    const existing = await this.prisma.$queryRaw<EpisodeRow[]>`
+      SELECT "bankCode", "expiredEventId", "runId", "expiredAuditDeliveredAt", "restoredAuditDeliveredAt"
+      FROM "BankSessionExpiryEpisode" WHERE "bankCode" = ${input.bankCode}
+    `;
+    if (!existing[0]) throw new Error("Bank session expiry episode was not available after insert conflict");
+    return { episode: mapRow(existing[0]), created: false };
+  }
+
+  async findByBankCode(bankCode: string): Promise<BankSessionExpiryEpisode | null> {
+    const rows = await this.prisma.$queryRaw<EpisodeRow[]>`
+      SELECT "bankCode", "expiredEventId", "runId", "expiredAuditDeliveredAt", "restoredAuditDeliveredAt"
+      FROM "BankSessionExpiryEpisode" WHERE "bankCode" = ${bankCode}
+    `;
+    return rows[0] ? mapRow(rows[0]) : null;
+  }
+
+  async isAuditDelivered(
+    episode: Pick<BankSessionExpiryEpisode, "bankCode" | "runId">,
+    kind: SessionEpisodeAuditKind,
+  ): Promise<boolean> {
+    const rows = kind === "expired"
+      ? await this.prisma.$queryRaw<{ deliveredAt: Date | null }[]>`
+          SELECT "expiredAuditDeliveredAt" AS "deliveredAt" FROM "BankSessionExpiryEpisode"
+          WHERE "bankCode" = ${episode.bankCode} AND "runId" = ${episode.runId}
+        `
+      : await this.prisma.$queryRaw<{ deliveredAt: Date | null }[]>`
+          SELECT "restoredAuditDeliveredAt" AS "deliveredAt" FROM "BankSessionExpiryEpisode"
+          WHERE "bankCode" = ${episode.bankCode} AND "runId" = ${episode.runId}
+        `;
+    return rows[0]?.deliveredAt !== null && rows[0] !== undefined;
+  }
+
+  async markAuditDelivered(
+    episode: Pick<BankSessionExpiryEpisode, "bankCode" | "runId">,
+    kind: SessionEpisodeAuditKind,
+  ): Promise<boolean> {
+    const updated = kind === "expired"
+      ? await this.prisma.$queryRaw<{ bankCode: string }[]>`
+          UPDATE "BankSessionExpiryEpisode" SET "expiredAuditDeliveredAt" = NOW(), "updatedAt" = NOW()
+          WHERE "bankCode" = ${episode.bankCode} AND "runId" = ${episode.runId} AND "expiredAuditDeliveredAt" IS NULL
+          RETURNING "bankCode"
+        `
+      : await this.prisma.$queryRaw<{ bankCode: string }[]>`
+          UPDATE "BankSessionExpiryEpisode" SET "restoredAuditDeliveredAt" = NOW(), "updatedAt" = NOW()
+          WHERE "bankCode" = ${episode.bankCode} AND "runId" = ${episode.runId} AND "restoredAuditDeliveredAt" IS NULL
+          RETURNING "bankCode"
+        `;
+    return updated.length === 1;
+  }
+
+  async close(episode: Pick<BankSessionExpiryEpisode, "bankCode" | "expiredEventId" | "runId">): Promise<EpisodeCloseResult> {
+    const deleted = await this.prisma.$executeRaw`
+      DELETE FROM "BankSessionExpiryEpisode"
+      WHERE "bankCode" = ${episode.bankCode} AND "expiredEventId" = ${episode.expiredEventId} AND "runId" = ${episode.runId}
+    `;
+    return deleted === 1 ? "closed" : "missing_or_stale";
+  }
+}

--- a/src/modules/persistence/prisma-contracts.test.ts
+++ b/src/modules/persistence/prisma-contracts.test.ts
@@ -19,13 +19,14 @@
  * so the production/dev database is never touched during testing.
  */
 
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "vitest";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "../../generated/prisma/client";
 
 import { PrismaTransactionRepository } from "./prisma-transaction-repository";
 import { PrismaScrapeRunRepository } from "./prisma-scrape-run-repository";
 import { PrismaAuditSink } from "./prisma-audit-sink";
+import { PrismaBankSessionExpiryEpisodeRepository } from "./prisma-bank-session-expiry-episode-repository";
 
 import { runTransactionRepositoryContract } from "./contracts/transaction-repository.contract";
 import { runScrapeRunRepositoryContract } from "./contracts/scrape-run-repository.contract";
@@ -76,6 +77,7 @@ async function truncateTables(): Promise<void> {
   await prisma.auditEvent.deleteMany();
   await prisma.transaction.deleteMany();
   await prisma.scrapeRun.deleteMany();
+  await prisma.$executeRawUnsafe('DELETE FROM "BankSessionExpiryEpisode"');
   await prisma.bank.deleteMany();
   await prisma.userRole.deleteMany();
   await prisma.user.deleteMany();
@@ -104,15 +106,119 @@ describe.skipIf(!hasTestDb)("Prisma scrape-run repository (requires RD_SYNC_TEST
   }));
 });
 
+describe.skipIf(!hasTestDb)("Prisma bank-session expiry episode repository (requires RD_SYNC_TEST_DATABASE_URL)", () => {
+  beforeEach(truncateTables);
+  afterEach(truncateTables);
+
+  it("persists create/conflict/read/audit acknowledgement/close with PostgreSQL", async () => {
+    if (!prisma) throw new Error("prisma not initialized");
+    const repo = new PrismaBankSessionExpiryEpisodeRepository(prisma);
+    const input = { bankCode: "popular", expiredEventId: "event-contract-1", runId: "popular-expiry-event-contract-1" };
+
+    await expect(repo.getOrCreate(input)).resolves.toMatchObject({ created: true, episode: input });
+    await expect(repo.getOrCreate({ ...input, expiredEventId: "ignored", runId: "ignored" }))
+      .resolves.toMatchObject({ created: false, episode: input });
+    await expect(repo.markAuditDelivered(input, "expired")).resolves.toBe(true);
+    await expect(repo.markAuditDelivered(input, "expired")).resolves.toBe(false);
+    await expect(repo.getOrCreate(input)).resolves.toMatchObject({
+      created: false,
+      episode: { ...input, expiredAuditDelivered: true },
+    });
+    await expect(repo.close(input)).resolves.toBe("closed");
+    await expect(repo.getOrCreate({ bankCode: "popular", expiredEventId: "event-contract-2", runId: "popular-expiry-event-contract-2" }))
+      .resolves.toMatchObject({ created: true });
+  });
+
+  it("allows a restarted active monitor to locate and identity-safely close the current episode", async () => {
+    if (!prisma) throw new Error("prisma not initialized");
+    const repo = new PrismaBankSessionExpiryEpisodeRepository(prisma);
+    const episode = { bankCode: "popular", expiredEventId: "event-restart", runId: "popular-expiry-event-restart" };
+
+    await repo.getOrCreate(episode);
+    await expect(repo.findByBankCode("popular")).resolves.toMatchObject(episode);
+    await expect(repo.close(episode)).resolves.toBe("closed");
+    await expect(repo.findByBankCode("popular")).resolves.toBeNull();
+  });
+
+  it("does not let a delayed stale close remove a replacement episode", async () => {
+    if (!prisma) throw new Error("prisma not initialized");
+    const repo = new PrismaBankSessionExpiryEpisodeRepository(prisma);
+    const firstEpisode = { bankCode: "popular", expiredEventId: "event-stale-e1", runId: "popular-expiry-event-stale-e1" };
+    const replacementEpisode = { bankCode: "popular", expiredEventId: "event-stale-e2", runId: "popular-expiry-event-stale-e2" };
+
+    await expect(repo.getOrCreate(firstEpisode)).resolves.toMatchObject({ created: true, episode: firstEpisode });
+    await expect(repo.close(firstEpisode)).resolves.toBe("closed");
+    await expect(repo.getOrCreate(replacementEpisode)).resolves.toMatchObject({ created: true, episode: replacementEpisode });
+    await expect(repo.close(firstEpisode)).resolves.toBe("missing_or_stale");
+    await expect(repo.findByBankCode("popular")).resolves.toEqual({
+      ...replacementEpisode,
+      expiredAuditDelivered: false,
+      restoredAuditDelivered: false,
+    });
+  });
+
+  it("linearizes concurrent episode creation, audit markers, and identity-safe close", async () => {
+    if (!prisma) throw new Error("prisma not initialized");
+    const first = new PrismaBankSessionExpiryEpisodeRepository(prisma);
+    const second = new PrismaBankSessionExpiryEpisodeRepository(prisma);
+    const firstCandidate = { bankCode: "popular", expiredEventId: "event-concurrent-a", runId: "popular-expiry-event-concurrent-a" };
+    const secondCandidate = { bankCode: "popular", expiredEventId: "event-concurrent-b", runId: "popular-expiry-event-concurrent-b" };
+    const created = await Promise.all([first.getOrCreate(firstCandidate), second.getOrCreate(secondCandidate)]);
+    expect(created.filter((result) => result.created)).toHaveLength(1);
+    const winner = created.find((result) => result.created)?.episode;
+    expect(winner).toBeDefined();
+    for (const result of created) {
+      expect(result.episode).toMatchObject(winner!);
+    }
+
+    const expiredMarkers = await Promise.all([
+      first.markAuditDelivered(winner!, "expired"),
+      second.markAuditDelivered(winner!, "expired"),
+    ]);
+    expect(expiredMarkers.filter(Boolean)).toHaveLength(1);
+    await expect(new PrismaBankSessionExpiryEpisodeRepository(prisma).isAuditDelivered(winner!, "expired")).resolves.toBe(true);
+
+    const restoredMarkers = await Promise.all([
+      first.markAuditDelivered(winner!, "restored"),
+      second.markAuditDelivered(winner!, "restored"),
+    ]);
+    expect(restoredMarkers.filter(Boolean)).toHaveLength(1);
+    const closes = await Promise.all([first.close(winner!), second.close(winner!)]);
+    expect(closes.filter((result) => result === "closed")).toHaveLength(1);
+  });
+
+});
+
 // ---------------------------------------------------------------------------
 // Prisma audit sink contract
 // ---------------------------------------------------------------------------
 
 describe.skipIf(!hasTestDb)("Prisma audit sink (requires RD_SYNC_TEST_DATABASE_URL)", () => {
+  beforeEach(truncateTables);
+  afterEach(truncateTables);
+
   runAuditRepositoryContract(async () => ({
     sink: new PrismaAuditSink(),
     cleanup: truncateTables,
   }));
+
+  it("stores one audit row for repeated deterministic delivery ids", async () => {
+    if (!prisma) throw new Error("prisma not initialized");
+    const sink = new PrismaAuditSink();
+    const event = {
+      id: "audit-delivery-contract-1",
+      actorId: "system:test",
+      actorRole: "system",
+      action: "bank_session.expired",
+      target: "bank_session",
+      targetId: null,
+      metadata: { sentinel: "opaque-audit-contract" },
+      createdAt: new Date("2026-07-12T00:00:00.000Z"),
+    };
+    await sink.record(event);
+    await sink.record(event);
+    await expect(prisma.auditEvent.count({ where: { id: event.id } })).resolves.toBe(1);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Persist one durable expiry episode per bank with atomic PostgreSQL winner election.
- Deliver ordered, deterministic canonical expiry/restoration audits with durable acknowledgement and identity-safe retry/close behavior.
- Fail closed during persistence outages and retain transient unpersisted candidates while the monitor process remains alive.

Exactly-once applies only to canonical expiry/restoration audits. The creation winner makes one best-effort expiry-notification attempt. The identity-safe close winner makes one best-effort restoration-notification attempt. Notification delivery and retry are not durable.

If PostgreSQL is unavailable and the process is lost before episode persistence, B1 cannot recover that observation.

publication path not implemented; producer remains dormant

## Chain Context
- Parent child PR: #35 (`feature/multi-bank-auto-login-pr4l-throttled-deferred`)
- This B1 branch: `feature/multi-bank-auto-login-pr4m-expiry-event-source`
- Future B2 remains unchecked and unimplemented.

## Explicit Exclusions
No outbox, publication-state transitions, queue handoff, consumer revalidation, claim, lease, or worker lifecycle changes are included. B2 records those requirements, including PostgreSQL-authoritative consumer revalidation and both forced interleavings.

## Review Order
1. Prisma schema and migration.
2. Expiry episode repository contract and PostgreSQL implementation.
3. Monitor election, audit ordering, outage retry, stale-identity, and close behavior.
4. In-memory and PostgreSQL regression contracts.
5. Dormant composition, runbook, roadmap, and B2 task ledger.

## Size Exception
Maintainer-approved `size:exception`: approximately +942/-190 across 16 substantive files. This remains one atomic review unit because schema, election, audit acknowledgement, outage retry, identity-safe close, PostgreSQL contracts, and dormant composition must be reviewed together. All DB-to-queue publication work was removed into B2.

## Verification
- Focused B1 contracts: 9 passed.
- PostgreSQL contracts: 44/44 passed twice with per-test isolation.
- Clean full suite: 1,043 passed, 44 skipped.
- `pnpm lint`: passed.
- `pnpm typecheck`: passed.
- `pnpm exec prisma validate`: passed.
- `git diff --check`: passed.
- Fresh full 4R completed; final R3 revalidation clean.
- Dual Judgment Day: APPROVED / APPROVED.