### PR TITLE
test(worker): PR4q4 — prove two-replica expiry runtime

### DIFF
--- a/docs/runbooks/worker.md
+++ b/docs/runbooks/worker.md
@@ -122,12 +122,14 @@ migrations and a dedicated Redis instance:
 ```bash
 RD_SYNC_TEST_DATABASE_URL="postgresql://test-user:test-password@localhost:5432/rd_sync_test" \
 RD_SYNC_TEST_REDIS_URL="redis://localhost:6379" \
-pnpm exec vitest run src/worker/expiry-runtime.integration.test.ts
+RD_SYNC_REQUIRE_INTEGRATION=true pnpm exec vitest run src/worker/expiry-runtime.integration.test.ts
 ```
 
-Until this command completes successfully against both dedicated services, the
-proof remains blocked and B2.5 remains pending. Record unavailable PostgreSQL
-or Redis as a blocked verification result; do not infer a pass from the skip.
+This command fails if either service URL is absent. Without
+`RD_SYNC_REQUIRE_INTEGRATION=true`, the normal full suite still skips this
+integration proof when services are unavailable. Until the required command
+completes successfully against both dedicated services, the proof remains
+blocked and B2.5 remains pending.
 
 Expected evidence:
 

--- a/docs/runbooks/worker.md
+++ b/docs/runbooks/worker.md
@@ -110,7 +110,49 @@ The following scenarios are only verifiable with a live Redis instance and are
 - [ ] Worker picks up the job, calls the processor, logs the run ID and status.
 - [ ] Restarting the worker mid-queue does not lose the pending job.
 - [ ] With `RD_SYNC_TEST_REDIS_URL=redis://localhost:6379 pnpm test`, the
-      integration test suite passes.
+       integration test suite passes.
+
+---
+
+## Two-replica expiry runtime proof
+
+Run the gated runtime proof only against a dedicated database with committed
+migrations and a dedicated Redis instance:
+
+```bash
+RD_SYNC_TEST_DATABASE_URL="postgresql://test-user:test-password@localhost:5432/rd_sync_test" \
+RD_SYNC_TEST_REDIS_URL="redis://localhost:6379" \
+pnpm exec vitest run src/worker/expiry-runtime.integration.test.ts
+```
+
+Until this command completes successfully against both dedicated services, the
+proof remains blocked and B2.5 remains pending. Record unavailable PostgreSQL
+or Redis as a blocked verification result; do not infer a pass from the skip.
+
+Expected evidence:
+
+- Two independently constructed runtimes use distinct lease owners, timer
+  handles, and BullMQ queue clients.
+- Concurrent expiry observations persist one episode, one expiry audit, and
+  one publication job.
+- A test-only worker forces that synthetic job to retained `failed`; concurrent
+  terminal observation emits one durable reconciliation audit and one fixed,
+  safe operator alert.
+- A pending manual-recovery audit outbox row is leased once and becomes one
+  delivered row with one resolution audit.
+- Shutdown waits for blocked ticks, clears both timers, closes each owned queue
+  once, and is idempotent.
+
+Cleanup is scoped to the test UUID queue through BullMQ `obliterate` and to
+the test's UUID database records. The test never calls Redis `FLUSHALL`.
+
+Safety boundaries:
+
+- Both variables must target disposable test services, never `DATABASE_URL`,
+  developer data, or production data.
+- The proof creates no ingestion, scraper, browser, CDP, credential, bank URL,
+  or login activity.
+- `unavailableScrapeTimeAutoLoginBrowserOpener` remains unchanged.
 
 ---
 

--- a/openspec/changes/multi-bank-auto-login/tasks.md
+++ b/openspec/changes/multi-bank-auto-login/tasks.md
@@ -127,7 +127,7 @@ Gate: full gates + FRESH 4R review + Judgment Day before merge; PR3B1 <=400 line
   - [ ] PR4p2b2b: deliver pending recovery-audit outbox rows and authorize one replay only for `safe_to_retry`, using a wholly new episode identity/token/attempt budget while preserving the original resolution.
   - [ ] PR4p2b3: define terminal-failure reconciliation and published-observe rejection signals.
 - [x] B2.4 Scheduler provider: deduplicate jobs by exact episode `runId`; configure three total attempts (initial attempt plus two automatic retries) with exponential backoff (30s), retained failures (10), and bounded completed history (100); return observed normal/resolved-race/thrown-race BullMQ states, leaving terminal failures retained without manual retry. A published monitor tick observes the exact retained job or `missing`; it never creates a replacement attempt budget. After a successful `add`, an observation failure propagates as the observation error itself without entering duplicate-add recovery.
