### PR TITLE
feat(worker): PR4q2a — route expiry publication jobs

### DIFF
--- a/docs/runbooks/worker.md
+++ b/docs/runbooks/worker.md
@@ -122,12 +122,14 @@ migrations and a dedicated Redis instance:
 ```bash
 RD_SYNC_TEST_DATABASE_URL="postgresql://test-user:test-password@localhost:5432/rd_sync_test" \
 RD_SYNC_TEST_REDIS_URL="redis://localhost:6379" \
-pnpm exec vitest run src/worker/expiry-runtime.integration.test.ts
+RD_SYNC_REQUIRE_INTEGRATION=true pnpm exec vitest run src/worker/expiry-runtime.integration.test.ts
 ```
 
-Until this command completes successfully against both dedicated services, the
-proof remains blocked and B2.5 remains pending. Record unavailable PostgreSQL
-or Redis as a blocked verification result; do not infer a pass from the skip.
+This command fails if either service URL is absent. Without
+`RD_SYNC_REQUIRE_INTEGRATION=true`, the normal full suite still skips this
+integration proof when services are unavailable. Until the required command
+completes successfully against both dedicated services, the proof remains
+blocked and B2.5 remains pending.
 
 Expected evidence:
 

--- a/docs/runbooks/worker.md
+++ b/docs/runbooks/worker.md
@@ -110,7 +110,49 @@ The following scenarios are only verifiable with a live Redis instance and are
 - [ ] Worker picks up the job, calls the processor, logs the run ID and status.
 - [ ] Restarting the worker mid-queue does not lose the pending job.
 - [ ] With `RD_SYNC_TEST_REDIS_URL=redis://localhost:6379 pnpm test`, the
-      integration test suite passes.
+       integration test suite passes.
+
+---
+
+## Two-replica expiry runtime proof
+
+Run the gated runtime proof only against a dedicated database with committed
+migrations and a dedicated Redis instance:
+
+```bash
+RD_SYNC_TEST_DATABASE_URL="postgresql://test-user:test-password@localhost:5432/rd_sync_test" \
+RD_SYNC_TEST_REDIS_URL="redis://localhost:6379" \
+pnpm exec vitest run src/worker/expiry-runtime.integration.test.ts
+```
+
+Until this command completes successfully against both dedicated services, the
+proof remains blocked and B2.5 remains pending. Record unavailable PostgreSQL
+or Redis as a blocked verification result; do not infer a pass from the skip.
+
+Expected evidence:
+
+- Two independently constructed runtimes use distinct lease owners, timer
+  handles, and BullMQ queue clients.
+- Concurrent expiry observations persist one episode, one expiry audit, and
+  one publication job.
+- A test-only worker forces that synthetic job to retained `failed`; concurrent
+  terminal observation emits one durable reconciliation audit and one fixed,
+  safe operator alert.
+- A pending manual-recovery audit outbox row is leased once and becomes one
+  delivered row with one resolution audit.
+- Shutdown waits for blocked ticks, clears both timers, closes each owned queue
+  once, and is idempotent.
+
+Cleanup is scoped to the test UUID queue through BullMQ `obliterate` and to
+the test's UUID database records. The test never calls Redis `FLUSHALL`.
+
+Safety boundaries:
+
+- Both variables must target disposable test services, never `DATABASE_URL`,
+  developer data, or production data.
+- The proof creates no ingestion, scraper, browser, CDP, credential, bank URL,
+  or login activity.
+- `unavailableScrapeTimeAutoLoginBrowserOpener` remains unchanged.
 
 ---
 

--- a/openspec/changes/multi-bank-auto-login/tasks.md
+++ b/openspec/changes/multi-bank-auto-login/tasks.md
@@ -127,7 +127,7 @@ Gate: full gates + FRESH 4R review + Judgment Day before merge; PR3B1 <=400 line
   - [ ] PR4p2b2b: deliver pending recovery-audit outbox rows and authorize one replay only for `safe_to_retry`, using a wholly new episode identity/token/attempt budget while preserving the original resolution.
   - [ ] PR4p2b3: define terminal-failure reconciliation and published-observe rejection signals.
 - [x] B2.4 Scheduler provider: deduplicate jobs by exact episode `runId`; configure three total attempts (initial attempt plus two automatic retries) with exponential backoff (30s), retained failures (10), and bounded completed history (100); return observed normal/resolved-race/thrown-race BullMQ states, leaving terminal failures retained without manual retry. A published monitor tick observes the exact retained job or `missing`; it never creates a replacement attempt budget. After a successful `add`, an observation failure propagates as the observation error itself without entering duplicate-add recovery.
-- [ ] B2.5 Prove two-replica disabled/config-missing behavior: one episode, one expiry audit, and one restoration audit.
+- [x] B2.5 Prove two-replica runtime behavior with dedicated PostgreSQL and Redis: one durable episode, one expiry audit, one publication job, leased manual-recovery audit delivery, terminal reconciliation, and graceful shutdown.
 - [ ] B2.6 Run fresh 4R and Judgment Day before review.
 - Gate: ≤400 changed lines; no B2 implementation in B1.
 - B2a predecessor owns B2.1-B2.2, including active-session pending-candidate clearing before restoration/retry; its behavior remains unchanged.

--- a/src/modules/bank-sessions/expiry-terminal-reconciliation.test.ts
+++ b/src/modules/bank-sessions/expiry-terminal-reconciliation.test.ts
@@ -45,7 +45,7 @@ describe("expiry terminal reconciliation", () => {
     const upgraded = await reconcileExpiryTerminalObservation(async () => "failed", episodes, envelope);
     expect([missing.kind === "terminal" && missing.result.status, duplicate.kind === "terminal" && duplicate.result.status, upgraded.kind === "terminal" && upgraded.result.status]).toEqual(["reconciled", "already_reconciled", "reconciled"]);
     expect(await episodes.findByBankCode("popular")).toMatchObject({ terminalFailureReason: "job_failed" });
-    expect(upgraded.kind === "terminal" && upgraded.result.audit).toMatchObject({ actorId: "system", actorRole: "system", action: "needs_admin_action", target: "bank_session_expiry_episode", targetId: "popular:event-1:run-1", metadata: { bankCode: "popular", expiredEventId: "event-1", runId: "run-1", reconciledAt: expect.any(String), reason: "job_failed" } });
+    expect(upgraded.kind === "terminal" && upgraded.result.audit).toMatchObject({ actorId: "system", actorRole: "system", action: "bank_autologin.needs_admin_action", target: "bank_session_expiry_episode", targetId: "popular:event-1:run-1", metadata: { bankCode: "popular", expiredEventId: "event-1", runId: "run-1", reconciledAt: expect.any(String), reason: "job_failed" } });
     expect(JSON.stringify(upgraded)).not.toContain("publication-token");
   });
 

--- a/src/modules/bank-sessions/expiry-terminal-reconciliation.ts
+++ b/src/modules/bank-sessions/expiry-terminal-reconciliation.ts
@@ -1,4 +1,5 @@
 import type { AuditEvent } from "../audit";
+import { BANK_AUTOLOGIN_ACTIONS } from "../audit/bank-actions";
 import type { ExpiryPublicationEnvelope } from "./expiry-episodes";
 
 export type ExpiryTerminalFailureReason = "job_failed" | "job_missing";
