### PR TITLE
feat(bank-sessions): expose safe expiry recovery contracts

### DIFF
--- a/src/modules/bank-sessions/expiry-episodes.test.ts
+++ b/src/modules/bank-sessions/expiry-episodes.test.ts
@@ -7,6 +7,7 @@ import {
   parseConsumerAttemptState,
   parseEpisodePublicationState,
   publishExpiryEpisode,
+  restoreExpiryEpisode,
   type BankSessionExpiryEpisode,
   type BankSessionExpiryEpisodeRepository,
   type ExpiryPublicationPublisher,
@@ -158,6 +159,75 @@ describe("Bank session expiry episodes", () => {
     expect(publish).toHaveBeenCalledTimes(1);
     expect(await episodes.findByBankCode("popular")).toBeNull();
     expect(await auditIdentities(audit)).toEqual([expect.objectContaining({ action: "bank_session.expired" }), expect.objectContaining({ action: "bank_session.restored" })]);
+  });
+
+  it("restores one exact episode through durable audits, cancellation, and identity-safe close", async () => {
+    const episodes = new InMemoryBankSessionExpiryEpisodeRepository();
+    const episode = (await episodes.getOrCreate({
+      bankCode: "popular", expiredEventId: "event-restoration-operation", runId: "popular-expiry-event-restoration-operation",
+    })).episode;
+    const steps: string[] = [];
+    const auditSink: Pick<AuditSink, "record"> = {
+      record: async (event) => { steps.push(event.action); },
+    };
+    const cancel = vi.spyOn(episodes, "cancelPublication").mockImplementation(async (current) => {
+      steps.push(`cancel:${current.expiredEventId}`);
+      return true;
+    });
+    const close = vi.spyOn(episodes, "close").mockImplementation(async (current) => {
+      steps.push(`close:${current.expiredEventId}`);
+      return "closed";
+    });
+
+    await expect(restoreExpiryEpisode(auditSink, episodes, episode, "2026-07-30T00:00:00.000Z"))
+      .resolves.toBe("closed");
+
+    expect(steps).toEqual([
+      "bank_session.expired",
+      "bank_session.restored",
+      "cancel:event-restoration-operation",
+      "close:event-restoration-operation",
+    ]);
+    expect(cancel).toHaveBeenCalledWith(episode);
+    expect(close).toHaveBeenCalledWith(episode);
+  });
+
+  it("retains manual recovery evidence when reusable restoration cannot close it", async () => {
+    const episodes = new InMemoryBankSessionExpiryEpisodeRepository();
+    const episode = (await episodes.getOrCreate({
+      bankCode: "popular", expiredEventId: "event-retained-operation", runId: "popular-expiry-event-retained-operation",
+    })).episode;
+    const envelope = await requireManualRecovery(episodes, episode);
+
+    await expect(restoreExpiryEpisode(new InMemoryAuditSink(), episodes, episode, "2026-07-30T00:00:00.000Z"))
+      .resolves.toBe("retained");
+
+    await expect(episodes.findByBankCode("popular")).resolves.toMatchObject({
+      expiredEventId: envelope.expiredEventId,
+      consumerAttemptState: "manual_recovery_required",
+      restoredAuditDelivered: true,
+    });
+  });
+
+  it("reports a replacement without allowing the reusable operation to close it", async () => {
+    const episodes = new InMemoryBankSessionExpiryEpisodeRepository();
+    const original = (await episodes.getOrCreate({
+      bankCode: "popular", expiredEventId: "event-original-operation", runId: "popular-expiry-event-original-operation",
+    })).episode;
+    const replacement = {
+      bankCode: "popular", expiredEventId: "event-replacement-operation", runId: "popular-expiry-event-replacement-operation",
+    };
+    const closeOriginal = episodes.close.bind(episodes);
+    vi.spyOn(episodes, "close").mockImplementation(async (episode) => {
+      await closeOriginal(episode);
+      await episodes.getOrCreate(replacement);
+      return "missing_or_stale";
+    });
+
+    await expect(restoreExpiryEpisode(new InMemoryAuditSink(), episodes, original, "2026-07-30T00:00:00.000Z"))
+      .resolves.toBe("missing_or_replaced");
+
+    await expect(episodes.findByBankCode("popular")).resolves.toMatchObject(replacement);
   });
 
   it("observes retained and evicted published jobs without scheduling another attempt", async () => {

--- a/src/modules/bank-sessions/expiry-episodes.ts
+++ b/src/modules/bank-sessions/expiry-episodes.ts
@@ -1,4 +1,6 @@
 import type { ManualRecoveryResolutionCommand, ManualRecoveryResolutionResult } from "./manual-recovery-resolution";
+import { createAuditEvent, type AuditSink } from "../audit";
+import { BANK_SESSION_ACTIONS } from "../audit/bank-actions";
 import {
   createManualRecoveryReplayAuthorizedAudit,
   type ManualRecoveryReplayAuthorizationCandidate,
@@ -130,6 +132,79 @@ export async function publishExpiryEpisode(
   }
   return episodes.markPublicationPublished(episode, token);
 }
+
+const EPISODE_AUDIT_ACTOR = "system:session-monitor";
+
+export async function deliverExpiryEpisodeAudit(
+  auditSink: Pick<AuditSink, "record"> | undefined,
+  episodes: BankSessionExpiryEpisodeRepository,
+  episode: BankSessionExpiryEpisode,
+  kind: SessionEpisodeAuditKind,
+  checkedAt: string,
+): Promise<boolean> {
+  try {
+    if (await episodes.isAuditDelivered(episode, kind)) return true;
+    if (!auditSink) return false;
+    const action = kind === "expired" ? BANK_SESSION_ACTIONS.EXPIRED : BANK_SESSION_ACTIONS.RESTORED;
+    await auditSink.record(createAuditEvent({
+      id: `bank-session-${action}:${episode.bankCode}:${episode.expiredEventId}`,
+      actorId: EPISODE_AUDIT_ACTOR,
+      actorRole: "system",
+      action,
+      target: "bank_session",
+      targetId: null,
+      metadata: { bankCode: episode.bankCode, expiredEventId: episode.expiredEventId, checkedAt },
+    }));
+    const marked = await episodes.markAuditDelivered(episode, kind);
+    return marked || await episodes.isAuditDelivered(episode, kind);
+  } catch {
+    return false;
+  }
+}
+
+export type ExpiryEpisodeRestorationResult = "closed" | "retained" | "missing_or_replaced";
+
+/**
+ * Restores one durable expiry episode without ever closing a replacement.
+ * Audit delivery deliberately precedes publication cancellation and close.
+ */
+export async function restoreExpiryEpisode(
+  auditSink: Pick<AuditSink, "record"> | undefined,
+  episodes: BankSessionExpiryEpisodeRepository,
+  episode: BankSessionExpiryEpisode,
+  checkedAt: string,
+): Promise<ExpiryEpisodeRestorationResult> {
+  if (!await deliverExpiryEpisodeAudit(auditSink, episodes, episode, "expired", checkedAt)) {
+    return reconcileRestorationEpisode(episodes, episode);
+  }
+  if (!await deliverExpiryEpisodeAudit(auditSink, episodes, episode, "restored", checkedAt)) {
+    return reconcileRestorationEpisode(episodes, episode);
+  }
+  try {
+    await episodes.cancelPublication(episode);
+    if (await episodes.close(episode) === "closed") return "closed";
+  } catch {
+    // A durable lookup below decides whether this exact episode remains retryable.
+  }
+  return reconcileRestorationEpisode(episodes, episode);
+}
+
+async function reconcileRestorationEpisode(
+  episodes: Pick<BankSessionExpiryEpisodeRepository, "findByBankCode">,
+  observed: Pick<BankSessionExpiryEpisode, "bankCode" | "expiredEventId" | "runId">,
+): Promise<"retained" | "missing_or_replaced"> {
+  try {
+    const current = await episodes.findByBankCode(observed.bankCode);
+    return current
+      && current.runId === observed.runId
+      && current.expiredEventId === observed.expiredEventId
+      ? "retained"
+      : "missing_or_replaced";
+  } catch {
+    return "retained";
+  }
+}
+
 export class InMemoryBankSessionExpiryEpisodeRepository implements BankSessionExpiryEpisodeRepository, ManualRecoveryReplayAuthorizationRepository {
   private readonly episodes = new Map<string, BankSessionExpiryEpisode>();
   private readonly resolutions: ManualRecoveryResolutionResult[] = [];

--- a/src/modules/bank-sessions/index.ts
+++ b/src/modules/bank-sessions/index.ts
@@ -9,6 +9,7 @@ import type {
   BankSessionExpiryEpisodeRepository,
   CreateBankSessionExpiryEpisodeInput,
 } from "./expiry-episodes";
+import { deliverExpiryEpisodeAudit, restoreExpiryEpisode } from "./expiry-episodes";
 import {
   CdpPopularPortalPage,
   type CdpBrowserLike,
@@ -303,24 +304,6 @@ export function createBankSessionMonitor(
   } | null = null;
   let handle: ScheduleHandle | null = null;
 
-  async function reconcileRecoveryEpisode(observedEpisode: BankSessionExpiryEpisode): Promise<boolean> {
-    try {
-      const currentEpisode = await expiryEpisodes?.findByBankCode(observedEpisode.bankCode);
-      if (
-        currentEpisode
-        && currentEpisode.runId === observedEpisode.runId
-        && currentEpisode.expiredEventId === observedEpisode.expiredEventId
-      ) {
-        recoveryEpisode = currentEpisode;
-        return false;
-      }
-      recoveryEpisode = null;
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
   async function tickOnce(): Promise<BankSessionCheckResult> {
     let result: BankSessionCheckResult;
     try {
@@ -370,7 +353,7 @@ export function createBankSessionMonitor(
         const durableEpisode = episodeResult.episode;
         createdEpisode = episodeResult.created;
         recoveryEpisode = durableEpisode;
-        expiryAuditAcknowledged = await deliverEpisodeAudit(auditSink, expiryEpisodes, durableEpisode, "expired", result);
+        expiryAuditAcknowledged = await deliverExpiryEpisodeAudit(auditSink, expiryEpisodes, durableEpisode, "expired", result.checkedAt);
         transitionReady = expiryAuditAcknowledged;
         if (createdEpisode) {
           expiryNotificationResult = candidate.observedResult;
@@ -396,41 +379,15 @@ export function createBankSessionMonitor(
     let recoveryWon = false;
     if (nextStatus === "active" && expiryEpisodes && recoveryEpisode) {
       const observedEpisode = recoveryEpisode;
-      const expiryAuditAcknowledged = await deliverEpisodeAudit(
+      const restoration = await restoreExpiryEpisode(
         auditSink,
         expiryEpisodes,
         observedEpisode,
-        "expired",
-        result,
+        result.checkedAt,
       );
-      if (!expiryAuditAcknowledged) {
-        recoveryClosed = await reconcileRecoveryEpisode(observedEpisode);
-      } else {
-        const restorationAuditAcknowledged = await deliverEpisodeAudit(
-          auditSink,
-          expiryEpisodes,
-          observedEpisode,
-          "restored",
-          result,
-        );
-        if (restorationAuditAcknowledged) {
-          try {
-            await expiryEpisodes.cancelPublication(observedEpisode);
-            const closeResult = await expiryEpisodes.close(observedEpisode);
-            recoveryWon = closeResult === "closed";
-            if (recoveryWon) {
-              recoveryEpisode = null;
-              recoveryClosed = true;
-            } else {
-              recoveryClosed = await reconcileRecoveryEpisode(observedEpisode);
-            }
-          } catch {
-            recoveryClosed = await reconcileRecoveryEpisode(observedEpisode);
-          }
-        } else {
-          recoveryClosed = await reconcileRecoveryEpisode(observedEpisode);
-        }
-      }
+      recoveryWon = restoration === "closed";
+      recoveryClosed = restoration !== "retained";
+      if (recoveryClosed) recoveryEpisode = null;
     }
 
     const usesDurableExpiryEpisodes = expiryEpisodes !== undefined && expiryBankCode !== undefined;
@@ -535,36 +492,5 @@ async function emitAudit(
     await auditSink.record(event);
   } catch {
     // Audit failures must never propagate.
-  }
-}
-
-async function deliverEpisodeAudit(
-  auditSink: Pick<AuditSink, "record"> | undefined,
-  episodes: BankSessionExpiryEpisodeRepository,
-  episode: BankSessionExpiryEpisode,
-  kind: "expired" | "restored",
-  result: BankSessionCheckResult,
-): Promise<boolean> {
-  try {
-    if (await episodes.isAuditDelivered(episode, kind)) return true;
-    if (!auditSink) return false;
-    const action = kind === "expired" ? BANK_SESSION_ACTIONS.EXPIRED : BANK_SESSION_ACTIONS.RESTORED;
-    await auditSink.record(createAuditEvent({
-      id: `bank-session-${action}:${episode.bankCode}:${episode.expiredEventId}`,
-      actorId: AUDIT_ACTOR,
-      actorRole: "system",
-      action,
-      target: "bank_session",
-      targetId: null,
-      metadata: {
-        bankCode: episode.bankCode,
-        expiredEventId: episode.expiredEventId,
-        checkedAt: result.checkedAt,
-      },
-    }));
-    const marked = await episodes.markAuditDelivered(episode, kind);
-    return marked || await episodes.isAuditDelivered(episode, kind);
-  } catch {
-    return false;
   }
 }

--- a/src/worker/scraper/index.ts
+++ b/src/worker/scraper/index.ts
@@ -36,11 +36,11 @@ export interface PlaywrightPageLike {
   };
 }
 
-export interface ScrapeCollectionResult {
-  status: ScrapeCollectionStatus;
-  movements: BankMovement[];
-  safeErrorSummary?: string;
-}
+export type ScrapeCollectionResult =
+  | { status: "collected"; movements: BankMovement[]; safeErrorSummary?: string; cause?: never }
+  | { status: "needs_admin_action"; movements: BankMovement[]; safeErrorSummary?: string; cause?: never }
+  /** Present only when navigation directly observed a login/session redirect. */
+  | { status: "needs_admin_action"; movements: BankMovement[]; safeErrorSummary?: string; cause: "session_expired" };
 
 export interface ReadOnlyBankScraper {
   collect(page: ReadOnlyBankPage): Promise<ScrapeCollectionResult>;

--- a/src/worker/scraper/navigation/popular-cdp.test.ts
+++ b/src/worker/scraper/navigation/popular-cdp.test.ts
@@ -188,6 +188,40 @@ describe("createPopularCdpScraper — happy path", () => {
       safeErrorSummary: SAFE_SUMMARY_POPULAR_PAGINATION_LIMIT_REACHED,
     });
   });
+
+  it("propagates only a navigation-observed session expiry cause", async () => {
+    const browser = new FakeCdpBrowser(() => makeFakeCdpPage());
+    const scraper = createPopularCdpScraper({
+      cdpUrl: "http://127.0.0.1:9222",
+      connect: async () => browser,
+      collectRows: async () => ({
+        kind: "needs_admin_action" as const,
+        safeErrorSummary: "Bank session expired or requires verification",
+        cause: "session_expired" as const,
+      }),
+    });
+
+    await expect(scraper.collect()).resolves.toMatchObject({
+      status: "needs_admin_action",
+      cause: "session_expired",
+    });
+  });
+
+  it("does not infer session expiry from an admin summary string", async () => {
+    const browser = new FakeCdpBrowser(() => makeFakeCdpPage());
+    const scraper = createPopularCdpScraper({
+      cdpUrl: "http://127.0.0.1:9222",
+      connect: async () => browser,
+      collectRows: async () => ({
+        kind: "needs_admin_action" as const,
+        safeErrorSummary: "Bank session expired or requires verification",
+      }),
+    });
+
+    const result = await scraper.collect();
+    expect(result.status).toBe("needs_admin_action");
+    expect(result).not.toHaveProperty("cause");
+  });
 });
 
 describe("createPopularCdpScraper — lookback window", () => {
@@ -283,6 +317,7 @@ describe("createPopularCdpScraper — connect failure", () => {
     expect(result.status).toBe("needs_admin_action");
     expect(result.movements).toEqual([]);
     expect(result.safeErrorSummary).toBe("Bank browser session is not available");
+    expect(result.cause).toBeUndefined();
   });
 
   it("rejects non-loopback CDP URLs before ensureBrowser or connect can run", async () => {
@@ -405,6 +440,7 @@ describe("createPopularCdpScraper — browser backpressure seam", () => {
       movements: [],
       safeErrorSummary: SAFE_SUMMARY_BROWSER_CAPACITY_THROTTLED,
     });
+    expect(throttledResult.cause).toBeUndefined();
     expect(blockedCalls).toEqual([]);
 
     let releaseCount = 0;

--- a/src/worker/scraper/navigation/popular-cdp.ts
+++ b/src/worker/scraper/navigation/popular-cdp.ts
@@ -351,6 +351,7 @@ export function createPopularCdpScraper(options: PopularCdpScraperOptions = {}):
             status: "needs_admin_action",
             movements: [],
             safeErrorSummary: collectResult.safeErrorSummary,
+            ...(collectResult.cause === "session_expired" ? { cause: "session_expired" as const } : {}),
           };
         }
 

--- a/src/worker/scraper/navigation/popular.test.ts
+++ b/src/worker/scraper/navigation/popular.test.ts
@@ -261,6 +261,7 @@ describe("collectPopularPortalRows — state detection", () => {
     expect(result.kind).toBe("needs_admin_action");
     if (result.kind !== "needs_admin_action") throw new Error("unreachable");
     expect(result.safeErrorSummary).toBe("Bank session expired or requires verification");
+    expect(result.cause).toBe("session_expired");
   });
 
   it("returns needs_admin_action when dashboard never renders (Producto wait times out)", async () => {
@@ -279,6 +280,7 @@ describe("collectPopularPortalRows — state detection", () => {
     expect(result.kind).toBe("needs_admin_action");
     if (result.kind !== "needs_admin_action") throw new Error("unreachable");
     expect(result.safeErrorSummary).toBe("Bank dashboard did not render");
+    expect(result.cause).toBeUndefined();
   });
 
   it("returns needs_admin_action when openDashboardAccount returns false (row not found)", async () => {
@@ -315,6 +317,7 @@ describe("collectPopularPortalRows — state detection", () => {
     expect(result.kind).toBe("needs_admin_action");
     if (result.kind !== "needs_admin_action") throw new Error("unreachable");
     expect(result.safeErrorSummary).toBe("Bank portal did not render transaction results");
+    expect(result.cause).toBeUndefined();
   });
 
   it("returns kind rows with empty array when table is present but has zero data rows", async () => {

--- a/src/worker/scraper/navigation/popular.ts
+++ b/src/worker/scraper/navigation/popular.ts
@@ -105,7 +105,8 @@ export interface PopularPortalPage {
 
 export type CollectPopularPortalRowsResult =
   | { kind: "rows"; rows: PopularTransactionRow[] }
-  | { kind: "needs_admin_action"; safeErrorSummary: string };
+  | { kind: "needs_admin_action"; safeErrorSummary: string; cause?: never }
+  | { kind: "needs_admin_action"; safeErrorSummary: string; cause: "session_expired" };
 
 // ---------------------------------------------------------------------------
 // buildPopularTransactionsUrl
@@ -312,6 +313,7 @@ export async function collectPopularPortalRows(
     return {
       kind: "needs_admin_action",
       safeErrorSummary: "Bank session expired or requires verification",
+      cause: "session_expired",
     };
   }
 
@@ -349,6 +351,7 @@ export async function collectPopularPortalRows(
       return {
         kind: "needs_admin_action",
         safeErrorSummary: "Bank session expired or requires verification",
+        cause: "session_expired",
       };
     }
 


### PR DESCRIPTION
## Summary

- Add a structured session_expired discriminator only for directly observed Popular login redirects.
- Preserve generic admin outcomes for portal drift, rendering failures, CDP failures, throttle, pagination, and protected flows.
- Extract reusable durable expiry restoration with audit delivery, publication cancellation, exact-identity close, and manual-recovery retention.
- Refactor the background monitor to reuse the same restoration operation.

## Chain context

📍 PR1: expiry classification and durable restoration contracts
└─ PR2: manual Run now activation, production opener wiring, one bounded retry

PR1 deliberately does not activate real auto-login. Production still wires unavailableScrapeTimeAutoLoginBrowserOpener.

## Verification

- Focused Popular/CDP/expiry/MFA/guard/lock tests: passed.
- Full suite: 1,247 passed, 98 skipped.
- Lint, typecheck, and diff-check: passed.
- Scope: 201 additions, 87 deletions, 288 changed lines.
- Native fresh review: approved; risk tier selected the reliability lens and found no issues.

## Safety

- No string parsing authorizes login.
- Only observed login redirects receive session_expired.
- No auto-login, credential, lookback, outbox, or monitor activation changes.
- autoLoginEnabled remains false by default.