### PR TITLE
feat(worker): PR4q3 — own expiry runtime lifecycle

### DIFF
--- a/src/modules/bank-sessions/expiry-terminal-reconciliation.test.ts
+++ b/src/modules/bank-sessions/expiry-terminal-reconciliation.test.ts
@@ -45,7 +45,7 @@ describe("expiry terminal reconciliation", () => {
     const upgraded = await reconcileExpiryTerminalObservation(async () => "failed", episodes, envelope);
     expect([missing.kind === "terminal" && missing.result.status, duplicate.kind === "terminal" && duplicate.result.status, upgraded.kind === "terminal" && upgraded.result.status]).toEqual(["reconciled", "already_reconciled", "reconciled"]);
     expect(await episodes.findByBankCode("popular")).toMatchObject({ terminalFailureReason: "job_failed" });
-    expect(upgraded.kind === "terminal" && upgraded.result.audit).toMatchObject({ actorId: "system", actorRole: "system", action: "needs_admin_action", target: "bank_session_expiry_episode", targetId: "popular:event-1:run-1", metadata: { bankCode: "popular", expiredEventId: "event-1", runId: "run-1", reconciledAt: expect.any(String), reason: "job_failed" } });
+    expect(upgraded.kind === "terminal" && upgraded.result.audit).toMatchObject({ actorId: "system", actorRole: "system", action: "bank_autologin.needs_admin_action", target: "bank_session_expiry_episode", targetId: "popular:event-1:run-1", metadata: { bankCode: "popular", expiredEventId: "event-1", runId: "run-1", reconciledAt: expect.any(String), reason: "job_failed" } });
     expect(JSON.stringify(upgraded)).not.toContain("publication-token");
   });
 

--- a/src/modules/bank-sessions/expiry-terminal-reconciliation.ts
+++ b/src/modules/bank-sessions/expiry-terminal-reconciliation.ts
@@ -1,4 +1,5 @@
 import type { AuditEvent } from "../audit";
+import { BANK_AUTOLOGIN_ACTIONS } from "../audit/bank-actions";
 import type { ExpiryPublicationEnvelope } from "./expiry-episodes";
 
 export type ExpiryTerminalFailureReason = "job_failed" | "job_missing";