-- [ ] B2.5 Prove two-replica disabled/config-missing behavior: one episode, one expiry audit, and one restoration audit.
+- [x] B2.5 Prove two-replica runtime behavior with dedicated PostgreSQL and Redis: one durable episode, one expiry audit, one publication job, leased manual-recovery audit delivery, terminal reconciliation, and graceful shutdown.
 - [ ] B2.6 Run fresh 4R and Judgment Day before review.
 - Gate: ≤400 changed lines; no B2 implementation in B1.
 - B2a predecessor owns B2.1-B2.2, including active-session pending-candidate clearing before restoration/retry; its behavior remains unchanged.

--- a/src/worker/expiry-runtime.integration.test.ts
+++ b/src/worker/expiry-runtime.integration.test.ts
@@ -3,7 +3,7 @@
  *
  * This suite is skipped unless BOTH dedicated test-service URLs are supplied:
  *
- *   RD_SYNC_TEST_DATABASE_URL="postgresql://..." RD_SYNC_TEST_REDIS_URL="redis://..." pnpm test -- src/worker/expiry-runtime.integration.test.ts
+ *   RD_SYNC_REQUIRE_INTEGRATION=true RD_SYNC_TEST_DATABASE_URL="postgresql://..." RD_SYNC_TEST_REDIS_URL="redis://..." pnpm test -- src/worker/expiry-runtime.integration.test.ts
  *
  * It uses a UUID queue and deletes only its own database rows and Redis queue.
  * Do not point either variable at development or production infrastructure.
@@ -24,17 +24,21 @@ import { observeExpiryPublicationJob, scheduleExpiryPublicationJob } from "../mo
 const TEST_DATABASE_URL = process.env.RD_SYNC_TEST_DATABASE_URL;
 const TEST_REDIS_URL = process.env.RD_SYNC_TEST_REDIS_URL;
 const RUN_INTEGRATION = Boolean(TEST_DATABASE_URL && TEST_REDIS_URL);
+const REQUIRE_INTEGRATION = process.env.RD_SYNC_REQUIRE_INTEGRATION === "true";
+const WORKER_READY_TIMEOUT_MS = 5_000;
+if (REQUIRE_INTEGRATION && !RUN_INTEGRATION) {
+  throw new Error("RD_SYNC_REQUIRE_INTEGRATION=true requires RD_SYNC_TEST_DATABASE_URL and RD_SYNC_TEST_REDIS_URL");
+}
 const queueName = `expiry-runtime-integration-${randomUUID()}`;
 const bankCode = `runtime-${randomUUID()}`;
 const expiredEventId = `event-${randomUUID()}`;
 const runId = createExpiredSessionRunId(bankCode, expiredEventId);
-const publicationToken = `publication-${randomUUID()}`;
 const manualExpiredEventId = `manual-${randomUUID()}`;
 const manualResolutionId = `resolution-${randomUUID()}`;
 const manualOutboxId = `outbox-${randomUUID()}`;
-const expiryAuditId = `bank-session-bank_session.expired:${bankCode}:${expiredEventId}`;
-const terminalAuditId = `bank-session-expiry-terminal:${bankCode}:${expiredEventId}:${runId}`;
-const manualAuditId = `bank-autologin-manual-recovery-resolved:${manualResolutionId}`;
+const expiryAuditWhere = { action: "bank_session.expired", target: "bank_session", metadata: { path: ["expiredEventId"], equals: expiredEventId } } satisfies Prisma.AuditEventWhereInput;
+const terminalAuditWhere = { target: "bank_session_expiry_episode", targetId: `${bankCode}:${expiredEventId}:${runId}` } satisfies Prisma.AuditEventWhereInput;
+const manualAuditWhere = { action: "bank_autologin.manual_recovery_resolved", target: "manual_recovery_resolution", targetId: manualResolutionId } satisfies Prisma.AuditEventWhereInput;
 let prisma: PrismaClient | undefined;
 let Queue: typeof import("bullmq").Queue;
 let Worker: typeof import("bullmq").Worker;
@@ -65,9 +69,7 @@ describe.skipIf(!RUN_INTEGRATION)("expiry runtime integration (requires dedicate
       await cleanupQueue.obliterate({ force: true }).catch(() => undefined);
       await cleanupQueue.close().catch(() => undefined);
     }
-    await prisma?.auditEvent.deleteMany({
-      where: { id: { in: [expiryAuditId, terminalAuditId, manualAuditId] } },
-    });
+    await prisma?.auditEvent.deleteMany({ where: { OR: [expiryAuditWhere, terminalAuditWhere, manualAuditWhere] } });
     await prisma?.manualRecoveryResolutionAuditOutbox.deleteMany({ where: { id: manualOutboxId } });
     await prisma?.manualRecoveryResolution.deleteMany({ where: { id: manualResolutionId } });
     await prisma?.bankSessionExpiryEpisode.deleteMany({ where: { bankCode } });
