### PR TITLE
feat(worker): activate manual Popular auto-login recovery

### DIFF
--- a/src/worker/ingestion-worker.ts
+++ b/src/worker/ingestion-worker.ts
@@ -42,9 +42,10 @@ import { createAuditEvent } from "../modules/audit";
 import { BANK_AUTOLOGIN_ACTIONS, BANK_CREDENTIAL_ACTIONS } from "../modules/audit/bank-actions";
 import { getPrismaClient } from "../modules/persistence/prisma-client";
 import { PrismaBankSessionExpiryEpisodeRepository } from "../modules/persistence/prisma-bank-session-expiry-episode-repository";
-import { popularScraperProfile } from "../modules/bank-adapters/popular";
-import { resolveBankBrowserEnv } from "./scraper/browser-runtime";
-import { createScrapeTimeAutoLoginRunner, unavailableScrapeTimeAutoLoginBrowserOpener, type BankAutoLoginStrategy } from "./scraper/auto-login";
+import { popularBankCode, popularScraperProfile } from "../modules/bank-adapters/popular";
+import { popularPortalConfig } from "../modules/bank-adapters/popular-portal";
+import { createAcquireBrowserSlotFromEnv, createEnsureBrowserForBank, resolveBankBrowserEnv } from "./scraper/browser-runtime";
+import { createScrapeTimeAutoLoginBrowserOpener, createScrapeTimeAutoLoginRunner, type BankAutoLoginStrategy } from "./scraper/auto-login";
 import { resolveDefaultScraper } from "../app/api/scrape-runs/consumer-defaults";
 import { defaultScrapeRunRepository } from "../app/api/scrape-runs/defaults";
 import { defaultTransactionRepository } from "../app/api/transactions/defaults";
@@ -72,6 +73,8 @@ const expiryRuntime = createDefaultExpiryRuntime();
 
 const connection = buildRedisConnectionOptions(redisUrl);
 const prisma = getPrismaClient();
+const expiryEpisodes = new PrismaBankSessionExpiryEpisodeRepository(prisma);
+const autoLoginConfigs = new BankAutoLoginConfigRepository(prisma);
 
 function toScrapeTimeAutoLoginStrategy(strategy: unknown, bankCode: string): BankAutoLoginStrategy {
   if (isScrapeTimeAutoLoginStrategy(strategy)) return strategy;
@@ -100,12 +103,19 @@ const runScrapeTimeAutoLogin = createScrapeTimeAutoLoginRunner({
       };
     },
   },
-  autoLoginConfigs: new BankAutoLoginConfigRepository(prisma),
+  autoLoginConfigs,
   credentials: new BankCredentialRepository(prisma),
   keyResolver: resolveCredentialKey,
   lock: defaultAutoLoginLock,
   cdpUrlForBankCode: (bankCode) => resolveBankBrowserEnv(bankCode, process.env).cdpUrl || undefined,