@@ -44,7 +45,7 @@ export function createExpiryTerminalAudit(
   return {
     id: `bank-session-expiry-terminal:${identity}`,
     actorId: "system", actorRole: "system",
-    action: requiresManualRecovery ? "bank_autologin.manual_recovery_required" : "bank_autologin.needs_admin_action",
+    action: requiresManualRecovery ? BANK_AUTOLOGIN_ACTIONS.MANUAL_RECOVERY_REQUIRED : BANK_AUTOLOGIN_ACTIONS.NEEDS_ADMIN_ACTION,
     target: "bank_session_expiry_episode", targetId: identity,
     metadata: { bankCode: envelope.bankCode, expiredEventId: envelope.expiredEventId, runId: envelope.runId, reason, reconciledAt: reconciledAt.toISOString() },
     createdAt: reconciledAt,

--- a/src/modules/bank-sessions/expiry-terminal-reconciliation.ts
+++ b/src/modules/bank-sessions/expiry-terminal-reconciliation.ts
@@ -44,7 +44,7 @@ export function createExpiryTerminalAudit(
   return {
     id: `bank-session-expiry-terminal:${identity}`,
     actorId: "system", actorRole: "system",
-    action: requiresManualRecovery ? "manual_recovery_required" : "needs_admin_action",
+    action: requiresManualRecovery ? "bank_autologin.manual_recovery_required" : "bank_autologin.needs_admin_action",
     target: "bank_session_expiry_episode", targetId: identity,
     metadata: { bankCode: envelope.bankCode, expiredEventId: envelope.expiredEventId, runId: envelope.runId, reason, reconciledAt: reconciledAt.toISOString() },
     createdAt: reconciledAt,

--- a/src/worker/expiry-runtime.test.ts
+++ b/src/worker/expiry-runtime.test.ts
@@ -125,6 +125,15 @@ describe("expiry runtime", () => {
     expect(outbox.markDelivered).toHaveBeenCalledOnce();
   });
 
+  it("limits manual recovery audit deliveries per tick", async () => {
+    const outbox = {
+      findClaimable: vi.fn().mockResolvedValue({ id: "outbox", resolution: { id: "resolution", bankCode: "popular", expiredEventId: "event", runId: "run", outcome: "resolved_no_retry" as const, reason: "closed_without_retry" as const, operatorId: "admin", resolvedAt: new Date() } }),
+      claim: vi.fn().mockResolvedValue(true), markDelivered: vi.fn().mockResolvedValue(true), releaseClaim: vi.fn(), inspect: vi.fn(),
+    };
+    await createExpiryRuntime(enabled, () => dependencies({ outbox })).tick();
+    expect(outbox.markDelivered).toHaveBeenCalledTimes(100);
+  });
+
   it("shares in-flight ticks and closes owned resources exactly once on shutdown", async () => {
     let release!: () => void;
     const pending = new Promise<void>((resolve) => { release = resolve; });
@@ -137,6 +146,21 @@ describe("expiry runtime", () => {
     release();
     await Promise.all([first, second, stopping, runtime.shutdown()]);
     expect(deps.monitor.tick).toHaveBeenCalledOnce();
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("waits for a failing in-flight tick but fulfills shutdown", async () => {
+    let reject!: (reason: Error) => void;
+    const failure = new Error("monitor failed");
+    const pending = new Promise<void>((_, rejectPending) => { reject = rejectPending; });
+    const close = vi.fn().mockResolvedValue(undefined);
+    const runtime = createExpiryRuntime(enabled, () => dependencies({ monitor: { tick: vi.fn().mockReturnValue(pending) }, close }));
+    const tick = runtime.tick();
+    const stopping = runtime.shutdown();
+    reject(failure);
+    await expect(tick).rejects.toBe(failure);
+    await expect(stopping).resolves.toBeUndefined();
+    await expect(runtime.shutdown()).resolves.toBeUndefined();
     expect(close).toHaveBeenCalledOnce();
   });
 });

--- a/src/worker/expiry-runtime.test.ts
+++ b/src/worker/expiry-runtime.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ExpiryRuntimeDependencies } from "./expiry-runtime";
+import { createExpiryRuntime } from "./expiry-runtime";
+
+const enabled = {
+  RD_SYNC_SESSION_MONITOR: "enabled",
+  DATABASE_URL: "postgres://test",
+  RD_SYNC_REDIS_URL: "redis://test",
+};
+const episode = {
+  bankCode: "popular",
+  expiredEventId: "event-1",
+  runId: "run-1",
+  publicationClaimToken: "token",
+  publicationState: "published" as const,
+};
+
+function dependencies(overrides: Partial<ExpiryRuntimeDependencies> = {}): ExpiryRuntimeDependencies {
+  return {
+    monitor: { tick: vi.fn().mockResolvedValue(undefined) },
+    episodes: {
+      findByBankCode: vi.fn().mockResolvedValue(episode),
+      reconcileTerminalFailure: vi.fn()
+        .mockResolvedValueOnce({ status: "reconciled", operatorSignal: "safe" })
+        .mockResolvedValue({ status: "already_reconciled", operatorSignal: "safe" }),
+    },
+    publisher: { observe: vi.fn().mockResolvedValue("failed") },
+    outbox: {
+      findClaimable: vi.fn().mockResolvedValue(null),
+      claim: vi.fn(),
+      markDelivered: vi.fn(),
+      releaseClaim: vi.fn(),
+      inspect: vi.fn(),
+    },
+    auditSink: { record: vi.fn(), list: vi.fn() },
+    alerts: { notifySessionAttention: vi.fn().mockResolvedValue(undefined) },
+    bankCode: "popular",
+    leaseOwner: "replica-a",
+    ...overrides,
+  };
+}
+
+describe("expiry runtime", () => {
+  it("is default-off without constructing runtime effects", async () => {
+    const create = vi.fn();
+    const runtime = createExpiryRuntime({}, create);
+    runtime.start();
+    await runtime.tick();
+    await runtime.shutdown();
+    expect(runtime.enabled).toBe(false);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("fails enabled startup before construction when configuration is missing", () => {
+    const create = vi.fn();
+    expect(() => createExpiryRuntime({ RD_SYNC_SESSION_MONITOR: "enabled" }, create))
+      .toThrow("DATABASE_URL");
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("leaves unavailable checks without an episode unobserved", async () => {
+    const deps = dependencies({
+      episodes: {
+        findByBankCode: vi.fn().mockResolvedValue(null),
+        reconcileTerminalFailure: vi.fn(),
+      },
+    });
+    await createExpiryRuntime(enabled, () => deps).tick();
+    expect(deps.publisher.observe).not.toHaveBeenCalled();
+    expect(deps.episodes.reconcileTerminalFailure).not.toHaveBeenCalled();
+  });
+
+  it("observes terminal publication once and sends only the fixed safe winner alert", async () => {
+    const notifySessionAttention = vi.fn().mockResolvedValue(undefined);
+    const deps = dependencies({ alerts: { notifySessionAttention } });
+    const runtime = createExpiryRuntime(enabled, () => deps);
+    await runtime.tick();
+    await runtime.tick();
+    expect(deps.publisher.observe).toHaveBeenCalledTimes(2);
+    expect(deps.episodes.reconcileTerminalFailure).toHaveBeenCalledTimes(2);
+    expect(deps.alerts.notifySessionAttention).toHaveBeenCalledOnce();
+    expect(deps.alerts.notifySessionAttention).toHaveBeenCalledWith({
+      status: "expired",
+      safeSummary: "Automatic session recovery requires administrative review",
+      checkedAt: expect.any(String),
+    });
+    expect(JSON.stringify(notifySessionAttention.mock.calls)).not.toContain("token");
+  });
+
+  it("rejects unsafe observations without durable terminal state or alerts", async () => {
+    const deps = dependencies({
+      publisher: { observe: vi.fn().mockRejectedValue(new Error("redis://secret")) },
+    });
+    await createExpiryRuntime(enabled, () => deps).tick();
+    expect(deps.episodes.reconcileTerminalFailure).not.toHaveBeenCalled();
+    expect(deps.alerts.notifySessionAttention).not.toHaveBeenCalled();
+  });
+
+  it("drains one leased audit delivery and lets the repository elect replicas", async () => {
+    const outbox = {
+      findClaimable: vi.fn()
+        .mockResolvedValueOnce({
+          id: "outbox",
+          resolution: {
+            id: "resolution",
+            bankCode: "popular",
+            expiredEventId: "event",
+            runId: "run",
+            outcome: "resolved_no_retry" as const,
+            reason: "closed_without_retry" as const,
+            operatorId: "admin",
+            resolvedAt: new Date(),
+          },
+        })
+        .mockResolvedValue(null),
+      claim: vi.fn().mockResolvedValue(true),
+      markDelivered: vi.fn().mockResolvedValue(true),
+      releaseClaim: vi.fn(),
+      inspect: vi.fn(),
+    };
+    const deps = dependencies({ outbox });
+    await createExpiryRuntime(enabled, () => deps).tick();
+    expect(outbox.claim).toHaveBeenCalledWith("outbox", "replica-a", 30_000);
+    expect(outbox.markDelivered).toHaveBeenCalledOnce();
+  });
+
+  it("shares in-flight ticks and closes owned resources exactly once on shutdown", async () => {
+    let release!: () => void;
+    const pending = new Promise<void>((resolve) => { release = resolve; });
+    const close = vi.fn().mockResolvedValue(undefined);
+    const deps = dependencies({ monitor: { tick: vi.fn().mockReturnValue(pending) }, close });
+    const runtime = createExpiryRuntime(enabled, () => deps);
+    const first = runtime.tick();
+    const second = runtime.tick();
+    const stopping = runtime.shutdown();
+    release();
+    await Promise.all([first, second, stopping, runtime.shutdown()]);
+    expect(deps.monitor.tick).toHaveBeenCalledOnce();
+    expect(close).toHaveBeenCalledOnce();
+  });
+});

--- a/src/worker/expiry-runtime.ts
+++ b/src/worker/expiry-runtime.ts
@@ -20,6 +20,7 @@ import type { AdminAlertSink } from "./queues";
 type Timer = ReturnType<typeof setInterval> | number;
 const INTERVAL_MS = 60_000;
 const LEASE_MS = 30_000;
+const MAX_MANUAL_RECOVERY_AUDIT_DELIVERIES_PER_TICK = 100;
 const TERMINAL_ALERT = "Automatic session recovery requires administrative review";
 
 export interface ExpiryRuntime {
@@ -97,7 +98,7 @@ function createEnabledRuntime(deps: ExpiryRuntimeDependencies): ExpiryRuntime {
   async function tickOnce(): Promise<void> {
     await deps.monitor.tick();
     await observeTerminalEpisode();
-    for (let delivered = true; delivered;) {
+    for (let delivered = true, deliveries = 0; delivered && deliveries < MAX_MANUAL_RECOVERY_AUDIT_DELIVERIES_PER_TICK; deliveries += 1) {
       delivered = await deliverManualRecoveryResolutionAudit(
         deps.outbox,
         deps.auditSink,
@@ -122,6 +123,8 @@ function createEnabledRuntime(deps: ExpiryRuntimeDependencies): ExpiryRuntime {
         timer = undefined;
         try {
           await inFlight;
+        } catch {
+          // tick() retains its failure; shutdown only waits for the resource-safe boundary.
         } finally {
           await deps.close?.();
         }

--- a/src/worker/expiry-runtime.ts
+++ b/src/worker/expiry-runtime.ts
@@ -1,0 +1,177 @@
+import { randomUUID } from "node:crypto";
+import { Queue } from "bullmq";
+
+import { popularScraperProfile } from "../modules/bank-adapters/popular";
+import { createBankSessionMonitor, createCdpSessionChecker, type BankSessionMonitor } from "../modules/bank-sessions";
+import { deliverManualRecoveryResolutionAudit, type ManualRecoveryResolutionAuditOutboxRepository } from "../modules/bank-sessions/manual-recovery-resolution-audit-delivery";
+import { reconcileExpiryTerminalObservation, type ExpiryTerminalReconciliationRepository } from "../modules/bank-sessions/expiry-terminal-reconciliation";
+import { observeExpiryPublicationJob, scheduleExpiryPublicationJob, type ExpiryPublicationQueue } from "../modules/bank-sessions/expiry-publication";
+import { publishExpiryEpisode, type BankSessionExpiryEpisode, type BankSessionExpiryEpisodeRepository, type ExpiryPublicationPublisher } from "../modules/bank-sessions/expiry-episodes";
+import type { AuditSink } from "../modules/audit";
+import { PrismaAuditSink } from "../modules/persistence/prisma-audit-sink";
+import { PrismaBankSessionExpiryEpisodeRepository } from "../modules/persistence/prisma-bank-session-expiry-episode-repository";
+import { PrismaManualRecoveryResolutionAuditOutboxRepository } from "../modules/persistence/prisma-manual-recovery-resolution-audit-outbox-repository";
+import { getPrismaClient } from "../modules/persistence/prisma-client";
+import { resolveDefaultAlertSink } from "./alerts/email-alert-sink";
+import { buildRedisConnectionOptions } from "./queues/bullmq-queue";
+import { resolveBankBrowserEnv } from "./scraper/browser-runtime";
+import type { AdminAlertSink } from "./queues";
+
+type Timer = ReturnType<typeof setInterval> | number;
+const INTERVAL_MS = 60_000;
+const LEASE_MS = 30_000;
+const TERMINAL_ALERT = "Automatic session recovery requires administrative review";
+
+export interface ExpiryRuntime {
+  readonly enabled: boolean;
+  tick(): Promise<void>;
+  start(): void;
+  shutdown(): Promise<void>;
+}
+
+export interface ExpiryRuntimeDependencies {
+  monitor: Pick<BankSessionMonitor, "tick">;
+  episodes: Pick<BankSessionExpiryEpisodeRepository, "findByBankCode"> & ExpiryTerminalReconciliationRepository;
+  publisher: Pick<ExpiryPublicationPublisher, "observe">;
+  outbox: ManualRecoveryResolutionAuditOutboxRepository;
+  auditSink: AuditSink;
+  alerts: Pick<AdminAlertSink, "notifySessionAttention">;
+  bankCode: string;
+  leaseOwner: string;
+  close?(): Promise<void>;
+  schedule?(callback: () => void, intervalMs: number): Timer;
+  clearSchedule?(timer: Timer): void;
+  clock?(): Date;
+}
+
+export function createExpiryRuntime(
+  env: Record<string, string | undefined>,
+  create: () => ExpiryRuntimeDependencies,
+): ExpiryRuntime {
+  if (env.RD_SYNC_SESSION_MONITOR !== "enabled") return disabledRuntime;
+  if (!env.DATABASE_URL || !env.RD_SYNC_REDIS_URL) {
+    throw new Error("Expiry runtime requires DATABASE_URL and RD_SYNC_REDIS_URL");
+  }
+  return createEnabledRuntime(create());
+}
+
+const disabledRuntime: ExpiryRuntime = {
+  enabled: false,
+  async tick() {},
+  start() {},
+  async shutdown() {},
+};
+
+function createEnabledRuntime(deps: ExpiryRuntimeDependencies): ExpiryRuntime {
+  const schedule = deps.schedule ?? setInterval;
+  const clearSchedule = deps.clearSchedule ?? clearInterval;
+  const clock = deps.clock ?? (() => new Date());
+  let timer: Timer | undefined;
+  let inFlight: Promise<void> | undefined;
+  let shutdown: Promise<void> | undefined;
+
+  async function observeTerminalEpisode(): Promise<void> {
+    const episode = await deps.episodes.findByBankCode(deps.bankCode);
+    if (!episode || episode.publicationState !== "published" || !episode.publicationClaimToken) return;
+    const envelope = {
+      bankCode: episode.bankCode,
+      expiredEventId: episode.expiredEventId,
+      runId: episode.runId,
+      token: episode.publicationClaimToken,
+    };
+    const observation = await reconcileExpiryTerminalObservation(
+      () => deps.publisher.observe(envelope),
+      deps.episodes,
+      envelope,
+      clock,
+    );
+    if (observation.kind === "terminal" && observation.result.status === "reconciled") {
+      await deps.alerts.notifySessionAttention({
+        status: "expired",
+        safeSummary: TERMINAL_ALERT,
+        checkedAt: clock().toISOString(),
+      });
+    }
+  }
+
+  async function tickOnce(): Promise<void> {
+    await deps.monitor.tick();
+    await observeTerminalEpisode();
+    for (let delivered = true; delivered;) {
+      delivered = await deliverManualRecoveryResolutionAudit(
+        deps.outbox,
+        deps.auditSink,
+        deps.leaseOwner,
+        LEASE_MS,
+      );
+    }
+  }
+
+  const runtime: ExpiryRuntime = {
+    enabled: true,
+    tick() {
+      if (!inFlight) inFlight = tickOnce().finally(() => { inFlight = undefined; });
+      return inFlight;
+    },
+    start() {
+      if (!timer) timer = schedule(() => { void runtime.tick().catch(() => undefined); }, INTERVAL_MS);
+    },
+    shutdown() {
+      if (!shutdown) shutdown = (async () => {
+        if (timer) clearSchedule(timer);
+        timer = undefined;
+        try {
+          await inFlight;
+        } finally {
+          await deps.close?.();
+        }
+      })();
+      return shutdown;
+    },
+  };
+  return runtime;
+}
+
+export function createDefaultExpiryRuntime(
+  env: Record<string, string | undefined> = process.env,
+): ExpiryRuntime {
+  return createExpiryRuntime(env, () => {
+    const prisma = getPrismaClient();
+    const episodes = new PrismaBankSessionExpiryEpisodeRepository(prisma);
+    const queue = new Queue("bank-transaction-ingestion", {
+      connection: buildRedisConnectionOptions(env.RD_SYNC_REDIS_URL!),
+    });
+    const publicationQueue = queue as unknown as ExpiryPublicationQueue;
+    const publisher: ExpiryPublicationPublisher = {
+      schedule: (job) => scheduleExpiryPublicationJob(publicationQueue, job),
+      observe: (job) => observeExpiryPublicationJob(publicationQueue, job.runId),
+    };
+    const alerts = resolveDefaultAlertSink();
+    const bankCode = popularScraperProfile.bankId;
+    return {
+      bankCode,
+      episodes,
+      publisher,
+      outbox: new PrismaManualRecoveryResolutionAuditOutboxRepository(prisma),
+      auditSink: new PrismaAuditSink(),
+      alerts,
+      leaseOwner: `expiry-runtime:${randomUUID()}`,
+      close: () => queue.close(),
+      monitor: createBankSessionMonitor({
+        check: createCdpSessionChecker({
+          cdpUrl: resolveBankBrowserEnv(bankCode, env).cdpUrl,
+        }).check,
+        alertSink: alerts,
+        auditSink: new PrismaAuditSink(),
+        intervalMs: INTERVAL_MS,
+        monitorMode: {
+          mode: "expiry_events",
+          bankCode,
+          episodes,
+          publish: (episode: BankSessionExpiryEpisode) =>
+            publishExpiryEpisode(episodes, episode, randomUUID(), publisher).then(() => undefined),
+        },
+      }),
+    };
+  });
+}

--- a/src/worker/ingestion-worker.ts
+++ b/src/worker/ingestion-worker.ts
@@ -31,6 +31,7 @@ import { Worker } from "bullmq";
 import { buildRedisConnectionOptions } from "./queues/bullmq-queue";
 import { createIngestionWorker, type WorkerConstructor } from "./ingestion-worker-factory";
 import { createExpiryPublicationConsumer } from "./expiry-publication-consumer";
+import { createDefaultExpiryRuntime } from "./expiry-runtime";
 import { resolveDefaultAlertSink } from "./alerts/email-alert-sink";
 import { bankAdapterRegistry } from "../modules/bank-adapters/registry";
 import { BankAutoLoginConfigRepository } from "../modules/bank-auto-login-config/repository";
@@ -63,6 +64,7 @@ if (!redisUrl) {
   );
   process.exit(1);
 }
+const expiryRuntime = createDefaultExpiryRuntime();
 
 // ---------------------------------------------------------------------------
 // Wire up real dependencies
@@ -160,6 +162,7 @@ const worker = createIngestionWorker({
   // our structural WorkerConstructor port.
   WorkerCtor: Worker as unknown as WorkerConstructor,
 });
+expiryRuntime.start();
 
 console.log("[ingestion-worker] Started. Waiting for jobs on 'bank-transaction-ingestion'...");
 
@@ -174,7 +177,7 @@ const SHUTDOWN_GRACE_MS = 25_000;
 async function shutdown(signal: string): Promise<void> {
   console.log(`[ingestion-worker] ${signal} received — shutting down gracefully (${SHUTDOWN_GRACE_MS}ms timeout)...`);
 
-  const graceful = worker.close();
+  const graceful = Promise.all([worker.close(), expiryRuntime.shutdown()]);
   const timeout = new Promise<void>((resolve) =>
     setTimeout(() => {
       console.warn("[ingestion-worker] Shutdown grace period exceeded — forcing exit.");


### PR DESCRIPTION
# PR4q3: Expiry runtime owner

Adds the default-off worker runtime that owns expiry monitoring, terminal reconciliation, resolution-audit delivery, safe winner alerts, and graceful shutdown.

## Chain context

PR #57 PR4q2b mutation lifecycle hooks
→ This PR: PR4q3 runtime owner/observer/audit poller/alerts
→ Next: PR4q4 two-replica PostgreSQL/Redis validation and runbooks

Base: PR #57 head 265bd1a.

## Changes

- Composes the bank session monitor and durable expiry publication flow behind RD_SYNC_SESSION_MONITOR=enabled.
- Fails fast on missing PostgreSQL or Redis configuration only when enabled.
- Reconciles terminal publication outcomes and alerts only the durable reconciliation winner.
- Drains manual-recovery resolution audit outbox deliveries with leased ownership.
- Prevents overlapping ticks and closes owned resources idempotently.
- Namespaces terminal recovery audit actions.
- Keeps the real browser opener unavailable.

## Verification

- Focused tests: 18 passed.
- Full suite: 1,235 passed, 97 skipped, 0 failed.
- Lint, typecheck, and diff-check: passed.
- Authored scope: 328 changed lines across five files.
- Review-driven development: disabled globally; delivered under ordinary repository gates.

## Scope boundary

No real PostgreSQL/Redis multi-replica exercise, browser opener activation, or banking login is included. Those remain PR4q4 and later controlled activation scope.