@@ -101,14 +103,17 @@ describe.skipIf(!RUN_INTEGRATION)("expiry runtime integration (requires dedicate
     const timers: number[] = [];
     const clearedTimers: number[] = [];
     const ownersSeen = new Set<string>();
+    const proposedTokens = new Map<string, string>();
     const alerts: Array<{ safeSummary: string }> = [];
-    const tickGate: { wait?: Promise<void>; release?: () => void } = {};
+    const tickGate: { wait?: Promise<void>; release?: () => void; signalReplicaATick?: () => void } = {};
     const localTickStats = new Map<string, { calls: number; active: number; max: number }>();
     let releaseClaimBarrier!: () => void;
     const claimBarrier = new Promise<void>((resolve) => { releaseClaimBarrier = resolve; });
 
     function replica(owner: string, queue: import("bullmq").Queue): ExpiryRuntime {
       const stats = { calls: 0, active: 0, max: 0 };
+      const proposedToken = `publication-${owner}-${randomUUID()}`;
+      proposedTokens.set(owner, proposedToken);
       localTickStats.set(owner, stats);
       const publisher = {
         schedule: (envelope: { bankCode: string; expiredEventId: string; runId: string; token: string }) =>
@@ -121,6 +126,7 @@ describe.skipIf(!RUN_INTEGRATION)("expiry runtime integration (requires dedicate
           stats.active += 1;
           stats.max = Math.max(stats.max, stats.active);
           try {
+            if (owner === "replica-a") tickGate.signalReplicaATick?.();
             await tickGate.wait;
             return { status: "expired", checkedAt: new Date().toISOString(), safeSummary: "Synthetic expiry" };
           } finally {
@@ -135,7 +141,7 @@ describe.skipIf(!RUN_INTEGRATION)("expiry runtime integration (requires dedicate
           bankCode,
           episodes,
           createExpiredEventId: () => expiredEventId,
-          publish: (episode) => publishExpiryEpisode(episodes, episode, publicationToken, publisher).then(() => undefined),
+          publish: (episode) => publishExpiryEpisode(episodes, episode, proposedToken, publisher).then(() => undefined),
         },
       });
       return createExpiryRuntime(
@@ -196,10 +202,12 @@ describe.skipIf(!RUN_INTEGRATION)("expiry runtime integration (requires dedicate
       expiredEventId,
       runId,
       publicationState: "published",
-      publicationClaimToken: publicationToken,
+      publicationClaimToken: expect.any(String),
     });
-    expect(await prisma.auditEvent.count({ where: { id: expiryAuditId } })).toBe(1);
-    expect(await queueA.getJob(runId)).toBeDefined();
+    expect([...proposedTokens.values()]).toEqual(expect.arrayContaining([episode!.publicationClaimToken!]));
+    expect(new Set(proposedTokens.values())).toHaveLength(2);
+    expect(await prisma.auditEvent.count({ where: expiryAuditWhere })).toBe(1);
+    expect((await queueA.getJob(runId))?.data.token).toBe(episode!.publicationClaimToken);
 
     worker = new Worker(
       queueName,
@@ -209,7 +217,11 @@ describe.skipIf(!RUN_INTEGRATION)("expiry runtime integration (requires dedicate
       },
       { connection, concurrency: 1 },
     );
-    await new Promise<void>((resolve) => worker!.once("ready", resolve));
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error(`Timed out after ${WORKER_READY_TIMEOUT_MS}ms waiting for BullMQ worker readiness`)), WORKER_READY_TIMEOUT_MS);
+      worker!.once("ready", () => { clearTimeout(timeout); resolve(); });
+      worker!.once("error", (error) => { clearTimeout(timeout); reject(error); });
+    });
     await new Promise<void>((resolve, reject) => {
       const timeout = setTimeout(() => reject(new Error("Timed out waiting for synthetic terminal failure")), 5_000);
       worker!.on("failed", (job) => {
@@ -238,18 +250,19 @@ describe.skipIf(!RUN_INTEGRATION)("expiry runtime integration (requires dedicate
     expect(await prisma.manualRecoveryResolutionAuditOutbox.count({
       where: { id: manualOutboxId, state: "delivered" },
     })).toBe(1);
-    expect(await prisma.auditEvent.count({ where: { id: manualAuditId } })).toBe(1);
-    expect(await prisma.auditEvent.count({ where: { id: terminalAuditId } })).toBe(1);
+    expect(await prisma.auditEvent.count({ where: manualAuditWhere })).toBe(1);
+    expect(await prisma.auditEvent.count({ where: terminalAuditWhere })).toBe(1);
     expect(alerts.filter((alert) => alert.safeSummary === "Automatic session recovery requires administrative review")).toHaveLength(1);
     expect(JSON.stringify(alerts)).not.toMatch(/token|https?:\/\/|synthetic publication failure/i);
 
     tickGate.wait = new Promise<void>((resolve) => { tickGate.release = resolve; });
+    const replicaATickEntered = new Promise<void>((resolve) => { tickGate.signalReplicaATick = resolve; });
     const replicaAStats = localTickStats.get("replica-a")!;
     const callsBeforeFinalTick = replicaAStats.calls;
     const firstTick = runtimeA.tick();
-    runtimeA.tick();
+    void runtimeA.tick();
     const finalTick = runtimeB.tick();
-    await Promise.resolve();
+    await replicaATickEntered;
     expect(replicaAStats.calls).toBe(callsBeforeFinalTick + 1);
     expect(replicaAStats.max).toBe(1);
     const stoppingA = runtimeA.shutdown();

--- a/src/worker/expiry-runtime.integration.test.ts
+++ b/src/worker/expiry-runtime.integration.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Real PostgreSQL + Redis two-replica runtime proof.
+ *
+ * This suite is skipped unless BOTH dedicated test-service URLs are supplied:
+ *
+ *   RD_SYNC_TEST_DATABASE_URL="postgresql://..." RD_SYNC_TEST_REDIS_URL="redis://..." pnpm test -- src/worker/expiry-runtime.integration.test.ts
+ *
+ * It uses a UUID queue and deletes only its own database rows and Redis queue.
+ * Do not point either variable at development or production infrastructure.
+ */
+import { randomUUID } from "node:crypto";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { PrismaPg } from "@prisma/adapter-pg";
+import type { PrismaClient, Prisma } from "../generated/prisma/client";
+import type { AuditSink } from "../modules/audit";
+import { createBankSessionMonitor, createExpiredSessionRunId } from "../modules/bank-sessions";
+import { publishExpiryEpisode } from "../modules/bank-sessions/expiry-episodes";
+import { PrismaBankSessionExpiryEpisodeRepository } from "../modules/persistence/prisma-bank-session-expiry-episode-repository";
+import { PrismaManualRecoveryResolutionAuditOutboxRepository } from "../modules/persistence/prisma-manual-recovery-resolution-audit-outbox-repository";
+import { buildRedisConnectionOptions } from "./queues/bullmq-queue";
+import { createExpiryRuntime, type ExpiryRuntime } from "./expiry-runtime";
+import { observeExpiryPublicationJob, scheduleExpiryPublicationJob } from "../modules/bank-sessions/expiry-publication";
+
+const TEST_DATABASE_URL = process.env.RD_SYNC_TEST_DATABASE_URL;
+const TEST_REDIS_URL = process.env.RD_SYNC_TEST_REDIS_URL;
+const RUN_INTEGRATION = Boolean(TEST_DATABASE_URL && TEST_REDIS_URL);
+const queueName = `expiry-runtime-integration-${randomUUID()}`;
+const bankCode = `runtime-${randomUUID()}`;
+const expiredEventId = `event-${randomUUID()}`;
+const runId = createExpiredSessionRunId(bankCode, expiredEventId);
+const publicationToken = `publication-${randomUUID()}`;
+const manualExpiredEventId = `manual-${randomUUID()}`;
+const manualResolutionId = `resolution-${randomUUID()}`;
+const manualOutboxId = `outbox-${randomUUID()}`;
+const expiryAuditId = `bank-session-bank_session.expired:${bankCode}:${expiredEventId}`;
+const terminalAuditId = `bank-session-expiry-terminal:${bankCode}:${expiredEventId}:${runId}`;
+const manualAuditId = `bank-autologin-manual-recovery-resolved:${manualResolutionId}`;
+let prisma: PrismaClient | undefined;
+let Queue: typeof import("bullmq").Queue;
+let Worker: typeof import("bullmq").Worker;
+let queueA: import("bullmq").Queue | undefined;
+let queueB: import("bullmq").Queue | undefined;
+let worker: import("bullmq").Worker | undefined;
+const closedQueues = new Set<import("bullmq").Queue>();
+const closeCounts = new Map<import("bullmq").Queue, number>();
+
+describe.skipIf(!RUN_INTEGRATION)("expiry runtime integration (requires dedicated PostgreSQL and Redis)", () => {
+  beforeAll(async () => {
+    const prismaModule = await import("../generated/prisma/client");
+    const bullmq = await import("bullmq");
+    Queue = bullmq.Queue;
+    Worker = bullmq.Worker;
+    prisma = new prismaModule.PrismaClient({
+      adapter: new PrismaPg({ connectionString: TEST_DATABASE_URL! }),
+    });
+  });
+
+  afterEach(async () => {
+    await worker?.close().catch(() => undefined);
+    worker = undefined;
+    if (TEST_REDIS_URL) {
+      const cleanupQueue = new Queue(queueName, {
+        connection: buildRedisConnectionOptions(TEST_REDIS_URL),
+      });
+      await cleanupQueue.obliterate({ force: true }).catch(() => undefined);
+      await cleanupQueue.close().catch(() => undefined);
+    }
+    await prisma?.auditEvent.deleteMany({
+      where: { id: { in: [expiryAuditId, terminalAuditId, manualAuditId] } },
+    });
+    await prisma?.manualRecoveryResolutionAuditOutbox.deleteMany({ where: { id: manualOutboxId } });
+    await prisma?.manualRecoveryResolution.deleteMany({ where: { id: manualResolutionId } });
+    await prisma?.bankSessionExpiryEpisode.deleteMany({ where: { bankCode } });
+  });
+
+  afterAll(async () => {
+    await worker?.close().catch(() => undefined);
+    for (const queue of [queueA, queueB]) {
+      if (queue && !closedQueues.has(queue)) await queue.close();
+    }
+    await prisma?.$disconnect();
+  });
+
+  it("elects durable owners, terminal reconciliation, delivery, and graceful shutdown across two replicas", async () => {
+    if (!prisma || !TEST_REDIS_URL) throw new Error("Dedicated integration services are required");
+    const connection = buildRedisConnectionOptions(TEST_REDIS_URL);
+    queueA = new Queue(queueName, { connection });
+    queueB = new Queue(queueName, { connection });
+    const episodes = new PrismaBankSessionExpiryEpisodeRepository(prisma);
+    const outbox = new PrismaManualRecoveryResolutionAuditOutboxRepository(prisma);
+    const auditSink: AuditSink = {
+      async record(event) {
+        await prisma!.auditEvent.upsert({
+          where: { id: event.id },
+          create: { ...event, metadata: (event.metadata as Prisma.InputJsonValue | null) ?? undefined },
+          update: {},
+        });
+      },
+      async list() { return []; },
+    };
+    const timers: number[] = [];
+    const clearedTimers: number[] = [];
+    const ownersSeen = new Set<string>();
+    const alerts: Array<{ safeSummary: string }> = [];
+    const tickGate: { wait?: Promise<void>; release?: () => void } = {};
+    const localTickStats = new Map<string, { calls: number; active: number; max: number }>();
+    let releaseClaimBarrier!: () => void;
+    const claimBarrier = new Promise<void>((resolve) => { releaseClaimBarrier = resolve; });
+
+    function replica(owner: string, queue: import("bullmq").Queue): ExpiryRuntime {
+      const stats = { calls: 0, active: 0, max: 0 };
+      localTickStats.set(owner, stats);
+      const publisher = {
+        schedule: (envelope: { bankCode: string; expiredEventId: string; runId: string; token: string }) =>
+          scheduleExpiryPublicationJob(queue, envelope),
+        observe: (envelope: { runId: string }) => observeExpiryPublicationJob(queue, envelope.runId),
+      };
+      const monitor = createBankSessionMonitor({
+        check: async () => {
+          stats.calls += 1;
+          stats.active += 1;
+          stats.max = Math.max(stats.max, stats.active);
+          try {
+            await tickGate.wait;
+            return { status: "expired", checkedAt: new Date().toISOString(), safeSummary: "Synthetic expiry" };
+          } finally {
+            stats.active -= 1;
+          }
+        },
+        intervalMs: 60_000,
+        alertSink: { notifySessionAttention: async (alert) => { alerts.push(alert); } },
+        auditSink,
+        monitorMode: {
+          mode: "expiry_events",
+          bankCode,
+          episodes,
+          createExpiredEventId: () => expiredEventId,
+          publish: (episode) => publishExpiryEpisode(episodes, episode, publicationToken, publisher).then(() => undefined),
+        },
+      });
+      return createExpiryRuntime(
+        {
+          RD_SYNC_SESSION_MONITOR: "enabled",
+          DATABASE_URL: TEST_DATABASE_URL,
+          RD_SYNC_REDIS_URL: TEST_REDIS_URL,
+        },
+        () => ({
+          monitor,
+          episodes,
+          publisher,
+          auditSink,
+          bankCode,
+          leaseOwner: owner,
+          outbox: {
+            findClaimable: async () => {
+              const candidate = await outbox.findClaimable();
+              if (candidate?.id === manualOutboxId) {
+                ownersSeen.add(owner);
+                if (ownersSeen.size === 2) releaseClaimBarrier();
+                await claimBarrier;
+              }
+              return candidate;
+            },
+            claim: (id, leaseOwner, leaseMs) => outbox.claim(id, leaseOwner, leaseMs),
+            markDelivered: (id, leaseOwner) => outbox.markDelivered(id, leaseOwner),
+            releaseClaim: (id, leaseOwner) => outbox.releaseClaim(id, leaseOwner),
+            inspect: (id) => outbox.inspect(id),
+          },
+          alerts: { notifySessionAttention: async (alert) => { alerts.push(alert); } },
+          schedule: () => {
+            const timer = timers.length + 1;
+            timers.push(timer);
+            return timer;
+          },
+          clearSchedule: (timer) => { clearedTimers.push(timer as number); },
+          close: async () => {
+            if (closedQueues.has(queue)) return;
+            closedQueues.add(queue);
+            closeCounts.set(queue, (closeCounts.get(queue) ?? 0) + 1);
+            await queue.close();
+          },
+        }),
+      );
+    }
+
+    const runtimeA = replica("replica-a", queueA);
+    const runtimeB = replica("replica-b", queueB);
+    runtimeA.start();
+    runtimeB.start();
+    expect(queueA).not.toBe(queueB);
+    expect(timers).toEqual([1, 2]);
+
+    await Promise.all([runtimeA.tick(), runtimeB.tick()]);
+    const episode = await episodes.findByBankCode(bankCode);
+    expect(episode).toMatchObject({
+      expiredEventId,
+      runId,
+      publicationState: "published",
+      publicationClaimToken: publicationToken,
+    });
+    expect(await prisma.auditEvent.count({ where: { id: expiryAuditId } })).toBe(1);
+    expect(await queueA.getJob(runId)).toBeDefined();
+
+    worker = new Worker(
+      queueName,
+      async (job) => {
+        job.discard();
+        throw new Error("synthetic publication failure");
+      },
+      { connection, concurrency: 1 },
+    );
+    await new Promise<void>((resolve) => worker!.once("ready", resolve));
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error("Timed out waiting for synthetic terminal failure")), 5_000);
+      worker!.on("failed", (job) => {
+        if (job?.id === runId) {
+          clearTimeout(timeout);
+          resolve();
+        }
+      });
+    });
+    await expect((await queueA.getJob(runId))?.getState()).resolves.toBe("failed");
+
+    await prisma.manualRecoveryResolution.create({
+      data: {
+        id: manualResolutionId,
+        expiredEventId: manualExpiredEventId,
+        bankCode,
+        runId: `manual-${runId}`,
+        outcome: "resolved_no_retry",
+        reason: "closed_without_retry",
+        operatorId: "operator-integration",
+        auditOutbox: { create: { id: manualOutboxId } },
+      },
+    });
+    await Promise.all([runtimeA.tick(), runtimeB.tick()]);
+    expect(ownersSeen).toEqual(new Set(["replica-a", "replica-b"]));
+    expect(await prisma.manualRecoveryResolutionAuditOutbox.count({
+      where: { id: manualOutboxId, state: "delivered" },
+    })).toBe(1);
+    expect(await prisma.auditEvent.count({ where: { id: manualAuditId } })).toBe(1);
+    expect(await prisma.auditEvent.count({ where: { id: terminalAuditId } })).toBe(1);
+    expect(alerts.filter((alert) => alert.safeSummary === "Automatic session recovery requires administrative review")).toHaveLength(1);
+    expect(JSON.stringify(alerts)).not.toMatch(/token|https?:\/\/|synthetic publication failure/i);
+
+    tickGate.wait = new Promise<void>((resolve) => { tickGate.release = resolve; });
+    const replicaAStats = localTickStats.get("replica-a")!;
+    const callsBeforeFinalTick = replicaAStats.calls;
+    const firstTick = runtimeA.tick();
+    runtimeA.tick();
+    const finalTick = runtimeB.tick();
+    await Promise.resolve();
+    expect(replicaAStats.calls).toBe(callsBeforeFinalTick + 1);
+    expect(replicaAStats.max).toBe(1);
+    const stoppingA = runtimeA.shutdown();
+    const stoppingB = runtimeB.shutdown();
+    let shutdownAComplete = false;
+    void stoppingA.then(() => { shutdownAComplete = true; });
+    await Promise.resolve();
+    expect(shutdownAComplete).toBe(false);
+    expect(new Set(clearedTimers)).toEqual(new Set([1, 2]));
+    tickGate.release?.();
+    await Promise.all([firstTick, finalTick, stoppingA, stoppingB, runtimeA.shutdown(), runtimeB.shutdown()]);
+    expect(new Set(clearedTimers)).toEqual(new Set([1, 2]));
+    expect(closeCounts.get(queueA)).toBe(1);
+    expect(closeCounts.get(queueB)).toBe(1);
+  });
+});

--- a/src/worker/expiry-runtime.integration.test.ts
+++ b/src/worker/expiry-runtime.integration.test.ts
@@ -37,8 +37,8 @@ const manualExpiredEventId = `manual-${randomUUID()}`;
 const manualResolutionId = `resolution-${randomUUID()}`;
 const manualOutboxId = `outbox-${randomUUID()}`;
 const expiryAuditWhere = { action: "bank_session.expired", target: "bank_session", metadata: { path: ["expiredEventId"], equals: expiredEventId } } satisfies Prisma.AuditEventWhereInput;
-const terminalAuditWhere = { target: "bank_session_expiry_episode", targetId: `${bankCode}:${expiredEventId}:${runId}` } satisfies Prisma.AuditEventWhereInput;
-const manualAuditWhere = { action: "bank_autologin.manual_recovery_resolved", target: "manual_recovery_resolution", targetId: manualResolutionId } satisfies Prisma.AuditEventWhereInput;
+const terminalAuditWhere = { action: "bank_autologin.needs_admin_action", target: "bank_session_expiry_episode", AND: [{ metadata: { path: ["expiredEventId"], equals: expiredEventId } }, { metadata: { path: ["runId"], equals: runId } }] } satisfies Prisma.AuditEventWhereInput;
+const manualAuditWhere = { action: "bank_autologin.manual_recovery_resolved", target: "manual_recovery_resolution", AND: [{ metadata: { path: ["expiredEventId"], equals: manualExpiredEventId } }, { metadata: { path: ["runId"], equals: `manual-${runId}` } }] } satisfies Prisma.AuditEventWhereInput;
 let prisma: PrismaClient | undefined;
 let Queue: typeof import("bullmq").Queue;
 let Worker: typeof import("bullmq").Worker;
@@ -105,8 +105,8 @@ describe.skipIf(!RUN_INTEGRATION)("expiry runtime integration (requires dedicate
     const ownersSeen = new Set<string>();
     const proposedTokens = new Map<string, string>();
     const alerts: Array<{ safeSummary: string }> = [];
-    const tickGate: { wait?: Promise<void>; release?: () => void; signalReplicaATick?: () => void } = {};
-    const localTickStats = new Map<string, { calls: number; active: number; max: number }>();
+    const runtimeTickGate: { wait?: Promise<void>; release?: () => void; signalReplicaATick?: () => void } = {};
+    const runtimeTickStats = new Map<string, { calls: number; active: number; max: number }>();
     let releaseClaimBarrier!: () => void;
     const claimBarrier = new Promise<void>((resolve) => { releaseClaimBarrier = resolve; });
 
@@ -114,7 +114,7 @@ describe.skipIf(!RUN_INTEGRATION)("expiry runtime integration (requires dedicate
       const stats = { calls: 0, active: 0, max: 0 };
       const proposedToken = `publication-${owner}-${randomUUID()}`;
       proposedTokens.set(owner, proposedToken);
-      localTickStats.set(owner, stats);
+      runtimeTickStats.set(owner, stats);
       const publisher = {
         schedule: (envelope: { bankCode: string; expiredEventId: string; runId: string; token: string }) =>
           scheduleExpiryPublicationJob(queue, envelope),
@@ -122,16 +122,7 @@ describe.skipIf(!RUN_INTEGRATION)("expiry runtime integration (requires dedicate
       };
       const monitor = createBankSessionMonitor({
         check: async () => {
-          stats.calls += 1;
-          stats.active += 1;
-          stats.max = Math.max(stats.max, stats.active);
-          try {
-            if (owner === "replica-a") tickGate.signalReplicaATick?.();
-            await tickGate.wait;
-            return { status: "expired", checkedAt: new Date().toISOString(), safeSummary: "Synthetic expiry" };
-          } finally {
-            stats.active -= 1;
-          }
+          return { status: "expired", checkedAt: new Date().toISOString(), safeSummary: "Synthetic expiry" };
         },
         intervalMs: 60_000,
         alertSink: { notifySessionAttention: async (alert) => { alerts.push(alert); } },
@@ -144,6 +135,20 @@ describe.skipIf(!RUN_INTEGRATION)("expiry runtime integration (requires dedicate
           publish: (episode) => publishExpiryEpisode(episodes, episode, proposedToken, publisher).then(() => undefined),
         },
       });
+      const runtimeMonitor = {
+        async tick() {
+          stats.calls += 1;
+          stats.active += 1;
+          stats.max = Math.max(stats.max, stats.active);
+          try {
+            if (owner === "replica-a") runtimeTickGate.signalReplicaATick?.();
+            await runtimeTickGate.wait;
+            return await monitor.tick();
+          } finally {
+            stats.active -= 1;
+          }
+        },
+      };
       return createExpiryRuntime(
         {
           RD_SYNC_SESSION_MONITOR: "enabled",
@@ -151,7 +156,7 @@ describe.skipIf(!RUN_INTEGRATION)("expiry runtime integration (requires dedicate
           RD_SYNC_REDIS_URL: TEST_REDIS_URL,
         },
         () => ({
-          monitor,
+          monitor: runtimeMonitor,
           episodes,
           publisher,
           auditSink,
@@ -252,12 +257,22 @@ describe.skipIf(!RUN_INTEGRATION)("expiry runtime integration (requires dedicate
     })).toBe(1);
     expect(await prisma.auditEvent.count({ where: manualAuditWhere })).toBe(1);
     expect(await prisma.auditEvent.count({ where: terminalAuditWhere })).toBe(1);
+    await prisma.auditEvent.create({
+      data: {
+        id: `semantic-duplicate-${randomUUID()}`,
+        action: "bank_autologin.manual_recovery_resolved",
+        target: "manual_recovery_resolution",
+        targetId: `duplicate-${manualResolutionId}`,
+        metadata: { bankCode, expiredEventId: manualExpiredEventId, runId: `manual-${runId}` },
+      },
+    });
+    expect(await prisma.auditEvent.count({ where: manualAuditWhere })).toBe(2);
     expect(alerts.filter((alert) => alert.safeSummary === "Automatic session recovery requires administrative review")).toHaveLength(1);
     expect(JSON.stringify(alerts)).not.toMatch(/token|https?:\/\/|synthetic publication failure/i);
 
-    tickGate.wait = new Promise<void>((resolve) => { tickGate.release = resolve; });
-    const replicaATickEntered = new Promise<void>((resolve) => { tickGate.signalReplicaATick = resolve; });
-    const replicaAStats = localTickStats.get("replica-a")!;
+    runtimeTickGate.wait = new Promise<void>((resolve) => { runtimeTickGate.release = resolve; });
+    const replicaATickEntered = new Promise<void>((resolve) => { runtimeTickGate.signalReplicaATick = resolve; });
+    const replicaAStats = runtimeTickStats.get("replica-a")!;
     const callsBeforeFinalTick = replicaAStats.calls;
     const firstTick = runtimeA.tick();
     void runtimeA.tick();
@@ -272,7 +287,7 @@ describe.skipIf(!RUN_INTEGRATION)("expiry runtime integration (requires dedicate
     await Promise.resolve();
     expect(shutdownAComplete).toBe(false);
     expect(new Set(clearedTimers)).toEqual(new Set([1, 2]));
-    tickGate.release?.();
+    runtimeTickGate.release?.();
     await Promise.all([firstTick, finalTick, stoppingA, stoppingB, runtimeA.shutdown(), runtimeB.shutdown()]);
     expect(new Set(clearedTimers)).toEqual(new Set([1, 2]));
     expect(closeCounts.get(queueA)).toBe(1);


### PR DESCRIPTION
# PR4q4: Two-replica expiry runtime proof

Adds an opt-in real PostgreSQL and Redis integration proof for the PR4q runtime without activating any browser or bank-login path.

## Chain context

PR #58 PR4q3 runtime owner
→ This PR: PR4q4 two-replica infrastructure proof and runbook

Base: PR #58 head 5cc2808.

## Changes

- Runs two independently constructed expiry runtimes against a dedicated PostgreSQL test database and Redis queue.
- Proves one durable expiry episode, one publication job, leased manual-recovery audit delivery, terminal reconciliation, and winner-only safe alerting.
- Proves same-replica non-overlap and idempotent graceful shutdown.
- Uses UUID-scoped database records and queue cleanup; never flushes Redis.
- Documents prerequisites, commands, evidence, cleanup, and safety boundaries.
- Marks B2.5 complete after the real local service proof passed.

## Verification

- Dedicated PostgreSQL database rd_sync_test: migrations applied.
- Local Compose PostgreSQL and Redis: healthy; Redis PONG.
- Focused real-service integration proof: 1 passed.
- Full suite: 1,235 passed, 98 skipped, 0 failed.
- Lint, typecheck, and diff-check: passed.
- Authored scope: 314 changed lines across three files.
- Review-driven development: disabled globally; delivered under ordinary repository gates.

## Safety boundary

No application worker, scraper, browser, CDP connection, credential retrieval, bank URL, or real login was started. No Redis flush or Docker volume deletion occurred.