-  ensureBrowser: unavailableScrapeTimeAutoLoginBrowserOpener,
+  ensureBrowser: createScrapeTimeAutoLoginBrowserOpener({
+    trustedLoginUrl: popularPortalConfig.baseUrl,
+    ensureBrowserRuntime: createEnsureBrowserForBank(popularBankCode, process.env),
+    acquireBrowserSlot: createAcquireBrowserSlotFromEnv(process.env),
+  }),
+  recordFailure: async (bankCode, occurredAt) => {
+    await autoLoginConfigs.recordFailure(bankCode, occurredAt);
+  },
   async recordLockReleaseFailure({ bankCode, expiredEventId }) {
     await defaultAuditSink.record(createAuditEvent({
       actorId: "system:auto-login",
@@ -135,10 +145,11 @@ const processor = createIngestionProcessor({
   auditSink: defaultAuditSink,
   resolveScraper: resolveDefaultScraper,
   runScrapeTimeAutoLogin,
+  expiryEpisodes,
 });
 
 const expiryPublicationConsumer = createExpiryPublicationConsumer({
-  episodes: new PrismaBankSessionExpiryEpisodeRepository(prisma),
+  episodes: expiryEpisodes,
   gate: { check: async () => "eligible" },
   ingest: processor,
   resolveAccountFingerprint(bankCode) {

--- a/src/worker/queues/index.ts
+++ b/src/worker/queues/index.ts
@@ -1,7 +1,10 @@
 import type { JobsOptions } from "bullmq";
+import { randomUUID } from "node:crypto";
 
 import { createAuditEvent, type AuditSink } from "../../modules/audit";
 import { BANK_AUTOLOGIN_ACTIONS } from "../../modules/audit/bank-actions";
+import { createExpiredSessionRunId } from "../../modules/bank-sessions";
+import { restoreExpiryEpisode, type BankSessionExpiryEpisode, type BankSessionExpiryEpisodeRepository, type ExpiryPublicationEnvelope } from "../../modules/bank-sessions/expiry-episodes";
 import { type BankMovement, type TransactionRecord, normalizeBankMovement } from "../../modules/transactions";
 import type { ScrapeTimeAutoLoginOutcome } from "../scraper/auto-login";
 import { redactDiagnosticText, type ScrapeCollectionResult } from "../scraper";
@@ -102,6 +105,8 @@ export interface IngestionProcessorDependencies {
   auditSink?: Pick<AuditSink, "record">;
   now?: () => Date;
   runScrapeTimeAutoLogin?: (job: IngestionJob) => Promise<ScrapeTimeAutoLoginOutcome | null>;
+  expiryEpisodes?: BankSessionExpiryEpisodeRepository;
+  createExpiredEventId?: () => string;
 }
 
 export interface QueueLike {
@@ -137,28 +142,26 @@ export function createIngestionProcessor(dependencies: IngestionProcessorDepende
     });
 
     try {
-      const autoLoginOutcome = await runScrapeTimeAutoLoginIfNeeded(job, dependencies.runScrapeTimeAutoLogin);
-      if (autoLoginOutcome?.status === "needs_admin_action") {
-        return markNeedsAdminActionTerminal(
+      let scrapeResult = await scraper.collect();
+      if (scrapeResult.status === "needs_admin_action" && scrapeResult.cause === "session_expired") {
+        const recoveryResult = await recoverExpiredSession(
+          job,
           dependencies,
-          job.data,
-          requestedBankCode,
-          autoLoginOutcome.safeSummary,
+          scraper,
+          scrapeResult,
           now,
         );
+        if (isAutoLoginOutcome(recoveryResult)) {
+          if (recoveryResult.status === "throttled") {
+            return markThrottledDeferred(dependencies, job.data, requestedBankCode, recoveryResult.safeSummary, now);
+          }
+          if (recoveryResult.status === "needs_admin_action") {
+            return markNeedsAdminActionTerminal(dependencies, job.data, requestedBankCode, recoveryResult.safeSummary, now);
+          }
+        } else {
+          scrapeResult = recoveryResult;
+        }
       }
-
-      if (autoLoginOutcome?.status === "throttled") {
-        return markThrottledDeferred(
-          dependencies,
-          job.data,
-          requestedBankCode,
-          autoLoginOutcome.safeSummary,
-          now,
-        );
-      }
-
-      const scrapeResult = await scraper.collect();
 
       if (scrapeResult.status === "needs_admin_action") {
         const safeErrorSummary = scrapeResult.safeErrorSummary ?? "Bank session requires admin action";
@@ -202,20 +205,87 @@ export function createIngestionProcessor(dependencies: IngestionProcessorDepende
   };
 }
 
-async function runScrapeTimeAutoLoginIfNeeded(
+async function recoverExpiredSession(
   job: IngestionJob,
-  runScrapeTimeAutoLogin: IngestionProcessorDependencies["runScrapeTimeAutoLogin"],
-): Promise<ScrapeTimeAutoLoginOutcome | null> {
-  if (!job.data.expiredEventId || !runScrapeTimeAutoLogin) return null;
+  dependencies: Pick<IngestionProcessorDependencies, "auditSink" | "createExpiredEventId" | "expiryEpisodes" | "runScrapeTimeAutoLogin">,
+  scraper: IngestionScraper,
+  initialResult: Extract<ScrapeCollectionResult, { status: "needs_admin_action"; cause: "session_expired" }>,
+  now: () => Date,
+): Promise<ScrapeCollectionResult | ScrapeTimeAutoLoginOutcome> {
+  if (!dependencies.expiryEpisodes || !dependencies.runScrapeTimeAutoLogin) return initialResult;
+
+  const expiredEventId = (dependencies.createExpiredEventId ?? randomUUID)();
+  const durable = await dependencies.expiryEpisodes.getOrCreate({
+    bankCode: job.data.bankId,
+    expiredEventId,
+    runId: createExpiredSessionRunId(job.data.bankId, expiredEventId),
+  });
+  const reservation = await reserveAutoLoginAttempt(dependencies.expiryEpisodes, durable.episode);
+  if (!reservation) return { status: "manual_required", reason: "lock_busy", safeSummary: "Manual scrape required before retrying bank auto-login" };
+
+  let autoLoginOutcome: ScrapeTimeAutoLoginOutcome | null;
   try {
-    return await runScrapeTimeAutoLogin(job);
+    autoLoginOutcome = await dependencies.runScrapeTimeAutoLogin({
+      data: { ...job.data, expiredEventId: durable.episode.expiredEventId },
+    });
   } catch {
-    return {
-      status: "needs_admin_action",
-      reason: "browser_unavailable",
-      safeSummary: "Bank auto-login requires admin action",
-    };
+    await requireManualRecovery(dependencies.expiryEpisodes, reservation);
+    return { status: "needs_admin_action", reason: "browser_unavailable", safeSummary: "Bank auto-login requires admin action" };
   }
+  if (autoLoginOutcome?.status !== "succeeded") {
+    await requireManualRecovery(dependencies.expiryEpisodes, reservation);
+    return autoLoginOutcome ?? initialResult;
+  }
+
+  const recollected = await scraper.collect();
+  if (recollected.status !== "collected") {
+    await requireManualRecovery(dependencies.expiryEpisodes, reservation);
+    return recollected;
+  }
+  if (!await dependencies.expiryEpisodes.markConsumerResolved(reservation.envelope, reservation.consumerClaimToken)) {
+    return { status: "needs_admin_action", reason: "browser_unavailable", safeSummary: "Bank auto-login requires admin action" };
+  }
+  await restoreExpiryEpisode(
+    dependencies.auditSink,
+    dependencies.expiryEpisodes,
+    durable.episode,
+    now().toISOString(),
+  );
+  return recollected;
+}
+
+async function reserveAutoLoginAttempt(
+  episodes: BankSessionExpiryEpisodeRepository,
+  episode: BankSessionExpiryEpisode,
+): Promise<{ envelope: ExpiryPublicationEnvelope; consumerClaimToken: string } | null> {
+  const token = episode.publicationClaimToken ?? randomUUID();
+  const envelope = { bankCode: episode.bankCode, expiredEventId: episode.expiredEventId, runId: episode.runId, token };
+  try {
+    if (episode.publicationState !== "published") {
+      if (!await episodes.claimPublication(episode, token) || !await episodes.markPublicationPublished(episode, token)) return null;
+    }
+    const consumerClaimToken = randomUUID();
+    if (!await episodes.claimConsumerAttempt(envelope, consumerClaimToken)) return null;
+    if (!await episodes.markConsumerMutationStarted(envelope, consumerClaimToken)) return null;
+    return { envelope, consumerClaimToken };
+  } catch {
+    return null;
+  }
+}
+
+async function requireManualRecovery(
+  episodes: BankSessionExpiryEpisodeRepository,
+  reservation: { envelope: ExpiryPublicationEnvelope; consumerClaimToken: string },
+): Promise<void> {
+  try {
+    await episodes.markConsumerManualRecoveryRequired(reservation.envelope, reservation.consumerClaimToken);
+  } catch {
+    // The durable mutation_started marker remains fail-closed if the transition cannot persist.
+  }
+}
+
+function isAutoLoginOutcome(value: ScrapeCollectionResult | ScrapeTimeAutoLoginOutcome): value is ScrapeTimeAutoLoginOutcome {
+  return !("movements" in value);
 }
 
 async function markNeedsAdminActionTerminal(

--- a/src/worker/queues/queues.test.ts
+++ b/src/worker/queues/queues.test.ts
@@ -11,6 +11,7 @@ import {
 } from "./index";
 import type { BankMovement } from "../../modules/transactions";
 import { InMemoryAuditSink } from "../../modules/audit";
+import { InMemoryBankSessionExpiryEpisodeRepository } from "../../modules/bank-sessions/expiry-episodes";
 
 const jobData: IngestionJobData = {
   runId: "run-1",
@@ -500,29 +501,34 @@ describe("ingestion processor — resolveScraper routing", () => {
 });
 
 describe("ingestion processor — scrape-time auto-login trigger", () => {
-  it("runs the scrape-time auto-login trigger before collection when the job carries an expired event", async () => {
+  it("recovers only after structured session expiry, then recollects exactly once", async () => {
     const calls: string[] = [];
+    const episodes = new InMemoryBankSessionExpiryEpisodeRepository();
     const processor = createIngestionProcessor({
       scrapeRuns: new FakeScrapeRunRepository(),
       transactions: new FakeTransactionRepository({ inserted: 0, skipped: 0 }),
       scraper: {
         collect: async () => {
           calls.push("collect");
-          return { status: "collected", movements: [] };
+          return calls.length === 1
+            ? { status: "needs_admin_action" as const, cause: "session_expired" as const, movements: [] }
+            : { status: "collected" as const, movements: [] };
         },
       },
       runScrapeTimeAutoLogin: async (job) => {
         calls.push(`auto-login:${job.data.bankId}:${job.data.expiredEventId}`);
         return { status: "succeeded" };
       },
+      expiryEpisodes: episodes,
+      createExpiredEventId: () => "durable-expiry",
+      auditSink: new InMemoryAuditSink(),
     });
 
-    const result = await processor({
-      data: { ...jobData, expiredEventId: "expired-1" },
-    });
+    const result = await processor({ data: jobData });
 
     expect(result).toEqual({ status: "succeeded", inserted: 0, skipped: 0 });
-    expect(calls).toEqual(["auto-login:popular:expired-1", "collect"]);
+    expect(calls).toEqual(["collect", "auto-login:popular:durable-expiry", "collect"]);
+    expect(await episodes.findByBankCode("popular")).toBeNull();
   });
 
   it("does not run the scrape-time auto-login trigger without expiredEventId and still collects", async () => {
@@ -579,7 +585,7 @@ describe("ingestion processor — scrape-time auto-login trigger", () => {
     const result = await processor({ data: { ...jobData, expiredEventId: "expired-null-runner" } });
 
     expect(result).toEqual({ status: "succeeded", inserted: 0, skipped: 0 });
-    expect(runScrapeTimeAutoLogin).toHaveBeenCalledOnce();
+    expect(runScrapeTimeAutoLogin).not.toHaveBeenCalled();
     expect(collect).toHaveBeenCalledOnce();
     expect(scrapeRuns.transitions).toEqual([
       { runId: "run-1", status: "running" },
@@ -594,15 +600,15 @@ describe("ingestion processor — scrape-time auto-login trigger", () => {
       scrapeRuns,
       transactions,
       scraper: {
-        collect: async () => {
-          throw new Error("collect must not run after auto-login admin action");
-        },
+        collect: async () => ({ status: "needs_admin_action", cause: "session_expired", movements: [] }),
       },
       runScrapeTimeAutoLogin: async () => ({
         status: "needs_admin_action",
         reason: "protected_flow",
         safeSummary: "Bank auto-login requires admin action",
       }),
+      expiryEpisodes: new InMemoryBankSessionExpiryEpisodeRepository(),
+      createExpiredEventId: () => "expired-2",
     });
 
     const result = await processor({ data: { ...jobData, expiredEventId: "expired-2" } });
@@ -624,9 +630,7 @@ describe("ingestion processor — scrape-time auto-login trigger", () => {
     const transactions = new FakeTransactionRepository({ inserted: 0, skipped: 0 });
     const adminAlerts = new FakeAdminAlertSink();
     const auditSink = new InMemoryAuditSink();
-    const collect = vi.fn(async () => {
-      throw new Error("collect must not run after throttled auto-login");
-    });
+    const collect = vi.fn(async () => ({ status: "needs_admin_action" as const, cause: "session_expired" as const, movements: [] }));
     const processor = createIngestionProcessor({
       scrapeRuns,
       transactions,
@@ -637,12 +641,14 @@ describe("ingestion processor — scrape-time auto-login trigger", () => {
         status: "throttled",
         safeSummary: "Bank browser capacity is temporarily unavailable",
       }),
+      expiryEpisodes: new InMemoryBankSessionExpiryEpisodeRepository(),
+      createExpiredEventId: () => "expired-throttled",
     });
 
     const result = await processor({ data: { ...jobData, expiredEventId: "expired-throttled" } });
 
     expect(result).toEqual({ status: "throttled", inserted: 0, skipped: 0 });
-    expect(collect).not.toHaveBeenCalled();
+    expect(collect).toHaveBeenCalledOnce();
     expect(scrapeRuns.transitions).toEqual([
       { runId: "run-1", status: "running" },
       {
@@ -678,9 +684,7 @@ describe("ingestion processor — scrape-time auto-login trigger", () => {
     const transactions = new FakeTransactionRepository({ inserted: 0, skipped: 0 });
     const adminAlerts = new FakeAdminAlertSink();
     const auditSink = new InMemoryAuditSink();
-    const collect = vi.fn(async () => {
-      throw new Error("collect must not run after thrown auto-login");
-    });
+    const collect = vi.fn(async () => ({ status: "needs_admin_action" as const, cause: "session_expired" as const, movements: [] }));
     const processor = createIngestionProcessor({
       scrapeRuns,
       transactions,
@@ -690,12 +694,14 @@ describe("ingestion processor — scrape-time auto-login trigger", () => {
       runScrapeTimeAutoLogin: async () => {
         throw new Error("cdp unavailable token=secret password=abc cdp_url=internal-bank-host/session");
       },
+      expiryEpisodes: new InMemoryBankSessionExpiryEpisodeRepository(),
+      createExpiredEventId: () => "expired-throw",
     });
 
     const result = await processor({ data: { ...jobData, expiredEventId: "expired-throw" } });
 
     expect(result).toEqual({ status: "needs_admin_action", inserted: 0, skipped: 0 });
-    expect(collect).not.toHaveBeenCalled();
+    expect(collect).toHaveBeenCalledOnce();
     expect(scrapeRuns.transitions).toEqual([
       { runId: "run-1", status: "running" },
       {
@@ -737,19 +743,62 @@ describe("ingestion processor — scrape-time auto-login trigger", () => {
       scraper: {
         collect: async () => {
           calls.push("collect");
-          return { status: "needs_admin_action", movements: [], safeErrorSummary: "Manual login required" };
+          return { status: "needs_admin_action", cause: "session_expired", movements: [], safeErrorSummary: "Manual login required" };
         },
       },
       runScrapeTimeAutoLogin: async () => {
         calls.push("auto-login");
         return { status: "manual_required", reason: "lock_busy", safeSummary: "Manual scrape required before retrying bank auto-login" };
       },
+      expiryEpisodes: new InMemoryBankSessionExpiryEpisodeRepository(),
+      createExpiredEventId: () => "expired-3",
     });
 
     const result = await processor({ data: { ...jobData, expiredEventId: "expired-3" } });
 
     expect(result).toEqual({ status: "needs_admin_action", inserted: 0, skipped: 0 });
-    expect(calls).toEqual(["auto-login", "collect"]);
+    expect(calls).toEqual(["collect", "auto-login"]);
+  });
+
+  it("runs one durable attempt when sequential jobs reuse an episode after a non-success outcome", async () => {
+    const episodes = new InMemoryBankSessionExpiryEpisodeRepository();
+    const runScrapeTimeAutoLogin = vi.fn(async () => ({ status: "needs_admin_action" as const, reason: "unknown_post_submit_state" as const, safeSummary: "Bank auto-login requires admin action" }));
+    const processor = createIngestionProcessor({
+      scrapeRuns: new FakeScrapeRunRepository(), transactions: new FakeTransactionRepository({ inserted: 0, skipped: 0 }),
+      scraper: { collect: async () => ({ status: "needs_admin_action" as const, cause: "session_expired" as const, movements: [] }) },
+      expiryEpisodes: episodes, createExpiredEventId: () => "shared-expiry", runScrapeTimeAutoLogin,
+    });
+
+    await expect(processor({ data: { ...jobData, runId: "run-first" } })).resolves.toEqual({ status: "needs_admin_action", inserted: 0, skipped: 0 });
+    await expect(processor({ data: { ...jobData, runId: "run-second" } })).resolves.toEqual({ status: "needs_admin_action", inserted: 0, skipped: 0 });
+
+    expect(runScrapeTimeAutoLogin).toHaveBeenCalledTimes(1);
+    expect(await episodes.findByBankCode("popular")).toMatchObject({ consumerAttemptState: "manual_recovery_required" });
+  });
+
+  it("converges concurrent expiry jobs on one durable reservation before invoking the runner", async () => {
+    const episodes = new InMemoryBankSessionExpiryEpisodeRepository();
+    let releaseLogin: () => void = () => undefined;
+    let signalLoginStarted: () => void = () => undefined;
+    const loginMayFinish = new Promise<void>((resolve) => { releaseLogin = resolve; });
+    const loginStarted = new Promise<void>((resolve) => { signalLoginStarted = resolve; });
+    const runScrapeTimeAutoLogin = vi.fn(async () => { signalLoginStarted(); await loginMayFinish; return { status: "succeeded" as const }; });
+    const makeProcessor = () => createIngestionProcessor({
+      scrapeRuns: new FakeScrapeRunRepository(), transactions: new FakeTransactionRepository({ inserted: 0, skipped: 0 }),
+      scraper: { collect: vi.fn().mockResolvedValueOnce({ status: "needs_admin_action", cause: "session_expired", movements: [] }).mockResolvedValue({ status: "collected", movements: [] }) },
+      expiryEpisodes: episodes, createExpiredEventId: () => "shared-expiry", auditSink: new InMemoryAuditSink(),
+      runScrapeTimeAutoLogin,
+    });
+    const first = makeProcessor()({ data: { ...jobData, runId: "run-concurrent-1" } });
+    await loginStarted;
+    const second = makeProcessor()({ data: { ...jobData, runId: "run-concurrent-2" } });
+    releaseLogin();
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      { status: "succeeded", inserted: 0, skipped: 0 },
+      { status: "needs_admin_action", inserted: 0, skipped: 0 },
+    ]);
+    expect(runScrapeTimeAutoLogin).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/worker/scraper/auto-login.test.ts
+++ b/src/worker/scraper/auto-login.test.ts
@@ -842,6 +842,53 @@ describe("createScrapeTimeAutoLoginRunner", () => {
     expect(acquire).toHaveBeenCalledWith("popular", "E1");
     expect(release).toHaveBeenCalledWith("popular", "E1", "lease-1");
   });
+
+  it("records only executed unknown post-submit failures and skips after the breaker opens", async () => {
+    let breakerState: "closed" | "open" = "closed";
+    const recordFailure = vi.fn(async () => { if (recordFailure.mock.calls.length === 3) breakerState = "open"; });
+    const outcomes = [
+      { status: "needs_admin_action" as const, reason: "protected_flow" as const, safeSummary: "MFA required" },
+      ...Array.from({ length: 3 }, () => ({ status: "needs_admin_action" as const, reason: "unknown_post_submit_state" as const, safeSummary: "Unknown state" })),
+    ];
+    const autoLogin = vi.fn(async () => outcomes.shift()!);
+    const run = createScrapeTimeAutoLoginRunner({
+      adapterRegistry: { get: () => ({ bankCode: "popular", createAutoLoginStrategy: () => ({ bankCode: "popular", autoLogin }) }) },
+      autoLoginConfigs: { getByBankCode: async () => ({ autoLoginEnabled: true, breakerState }) },
+      credentials: { findByBankCode: async () => encryptedCredentialRecord() }, keyResolver,
+      lock: { acquire: async () => ({ leaseToken: "lease", fencingToken: 1, expiresAt: 1 }), release: async () => true },
+      cdpUrlForBankCode: () => "http://127.0.0.1:9222", ensureBrowser: async () => readyBrowser(makePage()), recordFailure,
+    });
+
+    await run({ data: { bankId: "popular", expiredEventId: "event-mfa" } });
+    await run({ data: { bankId: "popular", expiredEventId: "event-1" } });
+    await run({ data: { bankId: "popular", expiredEventId: "event-2" } });
+    await run({ data: { bankId: "popular", expiredEventId: "event-3" } });
+    await run({ data: { bankId: "popular", expiredEventId: "event-open" } });
+
+    expect(recordFailure).toHaveBeenCalledTimes(3);
+    expect(autoLogin).toHaveBeenCalledTimes(4);
+  });
+
+  it("fails closed without leaking persistence errors when an executed failure cannot update the breaker", async () => {
+    const rawRejection = "database token=secret password=bank-password unavailable";
+    const autoLogin = vi.fn().mockResolvedValue({ status: "needs_admin_action" as const, reason: "unknown_post_submit_state" as const, safeSummary: "Unknown state" });
+    const recordFailure = vi.fn().mockRejectedValue(new Error(rawRejection));
+    const run = createScrapeTimeAutoLoginRunner({
+      adapterRegistry: { get: () => ({ bankCode: "popular", createAutoLoginStrategy: () => ({ bankCode: "popular", autoLogin }) }) },
+      autoLoginConfigs: { getByBankCode: async () => ({ autoLoginEnabled: true, breakerState: "closed" }) },
+      credentials: { findByBankCode: async () => encryptedCredentialRecord() }, keyResolver,
+      lock: { acquire: async () => ({ leaseToken: "lease", fencingToken: 1, expiresAt: 1 }), release: async () => true },
+      cdpUrlForBankCode: () => "http://127.0.0.1:9222", ensureBrowser: async () => readyBrowser(makePage()), recordFailure,
+    });
+
+    const result = await run({ data: { bankId: "popular", expiredEventId: "event-persist-failure" } });
+
+    expect(result).toEqual({ status: "needs_admin_action", reason: "portal_state_unavailable", safeSummary: "Bank auto-login requires admin action" });
+    expect(recordFailure).toHaveBeenCalledTimes(1);
+    expect(autoLogin).toHaveBeenCalledTimes(1);
+    expect(JSON.stringify(result)).not.toContain("secret");
+    expect(JSON.stringify(result)).not.toContain("bank-password");
+  });
 });
 
 describe("createScrapeTimeAutoLoginBrowserOpener", () => {
@@ -885,6 +932,18 @@ describe("createScrapeTimeAutoLoginBrowserOpener", () => {
     browser.contexts.mockReturnValue([{ newPage: vi.fn().mockRejectedValue(new Error("page creation failed")) }]);
     await expect(open({ connect: vi.fn().mockResolvedValue(browser), acquireBrowserSlot: vi.fn().mockResolvedValue({ kind: "acquired", release }) })).rejects.toThrow("page creation failed");
     expect({ browser: browser.close.mock.calls.length, browserSlot: release.mock.calls.length }).toEqual({ browser: 1, browserSlot: 1 });
+  });
+  it("returns throttled without connecting when shared browser capacity is unavailable", async () => {
+    const connect = vi.fn();
+    await expect(open({ connect, acquireBrowserSlot: vi.fn().mockResolvedValue({ kind: "throttled" }) })).resolves.toEqual({ status: "throttled" });
+    expect(connect).not.toHaveBeenCalled();
+  });
+  it("rejects non-loopback CDP before acquiring capacity or connecting", async () => {
+    const connect = vi.fn();
+    const acquireBrowserSlot = vi.fn();
+    await expect(createScrapeTimeAutoLoginBrowserOpener({ trustedLoginUrl: POPULAR_LOGIN_URL, connect, acquireBrowserSlot })("popular", "http://10.0.0.5:9222")).rejects.toThrow("loopback");
+    expect(acquireBrowserSlot).not.toHaveBeenCalled();
+    expect(connect).not.toHaveBeenCalled();
   });
   it("cleans up the page, browser, and slot after trusted navigation rejects", async () => {
     const release = vi.fn().mockResolvedValue(undefined);

--- a/src/worker/scraper/auto-login.ts
+++ b/src/worker/scraper/auto-login.ts
@@ -127,6 +127,7 @@ export interface ScrapeTimeAutoLoginRunnerDependencies {
   ensureBrowser(bankCode: string, cdpUrl: string): Promise<ScrapeTimeAutoLoginBrowserResult>;
   recordLockReleaseFailure?(metadata: { bankCode: string; expiredEventId: string }): void | Promise<void>;
   recordCredentialDecryptUse?(metadata: { bankCode: string; keyVersion: number }): void | Promise<void>;
+  recordFailure?(bankCode: string, occurredAt: Date): void | Promise<void>;
   beforeAutoLoginMutation?(metadata: AutoLoginMutationHookMetadata): boolean | Promise<boolean>;
   afterAutoLoginOutcome?(metadata: AutoLoginOutcomeHookMetadata): void | Promise<void>;
 }
@@ -330,7 +331,12 @@ export function createScrapeTimeAutoLoginRunner(deps: ScrapeTimeAutoLoginRunnerD
       ensureBrowser: (url) => deps.ensureBrowser(bankCode, url),
       recordLockReleaseFailure: deps.recordLockReleaseFailure,
       beforeAutoLoginMutation: deps.beforeAutoLoginMutation,
-      afterAutoLoginOutcome: deps.afterAutoLoginOutcome,
+      afterAutoLoginOutcome: async (metadata) => {
+        if (metadata.outcome.status === "needs_admin_action" && metadata.outcome.reason === "unknown_post_submit_state") {
+          await deps.recordFailure?.(metadata.bankCode, new Date());
+        }
+        await deps.afterAutoLoginOutcome?.(metadata);
+      },
     });
   };
 }
@@ -492,7 +498,7 @@ async function runOwnedAutoLogin(context: ScrapeTimeAutoLoginTriggerContext, cdp
       outcome: outcome.status === "succeeded" ? outcome : { status: outcome.status, reason: outcome.reason },
     });
   } catch {
-    if (outcome.status === "succeeded") return needsAdminAction("portal_state_unavailable");
+    return needsAdminAction("portal_state_unavailable");
   }
   return outcome;
 }


### PR DESCRIPTION
## Summary

- Attempt normal manual collection first and recover only from the typed session_expired result introduced by PR #61.
- Create or reuse the durable bank expiry episode, reserve its single consumer attempt, run auto-login with the returned identity, and recollect exactly once.
- Wire the existing production CDP opener with Popular trusted config, loopback enforcement, shared browser capacity, and bounded cleanup.
- Persist only executed unknown post-submit failures into the conservative breaker and fail closed if that persistence fails.

## Chain context

PR #61: typed expiry and durable restoration contracts
└─ 📍 This PR: manual Run now activation and one bounded retry

Base: PR #61 head 52bfbeb.

## Design decision

Uses collect-first recovery: the happy path adds no extra session check. Only a structured session_expired result may create/reuse an episode and enter auto-login. A successful recovery triggers exactly one recollection; a second expiry never loops.

## Safety

- Durable attempt reservation enforces maxAttemptsPerEvent=1 across sequential and concurrent jobs.
- Redis lock unavailable/busy, breaker open, kill switch off, throttle, MFA, incompatible, and unknown protected flows fail closed.
- Existing mutation guards remain before every credential fill and submit.
- Breaker counts only executed unknown post-submit outcomes; persistence failure returns a safe admin outcome.
- No raw errors, credentials, tokens, or CDP details are exposed.
- autoLoginEnabled remains false by default; background monitor remains disabled.

## Verification

- Full suite: 1,253 passed, 98 skipped.
- Focused correction tests: 80 passed.
- Lint, typecheck, and diff-check: passed.
- Scope against PR #61: 251 additions, 56 deletions, 307 changed lines.
- Native fresh review found two critical issues; both were corrected within one bounded transaction and independently validated. Final receipt approved.