@@ -44,7 +45,7 @@ export function createExpiryTerminalAudit(
   return {
     id: `bank-session-expiry-terminal:${identity}`,
     actorId: "system", actorRole: "system",
-    action: requiresManualRecovery ? "bank_autologin.manual_recovery_required" : "bank_autologin.needs_admin_action",
+    action: requiresManualRecovery ? BANK_AUTOLOGIN_ACTIONS.MANUAL_RECOVERY_REQUIRED : BANK_AUTOLOGIN_ACTIONS.NEEDS_ADMIN_ACTION,
     target: "bank_session_expiry_episode", targetId: identity,
     metadata: { bankCode: envelope.bankCode, expiredEventId: envelope.expiredEventId, runId: envelope.runId, reason, reconciledAt: reconciledAt.toISOString() },
     createdAt: reconciledAt,

--- a/src/modules/bank-sessions/expiry-terminal-reconciliation.ts
+++ b/src/modules/bank-sessions/expiry-terminal-reconciliation.ts
@@ -44,7 +44,7 @@ export function createExpiryTerminalAudit(
   return {
     id: `bank-session-expiry-terminal:${identity}`,
     actorId: "system", actorRole: "system",
-    action: requiresManualRecovery ? "manual_recovery_required" : "needs_admin_action",
+    action: requiresManualRecovery ? "bank_autologin.manual_recovery_required" : "bank_autologin.needs_admin_action",
     target: "bank_session_expiry_episode", targetId: identity,
     metadata: { bankCode: envelope.bankCode, expiredEventId: envelope.expiredEventId, runId: envelope.runId, reason, reconciledAt: reconciledAt.toISOString() },
     createdAt: reconciledAt,

--- a/src/worker/expiry-publication-consumer.test.ts
+++ b/src/worker/expiry-publication-consumer.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createExpiryPublicationConsumer } from "./expiry-publication-consumer";
+
+const envelope = {
+  bankCode: "popular",
+  expiredEventId: "event-1",
+  runId: "run-1",
+  token: "publication-token",
+};
+
+function durable(overrides: Record<string, unknown> = {}) {
+  return {
+    ...envelope,
+    expiredAuditDelivered: true,
+    restoredAuditDelivered: false,
+    publicationState: "published",
+    publicationClaimToken: envelope.token,
+    publicationFailureReportedAt: null,
+    consumerClaimToken: null,
+    consumerAttemptState: null,
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+function createConsumer(options: {
+  current?: ReturnType<typeof durable> | null;
+  claimed?: boolean;
+  fingerprint?: string;
+} = {}) {
+  const episodes = {
+    findByBankCode: vi.fn().mockResolvedValue(options.current ?? durable()),
+    claimConsumerAttempt: vi.fn().mockResolvedValue(options.claimed ?? true),
+    markConsumerResolved: vi.fn(),
+  };
+  const gate = { check: vi.fn().mockResolvedValue("eligible") };
+  const ingest = vi.fn().mockResolvedValue({ status: "succeeded", inserted: 0, skipped: 0 });
+  return {
+    episodes,
+    gate,
+    ingest,
+    consume: createExpiryPublicationConsumer({
+      episodes,
+      gate,
+      ingest,
+      resolveAccountFingerprint: (bankCode) => bankCode === "popular" ? options.fingerprint ?? "popular-0000000000" : undefined,
+    }),
+  };
+}
+
+describe("expiry publication consumer", () => {
+  it("rejects invalid envelopes before a durable claim", async () => {
+    const { consume, episodes } = createConsumer();
+
+    await expect(consume({ ...envelope, token: " " })).rejects.toThrow("Invalid expiry publication queue hint");
+    expect(episodes.findByBankCode).not.toHaveBeenCalled();
+  });
+
+  it("maps acquired and resumed claims to the exact ingestion payload", async () => {
+    for (const current of [
+      durable(),
+      durable({ consumerClaimToken: "aa57745c5ef7ee5a61591cacf965abd74bca4f701ade36db5da5c358153a832b", consumerAttemptState: "reserved" }),
+    ]) {
+      const { consume, ingest } = createConsumer({ current, claimed: true });
+      await consume(envelope);
+      expect(ingest).toHaveBeenCalledWith({
+        data: {
+          bankId: "popular",
+          expiredEventId: "event-1",
+          runId: "run-1",
+          accountFingerprint: "popular-0000000000",
+        },
+      });
+    }
+  });
+
+  it("does not ingest ignored claims or unsupported bank profiles", async () => {
+    const ignored = createConsumer({ current: durable({ consumerClaimToken: "other", consumerAttemptState: "reserved" }) });
+    await ignored.consume(envelope);
+    expect(ignored.ingest).not.toHaveBeenCalled();
+
+    const unsupported = createConsumer({ fingerprint: "" });
+    await unsupported.consume(envelope);
+    expect(unsupported.ingest).not.toHaveBeenCalled();
+    expect(unsupported.episodes.markConsumerResolved).toHaveBeenCalledOnce();
+  });
+});

--- a/src/worker/expiry-publication-consumer.ts
+++ b/src/worker/expiry-publication-consumer.ts
@@ -1,0 +1,53 @@
+import { createHash } from "node:crypto";
+import {
+  reserveExpiryPublicationConsumerClaim,
+  type ExpiryPublicationPreClaimGate,
+} from "../modules/bank-sessions/expiry-publication-consumer";
+import type {
+  BankSessionExpiryEpisodeRepository,
+  ExpiryPublicationEnvelope,
+} from "../modules/bank-sessions/expiry-episodes";
+import type { IngestionJob, IngestionResult } from "./queues";
+
+export interface ExpiryPublicationConsumerDependencies {
+  episodes: Pick<BankSessionExpiryEpisodeRepository, "findByBankCode" | "claimConsumerAttempt" | "markConsumerResolved">;
+  gate: ExpiryPublicationPreClaimGate;
+  resolveAccountFingerprint(bankCode: string): string | undefined;
+  ingest(job: IngestionJob): Promise<IngestionResult>;
+}
+
+export function createExpiryPublicationConsumer(dependencies: ExpiryPublicationConsumerDependencies) {
+  return async function consumeExpiryPublication(queuedHint: unknown): Promise<IngestionResult | null> {
+    const claim = await reserveExpiryPublicationConsumerClaim(
+      dependencies.episodes,
+      queuedHint,
+      dependencies.gate,
+    );
+    if (claim.status !== "claim_acquired" && claim.status !== "claim_resumed") {
+      return null;
+    }
+
+    // reserveExpiryPublicationConsumerClaim validates this untrusted hint first.
+    const envelope = queuedHint as ExpiryPublicationEnvelope;
+    const accountFingerprint = dependencies.resolveAccountFingerprint(envelope.bankCode);
+    if (!accountFingerprint) {
+      await dependencies.episodes.markConsumerResolved(envelope, claimToken(envelope));
+      return null;
+    }
+
+    return dependencies.ingest({
+      data: {
+        runId: envelope.runId,
+        bankId: envelope.bankCode,
+        expiredEventId: envelope.expiredEventId,
+        accountFingerprint,
+      },
+    });
+  };
+
+}
+function claimToken(envelope: ExpiryPublicationEnvelope): string {
+  return createHash("sha256")
+    .update(JSON.stringify([envelope.bankCode, envelope.expiredEventId, envelope.runId, envelope.token]))
+    .digest("hex");
+}

--- a/src/worker/expiry-runtime.integration.test.ts
+++ b/src/worker/expiry-runtime.integration.test.ts
@@ -3,7 +3,7 @@
  *
  * This suite is skipped unless BOTH dedicated test-service URLs are supplied:
  *
- *   RD_SYNC_TEST_DATABASE_URL="postgresql://..." RD_SYNC_TEST_REDIS_URL="redis://..." pnpm test -- src/worker/expiry-runtime.integration.test.ts
+ *   RD_SYNC_REQUIRE_INTEGRATION=true RD_SYNC_TEST_DATABASE_URL="postgresql://..." RD_SYNC_TEST_REDIS_URL="redis://..." pnpm test -- src/worker/expiry-runtime.integration.test.ts
  *
  * It uses a UUID queue and deletes only its own database rows and Redis queue.
  * Do not point either variable at development or production infrastructure.
@@ -24,17 +24,21 @@ import { observeExpiryPublicationJob, scheduleExpiryPublicationJob } from "../mo
 const TEST_DATABASE_URL = process.env.RD_SYNC_TEST_DATABASE_URL;
 const TEST_REDIS_URL = process.env.RD_SYNC_TEST_REDIS_URL;
 const RUN_INTEGRATION = Boolean(TEST_DATABASE_URL && TEST_REDIS_URL);
+const REQUIRE_INTEGRATION = process.env.RD_SYNC_REQUIRE_INTEGRATION === "true";
+const WORKER_READY_TIMEOUT_MS = 5_000;
+if (REQUIRE_INTEGRATION && !RUN_INTEGRATION) {
+  throw new Error("RD_SYNC_REQUIRE_INTEGRATION=true requires RD_SYNC_TEST_DATABASE_URL and RD_SYNC_TEST_REDIS_URL");
+}
 const queueName = `expiry-runtime-integration-${randomUUID()}`;
 const bankCode = `runtime-${randomUUID()}`;
 const expiredEventId = `event-${randomUUID()}`;
 const runId = createExpiredSessionRunId(bankCode, expiredEventId);
-const publicationToken = `publication-${randomUUID()}`;
 const manualExpiredEventId = `manual-${randomUUID()}`;
 const manualResolutionId = `resolution-${randomUUID()}`;
 const manualOutboxId = `outbox-${randomUUID()}`;
-const expiryAuditId = `bank-session-bank_session.expired:${bankCode}:${expiredEventId}`;
-const terminalAuditId = `bank-session-expiry-terminal:${bankCode}:${expiredEventId}:${runId}`;
-const manualAuditId = `bank-autologin-manual-recovery-resolved:${manualResolutionId}`;
+const expiryAuditWhere = { action: "bank_session.expired", target: "bank_session", metadata: { path: ["expiredEventId"], equals: expiredEventId } } satisfies Prisma.AuditEventWhereInput;
+const terminalAuditWhere = { target: "bank_session_expiry_episode", targetId: `${bankCode}:${expiredEventId}:${runId}` } satisfies Prisma.AuditEventWhereInput;
+const manualAuditWhere = { action: "bank_autologin.manual_recovery_resolved", target: "manual_recovery_resolution", targetId: manualResolutionId } satisfies Prisma.AuditEventWhereInput;
 let prisma: PrismaClient | undefined;
 let Queue: typeof import("bullmq").Queue;
 let Worker: typeof import("bullmq").Worker;
@@ -65,9 +69,7 @@ describe.skipIf(!RUN_INTEGRATION)("expiry runtime integration (requires dedicate
       await cleanupQueue.obliterate({ force: true }).catch(() => undefined);
       await cleanupQueue.close().catch(() => undefined);
     }
-    await prisma?.auditEvent.deleteMany({
-      where: { id: { in: [expiryAuditId, terminalAuditId, manualAuditId] } },
-    });
+    await prisma?.auditEvent.deleteMany({ where: { OR: [expiryAuditWhere, terminalAuditWhere, manualAuditWhere] } });
     await prisma?.manualRecoveryResolutionAuditOutbox.deleteMany({ where: { id: manualOutboxId } });
     await prisma?.manualRecoveryResolution.deleteMany({ where: { id: manualResolutionId } });
     await prisma?.bankSessionExpiryEpisode.deleteMany({ where: { bankCode } });
@@ -101,14 +103,17 @@ describe.skipIf(!RUN_INTEGRATION)("expiry runtime integration (requires dedicate
     const timers: number[] = [];
     const clearedTimers: number[] = [];
     const ownersSeen = new Set<string>();
+    const proposedTokens = new Map<string, string>();
     const alerts: Array<{ safeSummary: string }> = [];
-    const tickGate: { wait?: Promise<void>; release?: () => void } = {};
+    const tickGate: { wait?: Promise<void>; release?: () => void; signalReplicaATick?: () => void } = {};
     const localTickStats = new Map<string, { calls: number; active: number; max: number }>();
     let releaseClaimBarrier!: () => void;
     const claimBarrier = new Promise<void>((resolve) => { releaseClaimBarrier = resolve; });
 
     function replica(owner: string, queue: import("bullmq").Queue): ExpiryRuntime {
       const stats = { calls: 0, active: 0, max: 0 };
+      const proposedToken = `publication-${owner}-${randomUUID()}`;
+      proposedTokens.set(owner, proposedToken);
       localTickStats.set(owner, stats);
       const publisher = {
         schedule: (envelope: { bankCode: string; expiredEventId: string; runId: string; token: string }) =>
@@ -121,6 +126,7 @@ describe.skipIf(!RUN_INTEGRATION)("expiry runtime integration (requires dedicate
           stats.active += 1;
           stats.max = Math.max(stats.max, stats.active);
           try {
+            if (owner === "replica-a") tickGate.signalReplicaATick?.();
             await tickGate.wait;
             return { status: "expired", checkedAt: new Date().toISOString(), safeSummary: "Synthetic expiry" };
           } finally {
@@ -135,7 +141,7 @@ describe.skipIf(!RUN_INTEGRATION)("expiry runtime integration (requires dedicate
           bankCode,
           episodes,
           createExpiredEventId: () => expiredEventId,
-          publish: (episode) => publishExpiryEpisode(episodes, episode, publicationToken, publisher).then(() => undefined),
+          publish: (episode) => publishExpiryEpisode(episodes, episode, proposedToken, publisher).then(() => undefined),
         },
       });
       return createExpiryRuntime(
@@ -196,10 +202,12 @@ describe.skipIf(!RUN_INTEGRATION)("expiry runtime integration (requires dedicate
       expiredEventId,
       runId,
       publicationState: "published",
-      publicationClaimToken: publicationToken,
+      publicationClaimToken: expect.any(String),
     });
-    expect(await prisma.auditEvent.count({ where: { id: expiryAuditId } })).toBe(1);
-    expect(await queueA.getJob(runId)).toBeDefined();
+    expect([...proposedTokens.values()]).toEqual(expect.arrayContaining([episode!.publicationClaimToken!]));
+    expect(new Set(proposedTokens.values())).toHaveLength(2);
+    expect(await prisma.auditEvent.count({ where: expiryAuditWhere })).toBe(1);
+    expect((await queueA.getJob(runId))?.data.token).toBe(episode!.publicationClaimToken);
 
     worker = new Worker(
       queueName,
@@ -209,7 +217,11 @@ describe.skipIf(!RUN_INTEGRATION)("expiry runtime integration (requires dedicate
       },
       { connection, concurrency: 1 },
     );
-    await new Promise<void>((resolve) => worker!.once("ready", resolve));
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error(`Timed out after ${WORKER_READY_TIMEOUT_MS}ms waiting for BullMQ worker readiness`)), WORKER_READY_TIMEOUT_MS);
+      worker!.once("ready", () => { clearTimeout(timeout); resolve(); });
+      worker!.once("error", (error) => { clearTimeout(timeout); reject(error); });
+    });
     await new Promise<void>((resolve, reject) => {
       const timeout = setTimeout(() => reject(new Error("Timed out waiting for synthetic terminal failure")), 5_000);
       worker!.on("failed", (job) => {
@@ -238,18 +250,19 @@ describe.skipIf(!RUN_INTEGRATION)("expiry runtime integration (requires dedicate
     expect(await prisma.manualRecoveryResolutionAuditOutbox.count({
       where: { id: manualOutboxId, state: "delivered" },
     })).toBe(1);
-    expect(await prisma.auditEvent.count({ where: { id: manualAuditId } })).toBe(1);
-    expect(await prisma.auditEvent.count({ where: { id: terminalAuditId } })).toBe(1);
+    expect(await prisma.auditEvent.count({ where: manualAuditWhere })).toBe(1);
+    expect(await prisma.auditEvent.count({ where: terminalAuditWhere })).toBe(1);
     expect(alerts.filter((alert) => alert.safeSummary === "Automatic session recovery requires administrative review")).toHaveLength(1);
     expect(JSON.stringify(alerts)).not.toMatch(/token|https?:\/\/|synthetic publication failure/i);
 
     tickGate.wait = new Promise<void>((resolve) => { tickGate.release = resolve; });
+    const replicaATickEntered = new Promise<void>((resolve) => { tickGate.signalReplicaATick = resolve; });
     const replicaAStats = localTickStats.get("replica-a")!;
     const callsBeforeFinalTick = replicaAStats.calls;
     const firstTick = runtimeA.tick();
-    runtimeA.tick();
+    void runtimeA.tick();
     const finalTick = runtimeB.tick();
-    await Promise.resolve();
+    await replicaATickEntered;
     expect(replicaAStats.calls).toBe(callsBeforeFinalTick + 1);
     expect(replicaAStats.max).toBe(1);
     const stoppingA = runtimeA.shutdown();

--- a/src/worker/expiry-runtime.integration.test.ts
+++ b/src/worker/expiry-runtime.integration.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Real PostgreSQL + Redis two-replica runtime proof.
+ *
+ * This suite is skipped unless BOTH dedicated test-service URLs are supplied:
+ *
+ *   RD_SYNC_TEST_DATABASE_URL="postgresql://..." RD_SYNC_TEST_REDIS_URL="redis://..." pnpm test -- src/worker/expiry-runtime.integration.test.ts
+ *
+ * It uses a UUID queue and deletes only its own database rows and Redis queue.
+ * Do not point either variable at development or production infrastructure.
+ */
+import { randomUUID } from "node:crypto";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { PrismaPg } from "@prisma/adapter-pg";
+import type { PrismaClient, Prisma } from "../generated/prisma/client";
+import type { AuditSink } from "../modules/audit";
+import { createBankSessionMonitor, createExpiredSessionRunId } from "../modules/bank-sessions";
+import { publishExpiryEpisode } from "../modules/bank-sessions/expiry-episodes";
+import { PrismaBankSessionExpiryEpisodeRepository } from "../modules/persistence/prisma-bank-session-expiry-episode-repository";
+import { PrismaManualRecoveryResolutionAuditOutboxRepository } from "../modules/persistence/prisma-manual-recovery-resolution-audit-outbox-repository";
+import { buildRedisConnectionOptions } from "./queues/bullmq-queue";
+import { createExpiryRuntime, type ExpiryRuntime } from "./expiry-runtime";
+import { observeExpiryPublicationJob, scheduleExpiryPublicationJob } from "../modules/bank-sessions/expiry-publication";
+
+const TEST_DATABASE_URL = process.env.RD_SYNC_TEST_DATABASE_URL;
+const TEST_REDIS_URL = process.env.RD_SYNC_TEST_REDIS_URL;
+const RUN_INTEGRATION = Boolean(TEST_DATABASE_URL && TEST_REDIS_URL);
+const queueName = `expiry-runtime-integration-${randomUUID()}`;
+const bankCode = `runtime-${randomUUID()}`;
+const expiredEventId = `event-${randomUUID()}`;
+const runId = createExpiredSessionRunId(bankCode, expiredEventId);
+const publicationToken = `publication-${randomUUID()}`;
+const manualExpiredEventId = `manual-${randomUUID()}`;
+const manualResolutionId = `resolution-${randomUUID()}`;
+const manualOutboxId = `outbox-${randomUUID()}`;
+const expiryAuditId = `bank-session-bank_session.expired:${bankCode}:${expiredEventId}`;
+const terminalAuditId = `bank-session-expiry-terminal:${bankCode}:${expiredEventId}:${runId}`;
+const manualAuditId = `bank-autologin-manual-recovery-resolved:${manualResolutionId}`;
+let prisma: PrismaClient | undefined;
+let Queue: typeof import("bullmq").Queue;
+let Worker: typeof import("bullmq").Worker;
+let queueA: import("bullmq").Queue | undefined;
+let queueB: import("bullmq").Queue | undefined;
+let worker: import("bullmq").Worker | undefined;
+const closedQueues = new Set<import("bullmq").Queue>();
+const closeCounts = new Map<import("bullmq").Queue, number>();
+
+describe.skipIf(!RUN_INTEGRATION)("expiry runtime integration (requires dedicated PostgreSQL and Redis)", () => {
+  beforeAll(async () => {
+    const prismaModule = await import("../generated/prisma/client");
+    const bullmq = await import("bullmq");
+    Queue = bullmq.Queue;
+    Worker = bullmq.Worker;
+    prisma = new prismaModule.PrismaClient({
+      adapter: new PrismaPg({ connectionString: TEST_DATABASE_URL! }),
+    });
+  });
+
+  afterEach(async () => {
+    await worker?.close().catch(() => undefined);
+    worker = undefined;
+    if (TEST_REDIS_URL) {
+      const cleanupQueue = new Queue(queueName, {
+        connection: buildRedisConnectionOptions(TEST_REDIS_URL),
+      });
+      await cleanupQueue.obliterate({ force: true }).catch(() => undefined);
+      await cleanupQueue.close().catch(() => undefined);
+    }
+    await prisma?.auditEvent.deleteMany({
+      where: { id: { in: [expiryAuditId, terminalAuditId, manualAuditId] } },
+    });
+    await prisma?.manualRecoveryResolutionAuditOutbox.deleteMany({ where: { id: manualOutboxId } });
+    await prisma?.manualRecoveryResolution.deleteMany({ where: { id: manualResolutionId } });
+    await prisma?.bankSessionExpiryEpisode.deleteMany({ where: { bankCode } });
+  });
+
+  afterAll(async () => {
+    await worker?.close().catch(() => undefined);
+    for (const queue of [queueA, queueB]) {
+      if (queue && !closedQueues.has(queue)) await queue.close();
+    }
+    await prisma?.$disconnect();
+  });
+
+  it("elects durable owners, terminal reconciliation, delivery, and graceful shutdown across two replicas", async () => {
+    if (!prisma || !TEST_REDIS_URL) throw new Error("Dedicated integration services are required");
+    const connection = buildRedisConnectionOptions(TEST_REDIS_URL);
+    queueA = new Queue(queueName, { connection });
+    queueB = new Queue(queueName, { connection });
+    const episodes = new PrismaBankSessionExpiryEpisodeRepository(prisma);
+    const outbox = new PrismaManualRecoveryResolutionAuditOutboxRepository(prisma);
+    const auditSink: AuditSink = {
+      async record(event) {
+        await prisma!.auditEvent.upsert({
+          where: { id: event.id },
+          create: { ...event, metadata: (event.metadata as Prisma.InputJsonValue | null) ?? undefined },
+          update: {},
+        });
+      },
+      async list() { return []; },
+    };
+    const timers: number[] = [];
+    const clearedTimers: number[] = [];
+    const ownersSeen = new Set<string>();
+    const alerts: Array<{ safeSummary: string }> = [];
+    const tickGate: { wait?: Promise<void>; release?: () => void } = {};
+    const localTickStats = new Map<string, { calls: number; active: number; max: number }>();
+    let releaseClaimBarrier!: () => void;
+    const claimBarrier = new Promise<void>((resolve) => { releaseClaimBarrier = resolve; });
+
+    function replica(owner: string, queue: import("bullmq").Queue): ExpiryRuntime {
+      const stats = { calls: 0, active: 0, max: 0 };
+      localTickStats.set(owner, stats);
+      const publisher = {
+        schedule: (envelope: { bankCode: string; expiredEventId: string; runId: string; token: string }) =>
+          scheduleExpiryPublicationJob(queue, envelope),
+        observe: (envelope: { runId: string }) => observeExpiryPublicationJob(queue, envelope.runId),
+      };
+      const monitor = createBankSessionMonitor({
+        check: async () => {
+          stats.calls += 1;
+          stats.active += 1;
+          stats.max = Math.max(stats.max, stats.active);
+          try {
+            await tickGate.wait;
+            return { status: "expired", checkedAt: new Date().toISOString(), safeSummary: "Synthetic expiry" };
+          } finally {
+            stats.active -= 1;
+          }
+        },
+        intervalMs: 60_000,
+        alertSink: { notifySessionAttention: async (alert) => { alerts.push(alert); } },
+        auditSink,
+        monitorMode: {
+          mode: "expiry_events",
+          bankCode,
+          episodes,
+          createExpiredEventId: () => expiredEventId,
+          publish: (episode) => publishExpiryEpisode(episodes, episode, publicationToken, publisher).then(() => undefined),
+        },
+      });
+      return createExpiryRuntime(
+        {
+          RD_SYNC_SESSION_MONITOR: "enabled",
+          DATABASE_URL: TEST_DATABASE_URL,
+          RD_SYNC_REDIS_URL: TEST_REDIS_URL,
+        },
+        () => ({
+          monitor,
+          episodes,
+          publisher,
+          auditSink,
+          bankCode,
+          leaseOwner: owner,
+          outbox: {
+            findClaimable: async () => {
+              const candidate = await outbox.findClaimable();
+              if (candidate?.id === manualOutboxId) {
+                ownersSeen.add(owner);
+                if (ownersSeen.size === 2) releaseClaimBarrier();
+                await claimBarrier;
+              }
+              return candidate;
+            },
+            claim: (id, leaseOwner, leaseMs) => outbox.claim(id, leaseOwner, leaseMs),
+            markDelivered: (id, leaseOwner) => outbox.markDelivered(id, leaseOwner),
+            releaseClaim: (id, leaseOwner) => outbox.releaseClaim(id, leaseOwner),
+            inspect: (id) => outbox.inspect(id),
+          },
+          alerts: { notifySessionAttention: async (alert) => { alerts.push(alert); } },
+          schedule: () => {
+            const timer = timers.length + 1;
+            timers.push(timer);
+            return timer;
+          },
+          clearSchedule: (timer) => { clearedTimers.push(timer as number); },
+          close: async () => {
+            if (closedQueues.has(queue)) return;
+            closedQueues.add(queue);
+            closeCounts.set(queue, (closeCounts.get(queue) ?? 0) + 1);
+            await queue.close();
+          },
+        }),
+      );
+    }
+
+    const runtimeA = replica("replica-a", queueA);
+    const runtimeB = replica("replica-b", queueB);
+    runtimeA.start();
+    runtimeB.start();
+    expect(queueA).not.toBe(queueB);
+    expect(timers).toEqual([1, 2]);
+
+    await Promise.all([runtimeA.tick(), runtimeB.tick()]);
+    const episode = await episodes.findByBankCode(bankCode);
+    expect(episode).toMatchObject({
+      expiredEventId,
+      runId,
+      publicationState: "published",
+      publicationClaimToken: publicationToken,
+    });
+    expect(await prisma.auditEvent.count({ where: { id: expiryAuditId } })).toBe(1);
+    expect(await queueA.getJob(runId)).toBeDefined();
+
+    worker = new Worker(
+      queueName,
+      async (job) => {
+        job.discard();
+        throw new Error("synthetic publication failure");
+      },
+      { connection, concurrency: 1 },
+    );
+    await new Promise<void>((resolve) => worker!.once("ready", resolve));
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error("Timed out waiting for synthetic terminal failure")), 5_000);
+      worker!.on("failed", (job) => {
+        if (job?.id === runId) {
+          clearTimeout(timeout);
+          resolve();
+        }
+      });
+    });
+    await expect((await queueA.getJob(runId))?.getState()).resolves.toBe("failed");
+
+    await prisma.manualRecoveryResolution.create({
+      data: {
+        id: manualResolutionId,
+        expiredEventId: manualExpiredEventId,
+        bankCode,
+        runId: `manual-${runId}`,
+        outcome: "resolved_no_retry",
+        reason: "closed_without_retry",
+        operatorId: "operator-integration",
+        auditOutbox: { create: { id: manualOutboxId } },
+      },
+    });
+    await Promise.all([runtimeA.tick(), runtimeB.tick()]);
+    expect(ownersSeen).toEqual(new Set(["replica-a", "replica-b"]));
+    expect(await prisma.manualRecoveryResolutionAuditOutbox.count({
+      where: { id: manualOutboxId, state: "delivered" },
+    })).toBe(1);
+    expect(await prisma.auditEvent.count({ where: { id: manualAuditId } })).toBe(1);
+    expect(await prisma.auditEvent.count({ where: { id: terminalAuditId } })).toBe(1);
+    expect(alerts.filter((alert) => alert.safeSummary === "Automatic session recovery requires administrative review")).toHaveLength(1);
+    expect(JSON.stringify(alerts)).not.toMatch(/token|https?:\/\/|synthetic publication failure/i);
+
+    tickGate.wait = new Promise<void>((resolve) => { tickGate.release = resolve; });
+    const replicaAStats = localTickStats.get("replica-a")!;
+    const callsBeforeFinalTick = replicaAStats.calls;
+    const firstTick = runtimeA.tick();
+    runtimeA.tick();
+    const finalTick = runtimeB.tick();
+    await Promise.resolve();
+    expect(replicaAStats.calls).toBe(callsBeforeFinalTick + 1);
+    expect(replicaAStats.max).toBe(1);
+    const stoppingA = runtimeA.shutdown();
+    const stoppingB = runtimeB.shutdown();
+    let shutdownAComplete = false;
+    void stoppingA.then(() => { shutdownAComplete = true; });
+    await Promise.resolve();
+    expect(shutdownAComplete).toBe(false);
+    expect(new Set(clearedTimers)).toEqual(new Set([1, 2]));
+    tickGate.release?.();
+    await Promise.all([firstTick, finalTick, stoppingA, stoppingB, runtimeA.shutdown(), runtimeB.shutdown()]);
+    expect(new Set(clearedTimers)).toEqual(new Set([1, 2]));
+    expect(closeCounts.get(queueA)).toBe(1);
+    expect(closeCounts.get(queueB)).toBe(1);
+  });
+});

--- a/src/worker/expiry-runtime.integration.test.ts
+++ b/src/worker/expiry-runtime.integration.test.ts
@@ -37,8 +37,8 @@ const manualExpiredEventId = `manual-${randomUUID()}`;
 const manualResolutionId = `resolution-${randomUUID()}`;
 const manualOutboxId = `outbox-${randomUUID()}`;
 const expiryAuditWhere = { action: "bank_session.expired", target: "bank_session", metadata: { path: ["expiredEventId"], equals: expiredEventId } } satisfies Prisma.AuditEventWhereInput;
-const terminalAuditWhere = { target: "bank_session_expiry_episode", targetId: `${bankCode}:${expiredEventId}:${runId}` } satisfies Prisma.AuditEventWhereInput;
-const manualAuditWhere = { action: "bank_autologin.manual_recovery_resolved", target: "manual_recovery_resolution", targetId: manualResolutionId } satisfies Prisma.AuditEventWhereInput;
+const terminalAuditWhere = { action: "bank_autologin.needs_admin_action", target: "bank_session_expiry_episode", AND: [{ metadata: { path: ["expiredEventId"], equals: expiredEventId } }, { metadata: { path: ["runId"], equals: runId } }] } satisfies Prisma.AuditEventWhereInput;
+const manualAuditWhere = { action: "bank_autologin.manual_recovery_resolved", target: "manual_recovery_resolution", AND: [{ metadata: { path: ["expiredEventId"], equals: manualExpiredEventId } }, { metadata: { path: ["runId"], equals: `manual-${runId}` } }] } satisfies Prisma.AuditEventWhereInput;
 let prisma: PrismaClient | undefined;
 let Queue: typeof import("bullmq").Queue;
 let Worker: typeof import("bullmq").Worker;
@@ -105,8 +105,8 @@ describe.skipIf(!RUN_INTEGRATION)("expiry runtime integration (requires dedicate
     const ownersSeen = new Set<string>();
     const proposedTokens = new Map<string, string>();
     const alerts: Array<{ safeSummary: string }> = [];
-    const tickGate: { wait?: Promise<void>; release?: () => void; signalReplicaATick?: () => void } = {};
-    const localTickStats = new Map<string, { calls: number; active: number; max: number }>();
+    const runtimeTickGate: { wait?: Promise<void>; release?: () => void; signalReplicaATick?: () => void } = {};
+    const runtimeTickStats = new Map<string, { calls: number; active: number; max: number }>();
     let releaseClaimBarrier!: () => void;
     const claimBarrier = new Promise<void>((resolve) => { releaseClaimBarrier = resolve; });
 
@@ -114,7 +114,7 @@ describe.skipIf(!RUN_INTEGRATION)("expiry runtime integration (requires dedicate
       const stats = { calls: 0, active: 0, max: 0 };
       const proposedToken = `publication-${owner}-${randomUUID()}`;
       proposedTokens.set(owner, proposedToken);
-      localTickStats.set(owner, stats);
+      runtimeTickStats.set(owner, stats);
       const publisher = {
         schedule: (envelope: { bankCode: string; expiredEventId: string; runId: string; token: string }) =>
           scheduleExpiryPublicationJob(queue, envelope),
@@ -122,16 +122,7 @@ describe.skipIf(!RUN_INTEGRATION)("expiry runtime integration (requires dedicate
       };
       const monitor = createBankSessionMonitor({
         check: async () => {
-          stats.calls += 1;
-          stats.active += 1;
-          stats.max = Math.max(stats.max, stats.active);
-          try {
-            if (owner === "replica-a") tickGate.signalReplicaATick?.();
-            await tickGate.wait;
-            return { status: "expired", checkedAt: new Date().toISOString(), safeSummary: "Synthetic expiry" };
-          } finally {
-            stats.active -= 1;
-          }
+          return { status: "expired", checkedAt: new Date().toISOString(), safeSummary: "Synthetic expiry" };
         },
         intervalMs: 60_000,
         alertSink: { notifySessionAttention: async (alert) => { alerts.push(alert); } },
@@ -144,6 +135,20 @@ describe.skipIf(!RUN_INTEGRATION)("expiry runtime integration (requires dedicate
           publish: (episode) => publishExpiryEpisode(episodes, episode, proposedToken, publisher).then(() => undefined),
         },
       });
+      const runtimeMonitor = {
+        async tick() {
+          stats.calls += 1;
+          stats.active += 1;
+          stats.max = Math.max(stats.max, stats.active);
+          try {
+            if (owner === "replica-a") runtimeTickGate.signalReplicaATick?.();
+            await runtimeTickGate.wait;
+            return await monitor.tick();
+          } finally {
+            stats.active -= 1;
+          }
+        },
+      };
       return createExpiryRuntime(
         {
           RD_SYNC_SESSION_MONITOR: "enabled",
@@ -151,7 +156,7 @@ describe.skipIf(!RUN_INTEGRATION)("expiry runtime integration (requires dedicate
           RD_SYNC_REDIS_URL: TEST_REDIS_URL,
         },
         () => ({
-          monitor,
+          monitor: runtimeMonitor,
           episodes,
           publisher,
           auditSink,
@@ -252,12 +257,22 @@ describe.skipIf(!RUN_INTEGRATION)("expiry runtime integration (requires dedicate
     })).toBe(1);
     expect(await prisma.auditEvent.count({ where: manualAuditWhere })).toBe(1);
     expect(await prisma.auditEvent.count({ where: terminalAuditWhere })).toBe(1);
+    await prisma.auditEvent.create({
+      data: {
+        id: `semantic-duplicate-${randomUUID()}`,
+        action: "bank_autologin.manual_recovery_resolved",
+        target: "manual_recovery_resolution",
+        targetId: `duplicate-${manualResolutionId}`,
+        metadata: { bankCode, expiredEventId: manualExpiredEventId, runId: `manual-${runId}` },
+      },
+    });
+    expect(await prisma.auditEvent.count({ where: manualAuditWhere })).toBe(2);
     expect(alerts.filter((alert) => alert.safeSummary === "Automatic session recovery requires administrative review")).toHaveLength(1);
     expect(JSON.stringify(alerts)).not.toMatch(/token|https?:\/\/|synthetic publication failure/i);
 
-    tickGate.wait = new Promise<void>((resolve) => { tickGate.release = resolve; });
-    const replicaATickEntered = new Promise<void>((resolve) => { tickGate.signalReplicaATick = resolve; });
-    const replicaAStats = localTickStats.get("replica-a")!;
+    runtimeTickGate.wait = new Promise<void>((resolve) => { runtimeTickGate.release = resolve; });
+    const replicaATickEntered = new Promise<void>((resolve) => { runtimeTickGate.signalReplicaATick = resolve; });
+    const replicaAStats = runtimeTickStats.get("replica-a")!;
     const callsBeforeFinalTick = replicaAStats.calls;
     const firstTick = runtimeA.tick();
     void runtimeA.tick();
@@ -272,7 +287,7 @@ describe.skipIf(!RUN_INTEGRATION)("expiry runtime integration (requires dedicate
     await Promise.resolve();
     expect(shutdownAComplete).toBe(false);
     expect(new Set(clearedTimers)).toEqual(new Set([1, 2]));
-    tickGate.release?.();
+    runtimeTickGate.release?.();
     await Promise.all([firstTick, finalTick, stoppingA, stoppingB, runtimeA.shutdown(), runtimeB.shutdown()]);
     expect(new Set(clearedTimers)).toEqual(new Set([1, 2]));
     expect(closeCounts.get(queueA)).toBe(1);

--- a/src/worker/expiry-runtime.test.ts
+++ b/src/worker/expiry-runtime.test.ts
@@ -125,6 +125,15 @@ describe("expiry runtime", () => {
     expect(outbox.markDelivered).toHaveBeenCalledOnce();
   });
 
+  it("limits manual recovery audit deliveries per tick", async () => {
+    const outbox = {
+      findClaimable: vi.fn().mockResolvedValue({ id: "outbox", resolution: { id: "resolution", bankCode: "popular", expiredEventId: "event", runId: "run", outcome: "resolved_no_retry" as const, reason: "closed_without_retry" as const, operatorId: "admin", resolvedAt: new Date() } }),
+      claim: vi.fn().mockResolvedValue(true), markDelivered: vi.fn().mockResolvedValue(true), releaseClaim: vi.fn(), inspect: vi.fn(),
+    };
+    await createExpiryRuntime(enabled, () => dependencies({ outbox })).tick();
+    expect(outbox.markDelivered).toHaveBeenCalledTimes(100);
+  });
+
   it("shares in-flight ticks and closes owned resources exactly once on shutdown", async () => {
     let release!: () => void;
     const pending = new Promise<void>((resolve) => { release = resolve; });
@@ -137,6 +146,21 @@ describe("expiry runtime", () => {
     release();
     await Promise.all([first, second, stopping, runtime.shutdown()]);
     expect(deps.monitor.tick).toHaveBeenCalledOnce();
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("waits for a failing in-flight tick but fulfills shutdown", async () => {
+    let reject!: (reason: Error) => void;
+    const failure = new Error("monitor failed");
+    const pending = new Promise<void>((_, rejectPending) => { reject = rejectPending; });
+    const close = vi.fn().mockResolvedValue(undefined);
+    const runtime = createExpiryRuntime(enabled, () => dependencies({ monitor: { tick: vi.fn().mockReturnValue(pending) }, close }));
+    const tick = runtime.tick();
+    const stopping = runtime.shutdown();
+    reject(failure);
+    await expect(tick).rejects.toBe(failure);
+    await expect(stopping).resolves.toBeUndefined();
+    await expect(runtime.shutdown()).resolves.toBeUndefined();
     expect(close).toHaveBeenCalledOnce();
   });
 });

--- a/src/worker/expiry-runtime.test.ts
+++ b/src/worker/expiry-runtime.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ExpiryRuntimeDependencies } from "./expiry-runtime";
+import { createExpiryRuntime } from "./expiry-runtime";
+
+const enabled = {
+  RD_SYNC_SESSION_MONITOR: "enabled",
+  DATABASE_URL: "postgres://test",
+  RD_SYNC_REDIS_URL: "redis://test",
+};
+const episode = {
+  bankCode: "popular",
+  expiredEventId: "event-1",
+  runId: "run-1",
+  publicationClaimToken: "token",
+  publicationState: "published" as const,
+};
+
+function dependencies(overrides: Partial<ExpiryRuntimeDependencies> = {}): ExpiryRuntimeDependencies {
+  return {
+    monitor: { tick: vi.fn().mockResolvedValue(undefined) },
+    episodes: {
+      findByBankCode: vi.fn().mockResolvedValue(episode),
+      reconcileTerminalFailure: vi.fn()
+        .mockResolvedValueOnce({ status: "reconciled", operatorSignal: "safe" })
+        .mockResolvedValue({ status: "already_reconciled", operatorSignal: "safe" }),
+    },
+    publisher: { observe: vi.fn().mockResolvedValue("failed") },
+    outbox: {
+      findClaimable: vi.fn().mockResolvedValue(null),
+      claim: vi.fn(),
+      markDelivered: vi.fn(),
+      releaseClaim: vi.fn(),
+      inspect: vi.fn(),
+    },
+    auditSink: { record: vi.fn(), list: vi.fn() },
+    alerts: { notifySessionAttention: vi.fn().mockResolvedValue(undefined) },
+    bankCode: "popular",
+    leaseOwner: "replica-a",
+    ...overrides,
+  };
+}
+
+describe("expiry runtime", () => {
+  it("is default-off without constructing runtime effects", async () => {
+    const create = vi.fn();
+    const runtime = createExpiryRuntime({}, create);
+    runtime.start();
+    await runtime.tick();
+    await runtime.shutdown();
+    expect(runtime.enabled).toBe(false);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("fails enabled startup before construction when configuration is missing", () => {
+    const create = vi.fn();
+    expect(() => createExpiryRuntime({ RD_SYNC_SESSION_MONITOR: "enabled" }, create))
+      .toThrow("DATABASE_URL");
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("leaves unavailable checks without an episode unobserved", async () => {
+    const deps = dependencies({
+      episodes: {
+        findByBankCode: vi.fn().mockResolvedValue(null),
+        reconcileTerminalFailure: vi.fn(),
+      },
+    });
+    await createExpiryRuntime(enabled, () => deps).tick();
+    expect(deps.publisher.observe).not.toHaveBeenCalled();
+    expect(deps.episodes.reconcileTerminalFailure).not.toHaveBeenCalled();
+  });
+
+  it("observes terminal publication once and sends only the fixed safe winner alert", async () => {
+    const notifySessionAttention = vi.fn().mockResolvedValue(undefined);
+    const deps = dependencies({ alerts: { notifySessionAttention } });
+    const runtime = createExpiryRuntime(enabled, () => deps);
+    await runtime.tick();
+    await runtime.tick();
+    expect(deps.publisher.observe).toHaveBeenCalledTimes(2);
+    expect(deps.episodes.reconcileTerminalFailure).toHaveBeenCalledTimes(2);
+    expect(deps.alerts.notifySessionAttention).toHaveBeenCalledOnce();
+    expect(deps.alerts.notifySessionAttention).toHaveBeenCalledWith({
+      status: "expired",
+      safeSummary: "Automatic session recovery requires administrative review",
+      checkedAt: expect.any(String),
+    });
+    expect(JSON.stringify(notifySessionAttention.mock.calls)).not.toContain("token");
+  });
+
+  it("rejects unsafe observations without durable terminal state or alerts", async () => {
+    const deps = dependencies({
+      publisher: { observe: vi.fn().mockRejectedValue(new Error("redis://secret")) },
+    });
+    await createExpiryRuntime(enabled, () => deps).tick();
+    expect(deps.episodes.reconcileTerminalFailure).not.toHaveBeenCalled();
+    expect(deps.alerts.notifySessionAttention).not.toHaveBeenCalled();
+  });
+
+  it("drains one leased audit delivery and lets the repository elect replicas", async () => {
+    const outbox = {
+      findClaimable: vi.fn()
+        .mockResolvedValueOnce({
+          id: "outbox",
+          resolution: {
+            id: "resolution",
+            bankCode: "popular",
+            expiredEventId: "event",
+            runId: "run",
+            outcome: "resolved_no_retry" as const,
+            reason: "closed_without_retry" as const,
+            operatorId: "admin",
+            resolvedAt: new Date(),
+          },
+        })
+        .mockResolvedValue(null),
+      claim: vi.fn().mockResolvedValue(true),
+      markDelivered: vi.fn().mockResolvedValue(true),
+      releaseClaim: vi.fn(),
+      inspect: vi.fn(),
+    };
+    const deps = dependencies({ outbox });
+    await createExpiryRuntime(enabled, () => deps).tick();
+    expect(outbox.claim).toHaveBeenCalledWith("outbox", "replica-a", 30_000);
+    expect(outbox.markDelivered).toHaveBeenCalledOnce();
+  });
+
+  it("shares in-flight ticks and closes owned resources exactly once on shutdown", async () => {
+    let release!: () => void;
+    const pending = new Promise<void>((resolve) => { release = resolve; });
+    const close = vi.fn().mockResolvedValue(undefined);
+    const deps = dependencies({ monitor: { tick: vi.fn().mockReturnValue(pending) }, close });
+    const runtime = createExpiryRuntime(enabled, () => deps);
+    const first = runtime.tick();
+    const second = runtime.tick();
+    const stopping = runtime.shutdown();
+    release();
+    await Promise.all([first, second, stopping, runtime.shutdown()]);
+    expect(deps.monitor.tick).toHaveBeenCalledOnce();
+    expect(close).toHaveBeenCalledOnce();
+  });
+});

--- a/src/worker/expiry-runtime.ts
+++ b/src/worker/expiry-runtime.ts
@@ -20,6 +20,7 @@ import type { AdminAlertSink } from "./queues";
 type Timer = ReturnType<typeof setInterval> | number;
 const INTERVAL_MS = 60_000;
 const LEASE_MS = 30_000;
+const MAX_MANUAL_RECOVERY_AUDIT_DELIVERIES_PER_TICK = 100;
 const TERMINAL_ALERT = "Automatic session recovery requires administrative review";
 
 export interface ExpiryRuntime {
@@ -97,7 +98,7 @@ function createEnabledRuntime(deps: ExpiryRuntimeDependencies): ExpiryRuntime {
   async function tickOnce(): Promise<void> {
     await deps.monitor.tick();
     await observeTerminalEpisode();
-    for (let delivered = true; delivered;) {
+    for (let delivered = true, deliveries = 0; delivered && deliveries < MAX_MANUAL_RECOVERY_AUDIT_DELIVERIES_PER_TICK; deliveries += 1) {
       delivered = await deliverManualRecoveryResolutionAudit(
         deps.outbox,
         deps.auditSink,
@@ -122,6 +123,8 @@ function createEnabledRuntime(deps: ExpiryRuntimeDependencies): ExpiryRuntime {
         timer = undefined;
         try {
           await inFlight;
+        } catch {
+          // tick() retains its failure; shutdown only waits for the resource-safe boundary.
         } finally {
           await deps.close?.();
         }

--- a/src/worker/expiry-runtime.ts
+++ b/src/worker/expiry-runtime.ts
@@ -1,0 +1,177 @@
+import { randomUUID } from "node:crypto";
+import { Queue } from "bullmq";
+
+import { popularScraperProfile } from "../modules/bank-adapters/popular";
+import { createBankSessionMonitor, createCdpSessionChecker, type BankSessionMonitor } from "../modules/bank-sessions";
+import { deliverManualRecoveryResolutionAudit, type ManualRecoveryResolutionAuditOutboxRepository } from "../modules/bank-sessions/manual-recovery-resolution-audit-delivery";
+import { reconcileExpiryTerminalObservation, type ExpiryTerminalReconciliationRepository } from "../modules/bank-sessions/expiry-terminal-reconciliation";
+import { observeExpiryPublicationJob, scheduleExpiryPublicationJob, type ExpiryPublicationQueue } from "../modules/bank-sessions/expiry-publication";
+import { publishExpiryEpisode, type BankSessionExpiryEpisode, type BankSessionExpiryEpisodeRepository, type ExpiryPublicationPublisher } from "../modules/bank-sessions/expiry-episodes";
+import type { AuditSink } from "../modules/audit";
+import { PrismaAuditSink } from "../modules/persistence/prisma-audit-sink";
+import { PrismaBankSessionExpiryEpisodeRepository } from "../modules/persistence/prisma-bank-session-expiry-episode-repository";
+import { PrismaManualRecoveryResolutionAuditOutboxRepository } from "../modules/persistence/prisma-manual-recovery-resolution-audit-outbox-repository";
+import { getPrismaClient } from "../modules/persistence/prisma-client";
+import { resolveDefaultAlertSink } from "./alerts/email-alert-sink";
+import { buildRedisConnectionOptions } from "./queues/bullmq-queue";
+import { resolveBankBrowserEnv } from "./scraper/browser-runtime";
+import type { AdminAlertSink } from "./queues";
+
+type Timer = ReturnType<typeof setInterval> | number;
+const INTERVAL_MS = 60_000;
+const LEASE_MS = 30_000;
+const TERMINAL_ALERT = "Automatic session recovery requires administrative review";
+
+export interface ExpiryRuntime {
+  readonly enabled: boolean;
+  tick(): Promise<void>;
+  start(): void;
+  shutdown(): Promise<void>;
+}
+
+export interface ExpiryRuntimeDependencies {
+  monitor: Pick<BankSessionMonitor, "tick">;
+  episodes: Pick<BankSessionExpiryEpisodeRepository, "findByBankCode"> & ExpiryTerminalReconciliationRepository;
+  publisher: Pick<ExpiryPublicationPublisher, "observe">;
+  outbox: ManualRecoveryResolutionAuditOutboxRepository;
+  auditSink: AuditSink;
+  alerts: Pick<AdminAlertSink, "notifySessionAttention">;
+  bankCode: string;
+  leaseOwner: string;
+  close?(): Promise<void>;
+  schedule?(callback: () => void, intervalMs: number): Timer;
+  clearSchedule?(timer: Timer): void;
+  clock?(): Date;
+}
+
+export function createExpiryRuntime(
+  env: Record<string, string | undefined>,
+  create: () => ExpiryRuntimeDependencies,
+): ExpiryRuntime {
+  if (env.RD_SYNC_SESSION_MONITOR !== "enabled") return disabledRuntime;
+  if (!env.DATABASE_URL || !env.RD_SYNC_REDIS_URL) {
+    throw new Error("Expiry runtime requires DATABASE_URL and RD_SYNC_REDIS_URL");
+  }
+  return createEnabledRuntime(create());
+}
+
+const disabledRuntime: ExpiryRuntime = {
+  enabled: false,
+  async tick() {},
+  start() {},
+  async shutdown() {},
+};
+
+function createEnabledRuntime(deps: ExpiryRuntimeDependencies): ExpiryRuntime {
+  const schedule = deps.schedule ?? setInterval;
+  const clearSchedule = deps.clearSchedule ?? clearInterval;
+  const clock = deps.clock ?? (() => new Date());
+  let timer: Timer | undefined;
+  let inFlight: Promise<void> | undefined;
+  let shutdown: Promise<void> | undefined;
+
+  async function observeTerminalEpisode(): Promise<void> {
+    const episode = await deps.episodes.findByBankCode(deps.bankCode);
+    if (!episode || episode.publicationState !== "published" || !episode.publicationClaimToken) return;
+    const envelope = {
+      bankCode: episode.bankCode,
+      expiredEventId: episode.expiredEventId,
+      runId: episode.runId,
+      token: episode.publicationClaimToken,
+    };
+    const observation = await reconcileExpiryTerminalObservation(
+      () => deps.publisher.observe(envelope),
+      deps.episodes,
+      envelope,
+      clock,
+    );
+    if (observation.kind === "terminal" && observation.result.status === "reconciled") {
+      await deps.alerts.notifySessionAttention({
+        status: "expired",
+        safeSummary: TERMINAL_ALERT,
+        checkedAt: clock().toISOString(),
+      });
+    }
+  }
+
+  async function tickOnce(): Promise<void> {
+    await deps.monitor.tick();
+    await observeTerminalEpisode();
+    for (let delivered = true; delivered;) {
+      delivered = await deliverManualRecoveryResolutionAudit(
+        deps.outbox,
+        deps.auditSink,
+        deps.leaseOwner,
+        LEASE_MS,
+      );
+    }
+  }
+
+  const runtime: ExpiryRuntime = {
+    enabled: true,
+    tick() {
+      if (!inFlight) inFlight = tickOnce().finally(() => { inFlight = undefined; });
+      return inFlight;
+    },
+    start() {
+      if (!timer) timer = schedule(() => { void runtime.tick().catch(() => undefined); }, INTERVAL_MS);
+    },
+    shutdown() {
+      if (!shutdown) shutdown = (async () => {
+        if (timer) clearSchedule(timer);
+        timer = undefined;
+        try {
+          await inFlight;
+        } finally {
+          await deps.close?.();
+        }
+      })();
+      return shutdown;
+    },
+  };
+  return runtime;
+}
+
+export function createDefaultExpiryRuntime(
+  env: Record<string, string | undefined> = process.env,
+): ExpiryRuntime {
+  return createExpiryRuntime(env, () => {
+    const prisma = getPrismaClient();
+    const episodes = new PrismaBankSessionExpiryEpisodeRepository(prisma);
+    const queue = new Queue("bank-transaction-ingestion", {
+      connection: buildRedisConnectionOptions(env.RD_SYNC_REDIS_URL!),
+    });
+    const publicationQueue = queue as unknown as ExpiryPublicationQueue;
+    const publisher: ExpiryPublicationPublisher = {
+      schedule: (job) => scheduleExpiryPublicationJob(publicationQueue, job),
+      observe: (job) => observeExpiryPublicationJob(publicationQueue, job.runId),
+    };
+    const alerts = resolveDefaultAlertSink();
+    const bankCode = popularScraperProfile.bankId;
+    return {
+      bankCode,
+      episodes,
+      publisher,
+      outbox: new PrismaManualRecoveryResolutionAuditOutboxRepository(prisma),
+      auditSink: new PrismaAuditSink(),
+      alerts,
+      leaseOwner: `expiry-runtime:${randomUUID()}`,
+      close: () => queue.close(),
+      monitor: createBankSessionMonitor({
+        check: createCdpSessionChecker({
+          cdpUrl: resolveBankBrowserEnv(bankCode, env).cdpUrl,
+        }).check,
+        alertSink: alerts,
+        auditSink: new PrismaAuditSink(),
+        intervalMs: INTERVAL_MS,
+        monitorMode: {
+          mode: "expiry_events",
+          bankCode,
+          episodes,
+          publish: (episode: BankSessionExpiryEpisode) =>
+            publishExpiryEpisode(episodes, episode, randomUUID(), publisher).then(() => undefined),
+        },
+      }),
+    };
+  });
+}

--- a/src/worker/ingestion-worker-factory.test.ts
+++ b/src/worker/ingestion-worker-factory.test.ts
@@ -7,6 +7,7 @@ import {
   type WorkerHandle,
   type WorkerJob,
 } from "./ingestion-worker-factory";
+import { expiryPublicationJobName } from "../modules/bank-sessions/expiry-publication";
 import type { IngestionResult } from "./queues/index";
 
 // ---------------------------------------------------------------------------
@@ -70,6 +71,7 @@ const fakeConnection = {
 };
 
 const fakeJob: WorkerJob = {
+  name: INGESTION_QUEUE_NAME,
   data: { runId: "run-worker-1", bankId: "popular", accountFingerprint: "acct-main" },
 };
 
@@ -115,11 +117,31 @@ describe("createIngestionWorker", () => {
     const processor = makeSuccessProcessor();
     createIngestionWorker({ connection: fakeConnection, processor, WorkerCtor: Ctor });
 
-    const result = await instances[0].handler(fakeJob);
+    const result = await instances[0].handler({ ...fakeJob, name: INGESTION_QUEUE_NAME });
 
     expect(processor).toHaveBeenCalledOnce();
     expect(processor).toHaveBeenCalledWith({ data: fakeJob.data });
     expect(result).toEqual(successResult);
+  });
+
+  it("routes only the exact expiry publication job name to its consumer", async () => {
+    const { Ctor, instances } = makeFakeWorkerCtor();
+    const expiryPublicationConsumer = vi.fn(async () => ({ status: "ignored" }));
+    const processor = makeSuccessProcessor();
+    createIngestionWorker({ connection: fakeConnection, processor, expiryPublicationConsumer, WorkerCtor: Ctor });
+
+    await instances[0].handler({ ...fakeJob, name: expiryPublicationJobName });
+
+    expect(expiryPublicationConsumer).toHaveBeenCalledWith(fakeJob.data);
+    expect(processor).not.toHaveBeenCalled();
+  });
+
+  it("fails closed for unknown names and for expiry jobs without a consumer", async () => {
+    const { Ctor, instances } = makeFakeWorkerCtor();
+    createIngestionWorker({ connection: fakeConnection, processor: makeSuccessProcessor(), WorkerCtor: Ctor });
+
+    await expect(instances[0].handler({ ...fakeJob, name: "unknown" })).rejects.toThrow("Unsupported BullMQ job name");
+    await expect(instances[0].handler({ ...fakeJob, name: expiryPublicationJobName })).rejects.toThrow("Unsupported BullMQ job name");
   });
 
   it("the worker handler does NOT swallow an unexpected processor throw", async () => {

--- a/src/worker/ingestion-worker-factory.ts
+++ b/src/worker/ingestion-worker-factory.ts
@@ -6,9 +6,10 @@
  * connection.
  */
 
-import type { IngestionJob, IngestionResult } from "./queues/index";
+import { ingestionJobName, type IngestionJob, type IngestionResult } from "./queues/index";
+import { expiryPublicationJobName } from "../modules/bank-sessions/expiry-publication";
 
-export const INGESTION_QUEUE_NAME = "bank-transaction-ingestion";
+export const INGESTION_QUEUE_NAME = ingestionJobName;
 
 // ---------------------------------------------------------------------------
 // Ports (structural interfaces so tests never import bullmq directly)
@@ -16,6 +17,7 @@ export const INGESTION_QUEUE_NAME = "bank-transaction-ingestion";
 
 /** Minimal BullMQ Job surface the worker handler needs. */
 export interface WorkerJob {
+  name?: string;
   data: IngestionJob["data"];
 }
 
@@ -27,7 +29,7 @@ export interface WorkerHandle {
 /** The constructor signature for a BullMQ Worker (or a test double). */
 export type WorkerConstructor = new (
   queueName: string,
-  handler: (job: WorkerJob) => Promise<IngestionResult>,
+  handler: (job: WorkerJob) => Promise<unknown>,
   options: { connection: unknown; concurrency: number },
 ) => WorkerHandle;
 
@@ -40,6 +42,7 @@ export interface CreateIngestionWorkerOptions {
   connection: { host: string; port: number; password?: string; maxRetriesPerRequest: null };
   /** Ingestion processor — called once per job. */
   processor: (job: IngestionJob) => Promise<IngestionResult>;
+  expiryPublicationConsumer?: (data: unknown) => Promise<unknown>;
   /** How many jobs to process in parallel.  Defaults to 2. */
   concurrency?: number;
   /**
@@ -69,9 +72,14 @@ export function createIngestionWorker(options: CreateIngestionWorkerOptions): Wo
 
   const worker = new WorkerCtor(
     INGESTION_QUEUE_NAME,
-    async (job: WorkerJob): Promise<IngestionResult> => {
-      // Unexpected throws propagate — BullMQ applies attempts/backoff.
-      return options.processor({ data: job.data });
+    async (job: WorkerJob): Promise<unknown> => {
+      if (job.name === INGESTION_QUEUE_NAME) {
+        return options.processor({ data: job.data });
+      }
+      if (job.name === expiryPublicationJobName && options.expiryPublicationConsumer) {
+        return options.expiryPublicationConsumer(job.data);
+      }
+      throw new Error("Unsupported BullMQ job name");
     },
     {
       connection: options.connection,

--- a/src/worker/ingestion-worker.ts
+++ b/src/worker/ingestion-worker.ts
@@ -31,6 +31,7 @@ import { Worker } from "bullmq";
 import { buildRedisConnectionOptions } from "./queues/bullmq-queue";
 import { createIngestionWorker, type WorkerConstructor } from "./ingestion-worker-factory";
 import { createExpiryPublicationConsumer } from "./expiry-publication-consumer";
+import { createDefaultExpiryRuntime } from "./expiry-runtime";
 import { resolveDefaultAlertSink } from "./alerts/email-alert-sink";
 import { bankAdapterRegistry } from "../modules/bank-adapters/registry";
 import { BankAutoLoginConfigRepository } from "../modules/bank-auto-login-config/repository";
@@ -63,6 +64,7 @@ if (!redisUrl) {
   );
   process.exit(1);
 }
+const expiryRuntime = createDefaultExpiryRuntime();
 
 // ---------------------------------------------------------------------------
 // Wire up real dependencies
@@ -160,6 +162,7 @@ const worker = createIngestionWorker({
   // our structural WorkerConstructor port.
   WorkerCtor: Worker as unknown as WorkerConstructor,
 });
+expiryRuntime.start();
 
 console.log("[ingestion-worker] Started. Waiting for jobs on 'bank-transaction-ingestion'...");
 
@@ -174,7 +177,7 @@ const SHUTDOWN_GRACE_MS = 25_000;
 async function shutdown(signal: string): Promise<void> {
   console.log(`[ingestion-worker] ${signal} received — shutting down gracefully (${SHUTDOWN_GRACE_MS}ms timeout)...`);
 
-  const graceful = worker.close();
+  const graceful = Promise.all([worker.close(), expiryRuntime.shutdown()]);
   const timeout = new Promise<void>((resolve) =>
     setTimeout(() => {
       console.warn("[ingestion-worker] Shutdown grace period exceeded — forcing exit.");

--- a/src/worker/ingestion-worker.ts
+++ b/src/worker/ingestion-worker.ts
@@ -30,6 +30,7 @@ import { Worker } from "bullmq";
 
 import { buildRedisConnectionOptions } from "./queues/bullmq-queue";
 import { createIngestionWorker, type WorkerConstructor } from "./ingestion-worker-factory";
+import { createExpiryPublicationConsumer } from "./expiry-publication-consumer";
 import { resolveDefaultAlertSink } from "./alerts/email-alert-sink";
 import { bankAdapterRegistry } from "../modules/bank-adapters/registry";
 import { BankAutoLoginConfigRepository } from "../modules/bank-auto-login-config/repository";
@@ -39,6 +40,8 @@ import { resolveCredentialKey } from "../modules/bank-credentials/key-resolver";
 import { createAuditEvent } from "../modules/audit";
 import { BANK_AUTOLOGIN_ACTIONS, BANK_CREDENTIAL_ACTIONS } from "../modules/audit/bank-actions";
 import { getPrismaClient } from "../modules/persistence/prisma-client";
+import { PrismaBankSessionExpiryEpisodeRepository } from "../modules/persistence/prisma-bank-session-expiry-episode-repository";
+import { popularScraperProfile } from "../modules/bank-adapters/popular";
 import { resolveBankBrowserEnv } from "./scraper/browser-runtime";
 import { createScrapeTimeAutoLoginRunner, unavailableScrapeTimeAutoLoginBrowserOpener, type BankAutoLoginStrategy } from "./scraper/auto-login";
 import { resolveDefaultScraper } from "../app/api/scrape-runs/consumer-defaults";
@@ -132,6 +135,17 @@ const processor = createIngestionProcessor({
   runScrapeTimeAutoLogin,
 });
 
+const expiryPublicationConsumer = createExpiryPublicationConsumer({
+  episodes: new PrismaBankSessionExpiryEpisodeRepository(prisma),
+  gate: { check: async () => "eligible" },
+  ingest: processor,
+  resolveAccountFingerprint(bankCode) {
+    return bankCode === popularScraperProfile.bankId
+      ? popularScraperProfile.accountFingerprint
+      : undefined;
+  },
+});
+
 // ---------------------------------------------------------------------------
 // Start the worker
 // ---------------------------------------------------------------------------
@@ -139,6 +153,7 @@ const processor = createIngestionProcessor({
 const worker = createIngestionWorker({
   connection,
   processor,
+  expiryPublicationConsumer,
   concurrency: 2,
   // Bind the real bullmq Worker at the composition root; the factory stays
   // bullmq-free. The cast is the single adapter seam between the library and

--- a/src/worker/queues/index.ts
+++ b/src/worker/queues/index.ts
@@ -108,7 +108,7 @@ export interface QueueLike {
   add(name: string, data: IngestionJobData, options: JobsOptions): Promise<unknown>;
 }
 
-const ingestionJobName = "bank-transaction-ingestion";
+export const ingestionJobName = "bank-transaction-ingestion";
 const SYSTEM_INGESTION_ACTOR = "system:ingestion-worker";
 const SYSTEM_AUTOLOGIN_ACTOR = "system:auto-login";
 

--- a/src/worker/queues/queues.test.ts
+++ b/src/worker/queues/queues.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   createIngestionProcessor,
   createIngestionQueueOptions,
+  ingestionJobName,
   scheduleIngestionJob,
   type IngestionJobData,
   type ResolveScraper,
@@ -332,6 +333,10 @@ describe("ingestion processor — audit events", () => {
 });
 
 describe("BullMQ ingestion scheduling", () => {
+  it("exports the exact ingestion job name used by the shared queue router", () => {
+    expect(ingestionJobName).toBe("bank-transaction-ingestion");
+  });
+
   it("uses stable job ids and retry/backoff options", async () => {
     const queue = new FakeQueue();
 

--- a/src/worker/scraper/auto-login.test.ts
+++ b/src/worker/scraper/auto-login.test.ts
@@ -290,6 +290,80 @@ describe("createBankAutoLoginStrategy", () => {
 });
 
 describe("executeScrapeTimeAutoLoginTrigger", () => {
+  it("runs the mutation hook once immediately before the first credential fill", async () => {
+    const events: string[] = [];
+    const page = makePage({ onFill: (selector) => { events.push(`fill:${selector}`); } });
+    const beforeAutoLoginMutation = vi.fn(() => { events.push("before"); return true; });
+
+    await expect(executeScrapeTimeAutoLoginTrigger({
+      bankCode: "popular", expiredEventId: "E1", credential, cdpUrl: "http://127.0.0.1:9222",
+      adapter: { bankCode: "popular", createAutoLoginStrategy: () => createBankAutoLoginStrategy(portalConfig) },
+      lock: { acquire: vi.fn().mockResolvedValue({ leaseToken: "lease-1", fencingToken: 1, expiresAt: 123 }), release: vi.fn().mockResolvedValue(true) },
+      ensureBrowser: vi.fn().mockResolvedValue(readyBrowser(page)), beforeAutoLoginMutation,
+    })).resolves.toEqual({ status: "succeeded" });
+
+    expect(beforeAutoLoginMutation).toHaveBeenCalledTimes(1);
+    expect(events).toEqual(["before", "fill:#username", "fill:#password"]);
+  });
+
+  it("fails closed when the mutation hook rejects or denies the compare-and-set", async () => {
+    for (const beforeAutoLoginMutation of [vi.fn().mockResolvedValue(false), vi.fn().mockRejectedValue(new Error("CAS token=secret failed"))]) {
+      const fill = vi.fn();
+      const click = vi.fn();
+      await expect(executeScrapeTimeAutoLoginTrigger({
+        bankCode: "popular", expiredEventId: "E1", credential, cdpUrl: "http://127.0.0.1:9222",
+        adapter: { bankCode: "popular", createAutoLoginStrategy: () => createBankAutoLoginStrategy(portalConfig) },
+        lock: { acquire: vi.fn().mockResolvedValue({ leaseToken: "lease-1", fencingToken: 1, expiresAt: 123 }), release: vi.fn().mockResolvedValue(true) },
+        ensureBrowser: vi.fn().mockResolvedValue(readyBrowser(makePage({ onFill: fill, onClick: click }))), beforeAutoLoginMutation,
+      })).resolves.toMatchObject({ status: "needs_admin_action", reason: "portal_state_unavailable" });
+      expect(beforeAutoLoginMutation).toHaveBeenCalledTimes(1);
+      expect(fill).not.toHaveBeenCalled();
+      expect(click).not.toHaveBeenCalled();
+    }
+  });
+
+  it("reports safe terminal outcomes without credentials and never reports success after a fill failure", async () => {
+    const successOutcome = vi.fn();
+    await executeScrapeTimeAutoLoginTrigger({
+      bankCode: "popular", expiredEventId: "E1", credential, cdpUrl: "http://127.0.0.1:9222",
+      adapter: { bankCode: "popular", createAutoLoginStrategy: () => createBankAutoLoginStrategy(portalConfig) },
+      lock: { acquire: vi.fn().mockResolvedValue({ leaseToken: "lease-1", fencingToken: 1, expiresAt: 123 }), release: vi.fn().mockResolvedValue(true) },
+      ensureBrowser: vi.fn().mockResolvedValue(readyBrowser(makePage())), afterAutoLoginOutcome: successOutcome,
+    });
+    expect(successOutcome).toHaveBeenCalledWith({ bankCode: "popular", expiredEventId: "E1", outcome: { status: "succeeded" } });
+
+    const uncertainOutcome = vi.fn();
+    const page = makePage({ onFill: (selector) => { if (selector === portalConfig.passwordSelector) throw new Error("portal token=secret crashed"); } });
+    await expect(executeScrapeTimeAutoLoginTrigger({
+      bankCode: "popular", expiredEventId: "E1", credential, cdpUrl: "http://127.0.0.1:9222",
+      adapter: { bankCode: "popular", createAutoLoginStrategy: () => createBankAutoLoginStrategy(portalConfig) },
+      lock: { acquire: vi.fn().mockResolvedValue({ leaseToken: "lease-1", fencingToken: 1, expiresAt: 123 }), release: vi.fn().mockResolvedValue(true) },
+      ensureBrowser: vi.fn().mockResolvedValue(readyBrowser(page)), afterAutoLoginOutcome: uncertainOutcome,
+    })).resolves.toMatchObject({ status: "needs_admin_action", reason: "portal_state_unavailable" });
+    expect(uncertainOutcome).toHaveBeenCalledWith({ bankCode: "popular", expiredEventId: "E1", outcome: { status: "needs_admin_action", reason: "portal_state_unavailable" } });
+    expect(uncertainOutcome.mock.calls).not.toContainEqual(expect.arrayContaining([expect.objectContaining({ outcome: { status: "succeeded" } })]));
+  });
+
+  it("does not call the mutation hook before lock, browser, throttle, or guard rejections", async () => {
+    const beforeAutoLoginMutation = vi.fn();
+    const base = {
+      bankCode: "popular", expiredEventId: "E1", credential, cdpUrl: "http://127.0.0.1:9222",
+      adapter: { bankCode: "popular", createAutoLoginStrategy: () => createBankAutoLoginStrategy(portalConfig) },
+      beforeAutoLoginMutation,
+    };
+
+    await executeScrapeTimeAutoLoginTrigger({ ...base, lock: { acquire: vi.fn().mockRejectedValue(new Error("lock unavailable")), release: vi.fn() }, ensureBrowser: vi.fn() });
+    await executeScrapeTimeAutoLoginTrigger({ ...base, lock: { acquire: vi.fn().mockResolvedValue({ leaseToken: "lease-1", fencingToken: 1, expiresAt: 123 }), release: vi.fn() }, ensureBrowser: vi.fn().mockRejectedValue(new Error("browser unavailable")) });
+    await executeScrapeTimeAutoLoginTrigger({ ...base, lock: { acquire: vi.fn().mockResolvedValue({ leaseToken: "lease-1", fencingToken: 1, expiresAt: 123 }), release: vi.fn() }, ensureBrowser: vi.fn().mockResolvedValue({ status: "throttled" }) });
+    await executeScrapeTimeAutoLoginTrigger({
+      ...base,
+      lock: { acquire: vi.fn().mockResolvedValue({ leaseToken: "lease-1", fencingToken: 1, expiresAt: 123 }), release: vi.fn() },
+      ensureBrowser: vi.fn().mockResolvedValue(readyBrowser(makePage({ visible: [portalConfig.mfaIndicatorSelector, ...loginControls] }))),
+    });
+
+    expect(beforeAutoLoginMutation).not.toHaveBeenCalled();
+  });
+
   it("acquires the expired-event lock, runs browser login, and awaits owner release after success", async () => {
     const page = makePage();
     const events: string[] = [];
@@ -602,6 +676,28 @@ describe("createScrapeTimeAutoLoginRunner", () => {
       encryptedPasswordEnvelope: JSON.stringify(encryptCredentialField("bank-password", keyResolver)),
     };
   }
+
+  it("does not call the mutation hook when config is off or credentials are absent", async () => {
+    const beforeAutoLoginMutation = vi.fn();
+    for (const [config, storedCredential] of [
+      [{ autoLoginEnabled: false, breakerState: "closed" }, encryptedCredentialRecord()],
+      [{ autoLoginEnabled: true, breakerState: "closed" }, null],
+    ] as const) {
+      const run = createScrapeTimeAutoLoginRunner({
+        adapterRegistry: { get: vi.fn().mockReturnValue({ bankCode: "popular", createAutoLoginStrategy: vi.fn() }) },
+        autoLoginConfigs: { getByBankCode: vi.fn().mockResolvedValue(config) },
+        credentials: { findByBankCode: vi.fn().mockResolvedValue(storedCredential) },
+        keyResolver,
+        lock: { acquire: vi.fn(), release: vi.fn() },
+        cdpUrlForBankCode: vi.fn(),
+        ensureBrowser: vi.fn(),
+        beforeAutoLoginMutation,
+      });
+
+      await run({ data: { bankId: "popular", expiredEventId: "E1" } });
+    }
+    expect(beforeAutoLoginMutation).not.toHaveBeenCalled();
+  });
 
   it("fails closed for an explicit unknown bank without falling back to Popular", async () => {
     const findByBankCode = vi.fn();

--- a/src/worker/scraper/auto-login.ts
+++ b/src/worker/scraper/auto-login.ts
@@ -78,6 +78,17 @@ export interface ScrapeTimeAutoLoginTriggerContext {
   lock: Pick<AutoLoginLock, "acquire" | "release">;
   ensureBrowser(cdpUrl: string): Promise<ScrapeTimeAutoLoginBrowserResult>;
   recordLockReleaseFailure?(metadata: { bankCode: string; expiredEventId: string }): void | Promise<void>;
+  beforeAutoLoginMutation?(metadata: AutoLoginMutationHookMetadata): boolean | Promise<boolean>;
+  afterAutoLoginOutcome?(metadata: AutoLoginOutcomeHookMetadata): void | Promise<void>;
+}
+
+export interface AutoLoginMutationHookMetadata {
+  bankCode: string;
+  expiredEventId: string;
+}
+
+export interface AutoLoginOutcomeHookMetadata extends AutoLoginMutationHookMetadata {
+  outcome: { status: "succeeded" } | { status: "needs_admin_action"; reason: BankAutoLoginAdminActionReason };
 }
 
 export interface ScrapeTimeAutoLoginRunnerJob {
@@ -116,6 +127,8 @@ export interface ScrapeTimeAutoLoginRunnerDependencies {
   ensureBrowser(bankCode: string, cdpUrl: string): Promise<ScrapeTimeAutoLoginBrowserResult>;
   recordLockReleaseFailure?(metadata: { bankCode: string; expiredEventId: string }): void | Promise<void>;
   recordCredentialDecryptUse?(metadata: { bankCode: string; keyVersion: number }): void | Promise<void>;
+  beforeAutoLoginMutation?(metadata: AutoLoginMutationHookMetadata): boolean | Promise<boolean>;
+  afterAutoLoginOutcome?(metadata: AutoLoginOutcomeHookMetadata): void | Promise<void>;
 }
 
 const SAFE_ADMIN_ACTION_SUMMARY = "Bank auto-login requires admin action";
@@ -316,6 +329,8 @@ export function createScrapeTimeAutoLoginRunner(deps: ScrapeTimeAutoLoginRunnerD
       lock: deps.lock,
       ensureBrowser: (url) => deps.ensureBrowser(bankCode, url),
       recordLockReleaseFailure: deps.recordLockReleaseFailure,
+      beforeAutoLoginMutation: deps.beforeAutoLoginMutation,
+      afterAutoLoginOutcome: deps.afterAutoLoginOutcome,
     });
   };
 }
@@ -454,10 +469,14 @@ async function runOwnedAutoLogin(context: ScrapeTimeAutoLoginTriggerContext, cdp
   if (browser?.status === "throttled") return { status: "throttled", safeSummary: SAFE_BROWSER_THROTTLED_SUMMARY };
   if (!browser) return needsAdminAction("browser_unavailable");
 
+  let outcome: BankAutoLoginOutcome;
   try {
-    return await context.adapter.createAutoLoginStrategy().autoLogin({ credential: context.credential, page: browser.page });
+    outcome = await context.adapter.createAutoLoginStrategy().autoLogin({
+      credential: context.credential,
+      page: withAutoLoginMutationHook(browser.page, context),
+    });
   } catch {
-    return needsAdminAction("portal_state_unavailable");
+    outcome = needsAdminAction("portal_state_unavailable");
   } finally {
     try {
       await browser.close();
@@ -465,6 +484,35 @@ async function runOwnedAutoLogin(context: ScrapeTimeAutoLoginTriggerContext, cdp
       // Cleanup failures must not change or leak past the safe auto-login outcome.
     }
   }
+
+  try {
+    await context.afterAutoLoginOutcome?.({
+      bankCode: context.bankCode,
+      expiredEventId: context.expiredEventId,
+      outcome: outcome.status === "succeeded" ? outcome : { status: outcome.status, reason: outcome.reason },
+    });
+  } catch {
+    if (outcome.status === "succeeded") return needsAdminAction("portal_state_unavailable");
+  }
+  return outcome;
+}
+
+function withAutoLoginMutationHook(page: BankAutoLoginPage, context: ScrapeTimeAutoLoginTriggerContext): BankAutoLoginPage {
+  if (!context.beforeAutoLoginMutation) return page;
+  let mutationAuthorized = false;
+  return {
+    currentUrl: () => page.currentUrl(),
+    hasVisibleSelector: (selector) => page.hasVisibleSelector(selector),
+    async fill(selector, value) {
+      if (!mutationAuthorized) {
+        const permitted = await context.beforeAutoLoginMutation?.({ bankCode: context.bankCode, expiredEventId: context.expiredEventId });
+        if (permitted === false) throw new Error("Auto-login mutation was not authorized");
+        mutationAuthorized = true;
+      }
+      await page.fill(selector, value);
+    },
+    click: (selector) => page.click(selector),
+  };
 }
 
 function manualRequired(reason: "lock_busy" | "lock_unavailable"): ScrapeTimeAutoLoginOutcome {


### PR DESCRIPTION
# PR4q2a: Expiry publication worker bridge

Routes durable expiry publication jobs through the shared BullMQ worker and maps accepted claims into exact ingestion jobs without enabling browser mutation.

## Chain context

```text
PR #55 PR4q1 resumable durable claims
└─ 📍 This PR: PR4q2a BullMQ router + expiry bridge
   └─ Next: PR4q2b browser mutation lifecycle hooks
```

Base: PR #55 head `fb8d05c`.

## Changes

- Routes only exact ingestion and expiry-publication job names.
- Rejects unknown BullMQ jobs safely.
- Validates untrusted expiry envelopes before durable claim work.
- Bridges acquired/resumed claims into ingestion jobs carrying runId and expiredEventId.
- Resolves account fingerprints per supported bank and fails closed for unsupported profiles.
- Wires the bridge into the production worker while retaining the unavailable browser opener.
- Safely resolves accepted claims when no supported profile exists, without browser mutation.

## Verification

- Focused worker/queue/bridge tests: 37 passed.
- Full suite: 1,223 passed, 97 skipped, 0 failed.
- Lint, typecheck, and diff-check: passed.
- Authored scope: 207 changed lines across seven files.
- Review-driven development: disabled globally; delivered under ordinary repository gates.

## Scope boundary

No mutation lifecycle hooks, monitor timers, terminal observer, audit poller, alerts, real browser opener, or portal automation is included.
