### PR TITLE
feat(scraper): add configurable Popular lookback window

### DIFF
--- a/src/modules/bank-adapters/popular.test.ts
+++ b/src/modules/bank-adapters/popular.test.ts
@@ -23,7 +23,10 @@ describe("popularScraperProfile", () => {
       searchButtonText: "Buscar",
       resultsTable: "table:has-text('Fecha posteo')",
     });
-    expect(popularScraperProfile.defaultSearchMode).toBe("current-day");
+    expect(popularScraperProfile.defaultSearchMode).toBe("recent-lookback-window");
+    expect(popularPortalFixture.search.defaultSearchMode).toBe(
+      popularScraperProfile.defaultSearchMode,
+    );
   });
 });
 

--- a/src/modules/bank-adapters/popular.ts
+++ b/src/modules/bank-adapters/popular.ts
@@ -34,7 +34,7 @@ export interface PopularParseOptions {
 export const popularScraperProfile = {
   bankId: POPULAR_BANK_ID,
   accountFingerprint: POPULAR_ACCOUNT_FINGERPRINT,
-  defaultSearchMode: "current-day",
+  defaultSearchMode: "recent-lookback-window",
   selectors: {
     accountNumberText: POPULAR_ACCOUNT_NUMBER,
     accountTypeText: "Corriente",
@@ -62,7 +62,7 @@ export const popularPortalFixture = {
     currency: POPULAR_CURRENCY,
   },
   search: {
-    defaultSearchMode: "current-day",
+    defaultSearchMode: "recent-lookback-window",
     fromDate: "01/enero/2025",
     toDate: "01/enero/2025",
   },

--- a/src/modules/scrape-runs/scrape-runs.test.ts
+++ b/src/modules/scrape-runs/scrape-runs.test.ts
@@ -63,6 +63,25 @@ describe("filterScrapeRuns", () => {
 
     expect(result.map((run) => run.id)).toEqual(["run-newest", "run-middle"]);
   });
+
+  it("sorts runs by updatedAt descending", () => {
+    const result = filterScrapeRuns([
+      {
+        ...baseRun,
+        id: "run-updated-earlier",
+        createdAt: new Date("2026-06-08T15:00:00.000Z"),
+        updatedAt: new Date("2026-06-08T12:00:00.000Z"),
+      },
+      {
+        ...baseRun,
+        id: "run-updated-later",
+        createdAt: new Date("2026-06-08T11:00:00.000Z"),
+        updatedAt: new Date("2026-06-08T13:00:00.000Z"),
+      },
+    ], {});
+
+    expect(result.map((run) => run.id)).toEqual(["run-updated-later", "run-updated-earlier"]);
+  });
 });
 
 describe("toDashboardScrapeRun", () => {

--- a/src/modules/transactions/transactions.test.ts
+++ b/src/modules/transactions/transactions.test.ts
@@ -125,6 +125,21 @@ describe("filterTransactions", () => {
     expect(result.map((record) => record.id)).toEqual(["tx-2"]);
   });
 
+  it("sorts transactions by postedAt descending", () => {
+    const result = filterTransactions([
+      normalizeBankMovement(
+        { ...baseMovement, postedAt: "2026-06-07T08:45:00-04:00" },
+        { id: "tx-earlier" },
+      ),
+      normalizeBankMovement(
+        { ...baseMovement, postedAt: "2026-06-07T10:45:00-04:00" },
+        { id: "tx-later" },
+      ),
+    ], {});
+
+    expect(result.map((record) => record.id)).toEqual(["tx-later", "tx-earlier"]);
+  });
+
   it("returns an empty result for non-matching filters after evaluating data", () => {
     const result = filterTransactions(records, {
       bankId: "popular",
@@ -249,5 +264,4 @@ describe("InMemoryTransactionRepository", () => {
     expect(creditAfter?.reviewState).toBe("new");
   });
 });
-
 

--- a/src/worker/scraper/navigation/popular-cdp.test.ts
+++ b/src/worker/scraper/navigation/popular-cdp.test.ts
@@ -14,6 +14,10 @@ import {
   SAFE_SUMMARY_BROWSER_CAPACITY_THROTTLED,
 } from "../browser-runtime";
 import type { PopularTransactionRow } from "../../../modules/bank-adapters/popular";
+import {
+  formatPopularPortalDate,
+  SAFE_SUMMARY_POPULAR_PAGINATION_LIMIT_REACHED,
+} from "./popular";
 
 // ---------------------------------------------------------------------------
 // Synthetic fixture rows (same values as the brief fixture)
@@ -164,7 +168,7 @@ describe("createPopularCdpScraper — happy path", () => {
     expect(result.movements[1].direction).toBe("credit");
   });
 
-  it("returns status needs_admin_action when collectRows returns needs_admin_action", async () => {
+  it("propagates the pagination-limit signal without returning partial movements", async () => {
     const browser = new FakeCdpBrowser(() => makeFakeCdpPage());
     const scraper = createPopularCdpScraper({
       cdpUrl: "http://127.0.0.1:9222",
@@ -172,15 +176,50 @@ describe("createPopularCdpScraper — happy path", () => {
       connect: async (cdpEndpoint: string) => { void cdpEndpoint; return browser; },
       collectRows: async () => ({
         kind: "needs_admin_action" as const,
-        safeErrorSummary: "Bank session expired or requires verification",
+        safeErrorSummary: SAFE_SUMMARY_POPULAR_PAGINATION_LIMIT_REACHED,
       }),
     });
 
     const result = await scraper.collect();
 
-    expect(result.status).toBe("needs_admin_action");
-    expect(result.movements).toEqual([]);
-    expect(result.safeErrorSummary).toBe("Bank session expired or requires verification");
+    expect(result).toEqual({
+      status: "needs_admin_action",
+      movements: [],
+      safeErrorSummary: SAFE_SUMMARY_POPULAR_PAGINATION_LIMIT_REACHED,
+    });
+  });
+});
+
+describe("createPopularCdpScraper — lookback window", () => {
+  it("passes the configured Santo Domingo calendar window to portal collection", async () => {
+    const originalLookbackDays = process.env.RD_SYNC_SCRAPE_LOOKBACK_DAYS;
+    const browser = new FakeCdpBrowser(() => makeFakeCdpPage());
+    let scrapeWindow: { sDate: Date; eDate: Date } | undefined;
+
+    process.env.RD_SYNC_SCRAPE_LOOKBACK_DAYS = "7";
+    try {
+      const scraper = createPopularCdpScraper({
+        cdpUrl: "http://127.0.0.1:9222",
+        clock: () => new Date("2026-01-01T01:00:00Z"),
+        connect: async () => browser,
+        collectRows: async (_page, options) => {
+          scrapeWindow = { sDate: options.sDate, eDate: options.eDate };
+          return { kind: "rows" as const, rows: [] };
+        },
+      });
+
+      await scraper.collect();
+    } finally {
+      if (originalLookbackDays === undefined) {
+        delete process.env.RD_SYNC_SCRAPE_LOOKBACK_DAYS;
+      } else {
+        process.env.RD_SYNC_SCRAPE_LOOKBACK_DAYS = originalLookbackDays;
+      }
+    }
+
+    if (!scrapeWindow) throw new Error("collectRows was not called");
+    expect(formatPopularPortalDate(scrapeWindow.sDate)).toBe("25/12/2025");
+    expect(formatPopularPortalDate(scrapeWindow.eDate)).toBe("31/12/2025");
   });
 });
 

--- a/src/worker/scraper/navigation/popular-cdp.ts
+++ b/src/worker/scraper/navigation/popular-cdp.ts
@@ -18,6 +18,8 @@ import type { IngestionScraper } from "../../queues";
 import type { ScrapeCollectionResult } from "../../scraper";
 import {
   collectPopularPortalRows,
+  parseScrapeLookbackDays,
+  resolveScrapeWindow,
   type CollectPopularPortalRowsResult,
   type PopularPortalPage,
   type PortalTableSnapshot,
@@ -328,11 +330,14 @@ export function createPopularCdpScraper(options: PopularCdpScraperOptions = {}):
         cdpPage = await openCdpPageInDefaultContext(browser);
         const portalPage = new CdpPopularPortalPage(cdpPage);
 
-        const today = clock();
+        const scrapeWindow = resolveScrapeWindow(
+          clock(),
+          parseScrapeLookbackDays(process.env.RD_SYNC_SCRAPE_LOOKBACK_DAYS),
+        );
         const collectResult = await collectRows(portalPage, {
           baseUrl,
-          sDate: today,
-          eDate: today,
+          sDate: scrapeWindow.sDate,
+          eDate: scrapeWindow.eDate,
           itemsPerPage,
           maxPages,
           warmupPauseMs,

--- a/src/worker/scraper/navigation/popular.test.ts
+++ b/src/worker/scraper/navigation/popular.test.ts
@@ -4,6 +4,10 @@ import {
   formatPopularPortalDate,
   buildPopularTransactionsUrl,
   collectPopularPortalRows,
+  DEFAULT_SCRAPE_LOOKBACK_DAYS,
+  parseScrapeLookbackDays,
+  resolveScrapeWindow,
+  SAFE_SUMMARY_POPULAR_PAGINATION_LIMIT_REACHED,
   type PopularPortalPage,
   type PortalTableSnapshot,
 } from "./popular";
@@ -37,6 +41,28 @@ describe("formatPopularPortalDate", () => {
   });
 });
 
+describe("Popular scrape lookback window", () => {
+  it("defaults invalid values and clamps numeric values to the supported range", () => {
+    expect(parseScrapeLookbackDays(undefined)).toBe(DEFAULT_SCRAPE_LOOKBACK_DAYS);
+    expect(parseScrapeLookbackDays("")).toBe(DEFAULT_SCRAPE_LOOKBACK_DAYS);
+    expect(parseScrapeLookbackDays("not-a-number")).toBe(DEFAULT_SCRAPE_LOOKBACK_DAYS);
+    expect(parseScrapeLookbackDays("0")).toBe(1);
+    expect(parseScrapeLookbackDays("-3")).toBe(1);
+    expect(parseScrapeLookbackDays("32")).toBe(31);
+  });
+
+  it("resolves calendar dates in Santo Domingo across a UTC-near-midnight year boundary", () => {
+    const now = new Date("2026-01-01T01:00:00Z");
+    const oneDay = resolveScrapeWindow(now, 1);
+    const sevenDays = resolveScrapeWindow(now, 7);
+
+    expect(formatPopularPortalDate(oneDay.sDate)).toBe("31/12/2025");
+    expect(formatPopularPortalDate(oneDay.eDate)).toBe("31/12/2025");
+    expect(formatPopularPortalDate(sevenDays.sDate)).toBe("25/12/2025");
+    expect(formatPopularPortalDate(sevenDays.eDate)).toBe("31/12/2025");
+  });
+});
+
 // ---------------------------------------------------------------------------
 // buildPopularTransactionsUrl
 // ---------------------------------------------------------------------------
@@ -51,9 +77,10 @@ describe("buildPopularTransactionsUrl", () => {
   });
 
   it("encodes dates as dd%2Fmm%2Fyyyy (slash URL-encoded as %2F)", () => {
-    const date = new Date("2026-06-12T04:00:00Z");
-    const url = buildPopularTransactionsUrl({ baseUrl, sDate: date, eDate: date });
-    expect(url).toContain("sDate=12%2F06%2F2026");
+    const sDate = new Date("2026-06-06T04:00:00Z");
+    const eDate = new Date("2026-06-12T04:00:00Z");
+    const url = buildPopularTransactionsUrl({ baseUrl, sDate, eDate });
+    expect(url).toContain("sDate=06%2F06%2F2026");
     expect(url).toContain("eDate=12%2F06%2F2026");
   });
 
@@ -132,10 +159,11 @@ describe("collectPopularPortalRows — pagination URL construction", () => {
     expect(page.operations.find((op) => op.includes("itemsPerPage=100"))).toBeTruthy();
   });
 
-  it("paginates to page 2 when page 1 is full (itemsPerPage rows returned)", async () => {
+  it("does not report truncation when the final allowed page is short", async () => {
     const date = new Date("2026-06-12T04:00:00Z");
     const baseUrl = "https://ib.bpd.com.do";
     const itemsPerPage = 2;
+    const maxPages = 2;
     const page1Rows = [SYNTHETIC_ROW_1, SYNTHETIC_ROW_2];
     const page2Rows = [SYNTHETIC_ROW_3];
 
@@ -150,7 +178,7 @@ describe("collectPopularPortalRows — pagination URL construction", () => {
       ],
     });
 
-    const result = await collectPopularPortalRows(page, { baseUrl, sDate: date, eDate: date, itemsPerPage, warmupPauseMs: 0, settleIntervalMs: 0, settleFloorMs: 0, settleMaxMs: 0 });
+    const result = await collectPopularPortalRows(page, { baseUrl, sDate: date, eDate: date, itemsPerPage, maxPages, warmupPauseMs: 0, settleIntervalMs: 0, settleFloorMs: 0, settleMaxMs: 0 });
 
     expect(result.kind).toBe("rows");
     if (result.kind !== "rows") throw new Error("unreachable");
@@ -182,7 +210,7 @@ describe("collectPopularPortalRows — pagination URL construction", () => {
     expect(page.operations.some((op) => op.includes("pageNumber=2"))).toBe(false);
   });
 
-  it("enforces maxPages cap and stops before reading page maxPages+1", async () => {
+  it("reports a safe operator-visible signal when a full final allowed page may be truncated", async () => {
     const date = new Date("2026-06-12T04:00:00Z");
     const baseUrl = "https://ib.bpd.com.do";
     const itemsPerPage = 1;
@@ -202,9 +230,10 @@ describe("collectPopularPortalRows — pagination URL construction", () => {
 
     const result = await collectPopularPortalRows(page, { baseUrl, sDate: date, eDate: date, itemsPerPage, maxPages, warmupPauseMs: 0, settleIntervalMs: 0, settleFloorMs: 0, settleMaxMs: 0 });
 
-    expect(result.kind).toBe("rows");
-    if (result.kind !== "rows") throw new Error("unreachable");
-    expect(result.rows).toHaveLength(2); // only 2 pages read
+    expect(result).toEqual({
+      kind: "needs_admin_action",
+      safeErrorSummary: SAFE_SUMMARY_POPULAR_PAGINATION_LIMIT_REACHED,
+    });
     // No page 3
     expect(page.operations.some((op) => op.includes("pageNumber=3"))).toBe(false);
   });

--- a/src/worker/scraper/navigation/popular.ts
+++ b/src/worker/scraper/navigation/popular.ts
@@ -20,6 +20,14 @@ const DEFAULT_WARMUP_PAUSE_MS = 6_000;
 const DEFAULT_SETTLE_INTERVAL_MS = 1_500;
 const DEFAULT_SETTLE_FLOOR_MS = 8_000;
 const DEFAULT_SETTLE_MAX_MS = 25_000;
+const SANTO_DOMINGO_TIME_ZONE = "America/Santo_Domingo";
+const DAY_MS = 24 * 60 * 60 * 1_000;
+
+export const DEFAULT_SCRAPE_LOOKBACK_DAYS = 7;
+const MIN_SCRAPE_LOOKBACK_DAYS = 1;
+const MAX_SCRAPE_LOOKBACK_DAYS = 31;
+export const SAFE_SUMMARY_POPULAR_PAGINATION_LIMIT_REACHED =
+  "La consulta alcanzó el límite de páginas. Intente nuevamente con un rango de fechas más corto.";
 
 // These values come from the profile so the profile stops being dead code.
 const ACCOUNT_TYPE = "Corriente";
@@ -116,18 +124,57 @@ export interface BuildPopularTransactionsUrlOptions {
  * computed in the America/Santo_Domingo timezone (UTC-04:00, no DST).
  */
 export function formatPopularPortalDate(date: Date): string {
+  const { day, month, year } = getPopularPortalDateParts(date);
+  return `${day}/${month}/${year}`;
+}
+
+export function parseScrapeLookbackDays(value: string | undefined): number {
+  const normalized = value?.trim();
+  if (!normalized) return DEFAULT_SCRAPE_LOOKBACK_DAYS;
+
+  const parsed = Number(normalized);
+  if (!Number.isFinite(parsed)) return DEFAULT_SCRAPE_LOOKBACK_DAYS;
+
+  return Math.min(
+    MAX_SCRAPE_LOOKBACK_DAYS,
+    Math.max(MIN_SCRAPE_LOOKBACK_DAYS, Math.trunc(parsed)),
+  );
+}
+
+export function resolveScrapeWindow(
+  now: Date,
+  lookbackDays: number,
+): { sDate: Date; eDate: Date } {
+  const { day, month, year } = getPopularPortalDateParts(now);
+  const eDate = new Date(Date.UTC(Number(year), Number(month) - 1, Number(day), 12));
+  const normalizedLookbackDays = Number.isFinite(lookbackDays)
+    ? Math.min(
+      MAX_SCRAPE_LOOKBACK_DAYS,
+      Math.max(MIN_SCRAPE_LOOKBACK_DAYS, Math.trunc(lookbackDays)),
+    )
+    : DEFAULT_SCRAPE_LOOKBACK_DAYS;
+
+  return {
+    sDate: new Date(eDate.getTime() - (normalizedLookbackDays - 1) * DAY_MS),
+    eDate,
+  };
+}
+
+function getPopularPortalDateParts(date: Date): {
+  day: string;
+  month: string;
+  year: string;
+} {
   const fmt = new Intl.DateTimeFormat("en-CA", {
-    timeZone: "America/Santo_Domingo",
+    timeZone: SANTO_DOMINGO_TIME_ZONE,
     year: "numeric",
     month: "2-digit",
     day: "2-digit",
   });
 
-  // en-CA produces YYYY-MM-DD; split and re-order to dd/mm/yyyy.
   const parts = fmt.formatToParts(date);
   const get = (type: string): string => parts.find((p) => p.type === type)?.value ?? "00";
-
-  return `${get("day")}/${get("month")}/${get("year")}`;
+  return { day: get("day"), month: get("month"), year: get("year") };
 }
 
 /**
@@ -327,6 +374,13 @@ export async function collectPopularPortalRows(
 
     const pageRows = extractRowsFromSnapshot(snapshot);
     allRows.push(...pageRows);
+
+    if (pageRows.length === itemsPerPage && pageNumber === maxPages) {
+      return {
+        kind: "needs_admin_action",
+        safeErrorSummary: SAFE_SUMMARY_POPULAR_PAGINATION_LIMIT_REACHED,
+      };
+    }
 
     // Stop when fewer than a full page was returned
     if (pageRows.length < itemsPerPage) {


### PR DESCRIPTION
## Summary

- Query Banco Popular transactions across a configurable recent-day window instead of current-day only.
- Default RD_SYNC_SCRAPE_LOOKBACK_DAYS to 7 and safely clamp numeric values to 1..31 in the America/Santo_Domingo calendar.
- Fail closed with a fixed Spanish operator signal when the final allowed pagination page is full and results may be incomplete.
- Preserve sourceHash deduplication and pin transaction/run ordering contracts.

## Product boundary

This is an on-demand read-only query window, not backfill or recovery infrastructure. Auto-login, credentials, and browser mutation behavior are unchanged.

## Verification

- Focused tests: 98 passed.
- Full suite: 1,242 passed, 98 skipped.
- Lint, typecheck, and diff-check: passed.
- Authored scope: 188 additions, 25 deletions, 213 changed lines.
- Judgment Day: APPROVED; two fresh blind judges, zero confirmed findings. One unilateral fixture-date suspicion remained INFO and required no code change.

## Safety

- Invalid lookback configuration falls back safely without exposing raw values.
- Date math is based on America/Santo_Domingo calendar days.
- Potential maxPages truncation returns needs_admin_action with no partial movements.
- Re-reading previously captured transactions remains skipped by sourceHash.