### PR TITLE
fix(bank-auto-login): tolerate real Popular portal timing

### DIFF
--- a/src/worker/auto-login-composition.test.ts
+++ b/src/worker/auto-login-composition.test.ts
@@ -1,0 +1,42 @@
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, it } from "vitest";
+
+import { InMemoryAuditSink } from "../modules/audit";
+import { BANK_AUTOLOGIN_ACTIONS } from "../modules/audit/bank-actions";
+import { createProductionAutoLoginOutcomeHook } from "./auto-login-composition";
+
+describe("ingestion worker auto-login composition", () => {
+  it("records exactly one canonical event for every typed runner outcome", async () => {
+    const auditSink = new InMemoryAuditSink();
+    const afterAutoLoginOutcome = createProductionAutoLoginOutcomeHook(auditSink);
+    const metadata = { bankCode: "popular", expiredEventId: "expired-1", runId: "run-1" };
+
+    await afterAutoLoginOutcome({ ...metadata, outcome: { status: "succeeded" } });
+    await afterAutoLoginOutcome({ ...metadata, outcome: { status: "needs_admin_action", reason: "protected_flow", safeSummary: "Bank auto-login requires admin action" } });
+    await afterAutoLoginOutcome({ ...metadata, outcome: { status: "manual_required", reason: "lock_busy", safeSummary: "Manual scrape required before retrying bank auto-login" } });
+    await afterAutoLoginOutcome({ ...metadata, outcome: { status: "throttled", safeSummary: "Bank browser capacity is temporarily unavailable" } });
+
+    const events = await auditSink.list();
+
+    expect(events).toHaveLength(4);
+    expect(events.map((event) => event.action).sort()).toEqual([
+      BANK_AUTOLOGIN_ACTIONS.NEEDS_ADMIN_ACTION,
+      BANK_AUTOLOGIN_ACTIONS.SKIPPED,
+      BANK_AUTOLOGIN_ACTIONS.SKIPPED,
+      BANK_AUTOLOGIN_ACTIONS.SUCCEEDED,
+    ].sort());
+    expect(events.map((event) => event.metadata)).toEqual(expect.arrayContaining([
+      { bankCode: "popular", expiredEventId: "expired-1", runId: "run-1", reason: "succeeded" },
+      { bankCode: "popular", expiredEventId: "expired-1", runId: "run-1", reason: "protected_flow" },
+      { bankCode: "popular", expiredEventId: "expired-1", runId: "run-1", reason: "lock_busy" },
+      { bankCode: "popular", expiredEventId: "expired-1", runId: "run-1", reason: "throttled" },
+    ]));
+  });
+
+  it("uses the production outcome hook from the real worker composition root", async () => {
+    const workerSource = await readFile(new URL("./ingestion-worker.ts", import.meta.url), "utf8");
+
+    expect(workerSource).toContain("afterAutoLoginOutcome: createProductionAutoLoginOutcomeHook(defaultAuditSink)");
+  });
+});

--- a/src/worker/auto-login-composition.ts
+++ b/src/worker/auto-login-composition.ts
@@ -1,0 +1,29 @@
+import { createAuditEvent, type AuditSink } from "../modules/audit";
+import { BANK_AUTOLOGIN_ACTIONS } from "../modules/audit/bank-actions";
+import type { AutoLoginOutcomeHookMetadata } from "./scraper/auto-login";
+
+const SYSTEM_AUTOLOGIN_ACTOR = "system:auto-login";
+
+export function createProductionAutoLoginOutcomeHook(auditSink: Pick<AuditSink, "record">) {
+  return async ({ bankCode, expiredEventId, runId, outcome }: AutoLoginOutcomeHookMetadata): Promise<void> => {
+    const action = outcome.status === "succeeded"
+      ? BANK_AUTOLOGIN_ACTIONS.SUCCEEDED
+      : outcome.status === "needs_admin_action"
+        ? BANK_AUTOLOGIN_ACTIONS.NEEDS_ADMIN_ACTION
+        : BANK_AUTOLOGIN_ACTIONS.SKIPPED;
+    const reason = outcome.status === "succeeded" ? "succeeded" : outcome.status === "throttled" ? "throttled" : outcome.reason;
+
+    try {
+      await auditSink.record(createAuditEvent({
+        actorId: SYSTEM_AUTOLOGIN_ACTOR,
+        actorRole: null,
+        action,
+        target: "scrape_run",
+        targetId: runId,
+        metadata: { bankCode, expiredEventId, runId, reason },
+      }));
+    } catch {
+      // Audit persistence must not affect the protected auto-login flow.
+    }
+  };
+}

--- a/src/worker/ingestion-worker.ts
+++ b/src/worker/ingestion-worker.ts
@@ -45,7 +45,7 @@ import { PrismaBankSessionExpiryEpisodeRepository } from "../modules/persistence
 import { popularBankCode, popularScraperProfile } from "../modules/bank-adapters/popular";
 import { popularPortalConfig } from "../modules/bank-adapters/popular-portal";
 import { createAcquireBrowserSlotFromEnv, createEnsureBrowserForBank, resolveBankBrowserEnv } from "./scraper/browser-runtime";
-import { createScrapeTimeAutoLoginBrowserOpener, createScrapeTimeAutoLoginRunner, type BankAutoLoginStrategy } from "./scraper/auto-login";
+import { createScrapeTimeAutoLoginBrowserOpener, createScrapeTimeAutoLoginRunner, parseAutoLoginSelectorTimeoutMs, type BankAutoLoginStrategy } from "./scraper/auto-login";
 import { resolveDefaultScraper } from "../app/api/scrape-runs/consumer-defaults";
 import { defaultScrapeRunRepository } from "../app/api/scrape-runs/defaults";
 import { defaultTransactionRepository } from "../app/api/transactions/defaults";
@@ -110,6 +110,7 @@ const runScrapeTimeAutoLogin = createScrapeTimeAutoLoginRunner({
   cdpUrlForBankCode: (bankCode) => resolveBankBrowserEnv(bankCode, process.env).cdpUrl || undefined,
   ensureBrowser: createScrapeTimeAutoLoginBrowserOpener({
     trustedLoginUrl: popularPortalConfig.baseUrl,
+    visibleSelectorTimeoutMs: parseAutoLoginSelectorTimeoutMs(process.env.RD_SYNC_AUTOLOGIN_SELECTOR_TIMEOUT_MS),
     ensureBrowserRuntime: createEnsureBrowserForBank(popularBankCode, process.env),
     acquireBrowserSlot: createAcquireBrowserSlotFromEnv(process.env),
   }),

--- a/src/worker/ingestion-worker.ts
+++ b/src/worker/ingestion-worker.ts
@@ -51,6 +51,7 @@ import { defaultScrapeRunRepository } from "../app/api/scrape-runs/defaults";
 import { defaultTransactionRepository } from "../app/api/transactions/defaults";
 import { defaultAuditSink } from "../app/api/audit/defaults";
 import { createIngestionProcessor } from "./queues";
+import { createProductionAutoLoginOutcomeHook } from "./auto-login-composition";
 
 // ---------------------------------------------------------------------------
 // Fail fast if required env vars are absent
@@ -137,6 +138,7 @@ const runScrapeTimeAutoLogin = createScrapeTimeAutoLoginRunner({
       metadata: { bankCode, keyVersion },
     }));
   },
+  afterAutoLoginOutcome: createProductionAutoLoginOutcomeHook(defaultAuditSink),
 });
 
 const processor = createIngestionProcessor({

--- a/src/worker/queues/index.ts
+++ b/src/worker/queues/index.ts
@@ -158,6 +158,10 @@ export function createIngestionProcessor(dependencies: IngestionProcessorDepende
           if (recoveryResult.status === "needs_admin_action") {
             return markNeedsAdminActionTerminal(dependencies, job.data, requestedBankCode, recoveryResult.safeSummary, now);
           }
+          if (recoveryResult.status === "succeeded") {
+            return markNeedsAdminActionTerminal(dependencies, job.data, requestedBankCode, "Bank auto-login requires admin action", now);
+          }
+          return markNeedsAdminActionTerminal(dependencies, job.data, requestedBankCode, recoveryResult.safeSummary, now);
         } else {
           scrapeResult = recoveryResult;
         }
@@ -221,7 +225,11 @@ async function recoverExpiredSession(
     runId: createExpiredSessionRunId(job.data.bankId, expiredEventId),
   });
   const reservation = await reserveAutoLoginAttempt(dependencies.expiryEpisodes, durable.episode);
-  if (!reservation) return { status: "manual_required", reason: "lock_busy", safeSummary: "Manual scrape required before retrying bank auto-login" };
+  if (!reservation) {
+    const outcome = { status: "manual_required", reason: "lock_busy", safeSummary: "Manual scrape required before retrying bank auto-login" } as const;
+    await emitAutoLoginOutcomeAuditEvent(dependencies.auditSink, job.data.runId, durable.episode.expiredEventId, durable.episode.bankCode, outcome);
+    return outcome;
+  }
 
   let autoLoginOutcome: ScrapeTimeAutoLoginOutcome | null;
   try {
@@ -230,12 +238,19 @@ async function recoverExpiredSession(
     });
   } catch {
     await requireManualRecovery(dependencies.expiryEpisodes, reservation);
-    return { status: "needs_admin_action", reason: "browser_unavailable", safeSummary: "Bank auto-login requires admin action" };
+    const outcome = { status: "needs_admin_action", reason: "auto_login_execution_failed", safeSummary: "Bank auto-login requires admin action" } as const;
+    await emitAutoLoginOutcomeAuditEvent(dependencies.auditSink, job.data.runId, durable.episode.expiredEventId, durable.episode.bankCode, outcome);
+    return outcome;
   }
   if (autoLoginOutcome?.status !== "succeeded") {
     await requireManualRecovery(dependencies.expiryEpisodes, reservation);
+    if (autoLoginOutcome) {
+      await emitAutoLoginOutcomeAuditEvent(dependencies.auditSink, job.data.runId, durable.episode.expiredEventId, durable.episode.bankCode, autoLoginOutcome);
+    }
     return autoLoginOutcome ?? initialResult;
   }
+
+  await emitAutoLoginOutcomeAuditEvent(dependencies.auditSink, job.data.runId, durable.episode.expiredEventId, durable.episode.bankCode, autoLoginOutcome);
 
   const recollected = await scraper.collect();
   if (recollected.status !== "collected") {
@@ -325,12 +340,6 @@ async function markThrottledDeferred(
     bankId: requestedBankCode,
     metadata: { safeErrorSummary },
   });
-  await emitAutoLoginThrottledAuditEvent(
-    dependencies.auditSink,
-    jobData.runId,
-    requestedBankCode,
-  );
-
   return { status: "throttled", inserted: 0, skipped: 0 };
 }
 
@@ -390,21 +399,29 @@ async function emitAuditEvent(
   }
 }
 
-async function emitAutoLoginThrottledAuditEvent(
+async function emitAutoLoginOutcomeAuditEvent(
   auditSink: Pick<AuditSink, "record"> | undefined,
   runId: string,
+  expiredEventId: string,
   bankCode: string,
+  outcome: ScrapeTimeAutoLoginOutcome,
 ): Promise<void> {
   if (!auditSink) return;
+  const action = outcome.status === "succeeded"
+    ? BANK_AUTOLOGIN_ACTIONS.SUCCEEDED
+    : outcome.status === "needs_admin_action"
+      ? BANK_AUTOLOGIN_ACTIONS.NEEDS_ADMIN_ACTION
+      : BANK_AUTOLOGIN_ACTIONS.SKIPPED;
+  const reason = outcome.status === "succeeded" ? "succeeded" : outcome.status === "throttled" ? "throttled" : outcome.reason;
   try {
     await auditSink.record(
       createAuditEvent({
         actorId: SYSTEM_AUTOLOGIN_ACTOR,
         actorRole: null,
-        action: BANK_AUTOLOGIN_ACTIONS.SKIPPED,
+        action,
         target: "scrape_run",
         targetId: runId,
-        metadata: { bankCode, reason: "throttled" },
+        metadata: { bankCode, expiredEventId, runId, reason },
       }),
     );
   } catch {

--- a/src/worker/queues/index.ts
+++ b/src/worker/queues/index.ts
@@ -244,13 +244,8 @@ async function recoverExpiredSession(
   }
   if (autoLoginOutcome?.status !== "succeeded") {
     await requireManualRecovery(dependencies.expiryEpisodes, reservation);
-    if (autoLoginOutcome) {
-      await emitAutoLoginOutcomeAuditEvent(dependencies.auditSink, job.data.runId, durable.episode.expiredEventId, durable.episode.bankCode, autoLoginOutcome);
-    }
     return autoLoginOutcome ?? initialResult;
   }
-
-  await emitAutoLoginOutcomeAuditEvent(dependencies.auditSink, job.data.runId, durable.episode.expiredEventId, durable.episode.bankCode, autoLoginOutcome);
 
   const recollected = await scraper.collect();
   if (recollected.status !== "collected") {

--- a/src/worker/queues/queues.test.ts
+++ b/src/worker/queues/queues.test.ts
@@ -531,9 +531,7 @@ describe("ingestion processor — scrape-time auto-login trigger", () => {
     expect(result).toEqual({ status: "succeeded", inserted: 0, skipped: 0 });
     expect(calls).toEqual(["collect", "auto-login:popular:durable-expiry", "collect"]);
     expect(await episodes.findByBankCode("popular")).toBeNull();
-    expect((await auditSink.list()).filter((event) => event.action === BANK_AUTOLOGIN_ACTIONS.SUCCEEDED)).toMatchObject([{
-      metadata: { bankCode: "popular", expiredEventId: "durable-expiry", runId: "run-1", reason: "succeeded" },
-    }]);
+    expect((await auditSink.list()).filter((event) => event.action === BANK_AUTOLOGIN_ACTIONS.SUCCEEDED)).toHaveLength(0);
   });
 
   it("does not run the scrape-time auto-login trigger without expiredEventId and still collects", async () => {
@@ -630,9 +628,7 @@ describe("ingestion processor — scrape-time auto-login trigger", () => {
       },
     ]);
     expect(transactions.received).toEqual([]);
-    expect((await auditSink.list()).filter((event) => event.action === BANK_AUTOLOGIN_ACTIONS.NEEDS_ADMIN_ACTION)).toMatchObject([{
-      metadata: { bankCode: "popular", expiredEventId: "expired-2", runId: "run-1", reason: "protected_flow" },
-    }]);
+    expect((await auditSink.list()).filter((event) => event.action === BANK_AUTOLOGIN_ACTIONS.NEEDS_ADMIN_ACTION)).toHaveLength(0);
   });
 
   it("persists throttled auto-login as deferred without collecting or alerting admins", async () => {
@@ -677,15 +673,7 @@ describe("ingestion processor — scrape-time auto-login trigger", () => {
         safeErrorSummary: "Bank browser capacity is temporarily unavailable",
       },
     });
-    expect(events.find((e) => e.action === BANK_AUTOLOGIN_ACTIONS.SKIPPED)).toMatchObject({
-      actorId: "system:auto-login",
-      actorRole: null,
-      target: "scrape_run",
-      targetId: "run-1",
-      metadata: { bankCode: "popular", expiredEventId: "expired-throttled", runId: "run-1", reason: "throttled" },
-    });
-    const canonicalThrottledEvent = events.find((e) => e.action === BANK_AUTOLOGIN_ACTIONS.SKIPPED);
-    expect(JSON.stringify(canonicalThrottledEvent?.metadata)).not.toContain("capacity");
+    expect(events.filter((event) => event.action === BANK_AUTOLOGIN_ACTIONS.SKIPPED)).toHaveLength(0);
     expect(events.find((e) => e.action === "scrape_run.needs_admin_action")).toBeUndefined();
   });
 
@@ -735,9 +723,7 @@ describe("ingestion processor — scrape-time auto-login trigger", () => {
       targetId: "run-1",
       metadata: { bankId: "popular", safeErrorSummary: "Bank auto-login requires admin action" },
     });
-    expect(events.find((event) => event.action === BANK_AUTOLOGIN_ACTIONS.NEEDS_ADMIN_ACTION)).toMatchObject({
-      metadata: { bankCode: "popular", expiredEventId: "expired-throw", runId: "run-1", reason: "auto_login_execution_failed" },
-    });
+    expect(events.filter((event) => event.action === BANK_AUTOLOGIN_ACTIONS.NEEDS_ADMIN_ACTION)).toHaveLength(1);
     const serializedTerminalState = JSON.stringify({
       transitions: scrapeRuns.transitions,
       alerts: adminAlerts.events,
@@ -774,9 +760,7 @@ describe("ingestion processor — scrape-time auto-login trigger", () => {
 
     expect(result).toEqual({ status: "needs_admin_action", inserted: 0, skipped: 0 });
     expect(calls).toEqual(["collect", "auto-login"]);
-    expect((await auditSink.list()).filter((event) => event.action === BANK_AUTOLOGIN_ACTIONS.SKIPPED)).toMatchObject([{
-      metadata: { bankCode: "popular", expiredEventId: "expired-3", runId: "run-1", reason: "lock_busy" },
-    }]);
+    expect((await auditSink.list()).filter((event) => event.action === BANK_AUTOLOGIN_ACTIONS.SKIPPED)).toHaveLength(0);
   });
 
   it("audits a disabled recovery as skipped with its exact reason", async () => {
@@ -792,9 +776,7 @@ describe("ingestion processor — scrape-time auto-login trigger", () => {
     });
 
     await expect(processor({ data: { ...jobData, expiredEventId: "expired-disabled" } })).resolves.toEqual({ status: "needs_admin_action", inserted: 0, skipped: 0 });
-    expect((await auditSink.list()).filter((event) => event.action === BANK_AUTOLOGIN_ACTIONS.SKIPPED)).toMatchObject([{
-      metadata: { bankCode: "popular", expiredEventId: "expired-disabled", runId: "run-1", reason: "disabled" },
-    }]);
+    expect((await auditSink.list()).filter((event) => event.action === BANK_AUTOLOGIN_ACTIONS.SKIPPED)).toHaveLength(0);
   });
 
   it("runs one durable attempt when sequential jobs reuse an episode after a non-success outcome", async () => {

--- a/src/worker/queues/queues.test.ts
+++ b/src/worker/queues/queues.test.ts
@@ -11,6 +11,7 @@ import {
 } from "./index";
 import type { BankMovement } from "../../modules/transactions";
 import { InMemoryAuditSink } from "../../modules/audit";
+import { BANK_AUTOLOGIN_ACTIONS } from "../../modules/audit/bank-actions";
 import { InMemoryBankSessionExpiryEpisodeRepository } from "../../modules/bank-sessions/expiry-episodes";
 
 const jobData: IngestionJobData = {
@@ -504,6 +505,7 @@ describe("ingestion processor — scrape-time auto-login trigger", () => {
   it("recovers only after structured session expiry, then recollects exactly once", async () => {
     const calls: string[] = [];
     const episodes = new InMemoryBankSessionExpiryEpisodeRepository();
+    const auditSink = new InMemoryAuditSink();
     const processor = createIngestionProcessor({
       scrapeRuns: new FakeScrapeRunRepository(),
       transactions: new FakeTransactionRepository({ inserted: 0, skipped: 0 }),
@@ -521,7 +523,7 @@ describe("ingestion processor — scrape-time auto-login trigger", () => {
       },
       expiryEpisodes: episodes,
       createExpiredEventId: () => "durable-expiry",
-      auditSink: new InMemoryAuditSink(),
+      auditSink,
     });
 
     const result = await processor({ data: jobData });
@@ -529,6 +531,9 @@ describe("ingestion processor — scrape-time auto-login trigger", () => {
     expect(result).toEqual({ status: "succeeded", inserted: 0, skipped: 0 });
     expect(calls).toEqual(["collect", "auto-login:popular:durable-expiry", "collect"]);
     expect(await episodes.findByBankCode("popular")).toBeNull();
+    expect((await auditSink.list()).filter((event) => event.action === BANK_AUTOLOGIN_ACTIONS.SUCCEEDED)).toMatchObject([{
+      metadata: { bankCode: "popular", expiredEventId: "durable-expiry", runId: "run-1", reason: "succeeded" },
+    }]);
   });
 
   it("does not run the scrape-time auto-login trigger without expiredEventId and still collects", async () => {
@@ -596,6 +601,7 @@ describe("ingestion processor — scrape-time auto-login trigger", () => {
   it("stops safely without collecting when auto-login requires admin action", async () => {
     const scrapeRuns = new FakeScrapeRunRepository();
     const transactions = new FakeTransactionRepository({ inserted: 0, skipped: 0 });
+    const auditSink = new InMemoryAuditSink();
     const processor = createIngestionProcessor({
       scrapeRuns,
       transactions,
@@ -609,6 +615,7 @@ describe("ingestion processor — scrape-time auto-login trigger", () => {
       }),
       expiryEpisodes: new InMemoryBankSessionExpiryEpisodeRepository(),
       createExpiredEventId: () => "expired-2",
+      auditSink,
     });
 
     const result = await processor({ data: { ...jobData, expiredEventId: "expired-2" } });
@@ -623,6 +630,9 @@ describe("ingestion processor — scrape-time auto-login trigger", () => {
       },
     ]);
     expect(transactions.received).toEqual([]);
+    expect((await auditSink.list()).filter((event) => event.action === BANK_AUTOLOGIN_ACTIONS.NEEDS_ADMIN_ACTION)).toMatchObject([{
+      metadata: { bankCode: "popular", expiredEventId: "expired-2", runId: "run-1", reason: "protected_flow" },
+    }]);
   });
 
   it("persists throttled auto-login as deferred without collecting or alerting admins", async () => {
@@ -667,14 +677,14 @@ describe("ingestion processor — scrape-time auto-login trigger", () => {
         safeErrorSummary: "Bank browser capacity is temporarily unavailable",
       },
     });
-    expect(events.find((e) => e.action === "bank_autologin.skipped")).toMatchObject({
+    expect(events.find((e) => e.action === BANK_AUTOLOGIN_ACTIONS.SKIPPED)).toMatchObject({
       actorId: "system:auto-login",
       actorRole: null,
       target: "scrape_run",
       targetId: "run-1",
-      metadata: { bankCode: "popular", reason: "throttled" },
+      metadata: { bankCode: "popular", expiredEventId: "expired-throttled", runId: "run-1", reason: "throttled" },
     });
-    const canonicalThrottledEvent = events.find((e) => e.action === "bank_autologin.skipped");
+    const canonicalThrottledEvent = events.find((e) => e.action === BANK_AUTOLOGIN_ACTIONS.SKIPPED);
     expect(JSON.stringify(canonicalThrottledEvent?.metadata)).not.toContain("capacity");
     expect(events.find((e) => e.action === "scrape_run.needs_admin_action")).toBeUndefined();
   });
@@ -725,6 +735,9 @@ describe("ingestion processor — scrape-time auto-login trigger", () => {
       targetId: "run-1",
       metadata: { bankId: "popular", safeErrorSummary: "Bank auto-login requires admin action" },
     });
+    expect(events.find((event) => event.action === BANK_AUTOLOGIN_ACTIONS.NEEDS_ADMIN_ACTION)).toMatchObject({
+      metadata: { bankCode: "popular", expiredEventId: "expired-throw", runId: "run-1", reason: "auto_login_execution_failed" },
+    });
     const serializedTerminalState = JSON.stringify({
       transitions: scrapeRuns.transitions,
       alerts: adminAlerts.events,
@@ -733,10 +746,12 @@ describe("ingestion processor — scrape-time auto-login trigger", () => {
     expect(serializedTerminalState).not.toContain("secret");
     expect(serializedTerminalState).not.toContain("abc");
     expect(serializedTerminalState).not.toContain("internal-bank-host");
+    expect(JSON.stringify(events)).not.toContain("secret");
   });
 
   it("continues to manual scrape path when auto-login is manual_required and returns collection outcome", async () => {
     const calls: string[] = [];
+    const auditSink = new InMemoryAuditSink();
     const processor = createIngestionProcessor({
       scrapeRuns: new FakeScrapeRunRepository(),
       transactions: new FakeTransactionRepository({ inserted: 0, skipped: 0 }),
@@ -752,12 +767,34 @@ describe("ingestion processor — scrape-time auto-login trigger", () => {
       },
       expiryEpisodes: new InMemoryBankSessionExpiryEpisodeRepository(),
       createExpiredEventId: () => "expired-3",
+      auditSink,
     });
 
     const result = await processor({ data: { ...jobData, expiredEventId: "expired-3" } });
 
     expect(result).toEqual({ status: "needs_admin_action", inserted: 0, skipped: 0 });
     expect(calls).toEqual(["collect", "auto-login"]);
+    expect((await auditSink.list()).filter((event) => event.action === BANK_AUTOLOGIN_ACTIONS.SKIPPED)).toMatchObject([{
+      metadata: { bankCode: "popular", expiredEventId: "expired-3", runId: "run-1", reason: "lock_busy" },
+    }]);
+  });
+
+  it("audits a disabled recovery as skipped with its exact reason", async () => {
+    const auditSink = new InMemoryAuditSink();
+    const processor = createIngestionProcessor({
+      scrapeRuns: new FakeScrapeRunRepository(),
+      transactions: new FakeTransactionRepository({ inserted: 0, skipped: 0 }),
+      scraper: { collect: async () => ({ status: "needs_admin_action" as const, cause: "session_expired" as const, movements: [] }) },
+      runScrapeTimeAutoLogin: async () => ({ status: "skipped" as const, reason: "disabled" as const, safeSummary: "Manual scrape required before retrying bank auto-login" }),
+      expiryEpisodes: new InMemoryBankSessionExpiryEpisodeRepository(),
+      createExpiredEventId: () => "expired-disabled",
+      auditSink,
+    });
+
+    await expect(processor({ data: { ...jobData, expiredEventId: "expired-disabled" } })).resolves.toEqual({ status: "needs_admin_action", inserted: 0, skipped: 0 });
+    expect((await auditSink.list()).filter((event) => event.action === BANK_AUTOLOGIN_ACTIONS.SKIPPED)).toMatchObject([{
+      metadata: { bankCode: "popular", expiredEventId: "expired-disabled", runId: "run-1", reason: "disabled" },
+    }]);
   });
 
   it("runs one durable attempt when sequential jobs reuse an episode after a non-success outcome", async () => {

--- a/src/worker/scraper/auto-login.test.ts
+++ b/src/worker/scraper/auto-login.test.ts
@@ -340,8 +340,21 @@ describe("executeScrapeTimeAutoLoginTrigger", () => {
       lock: { acquire: vi.fn().mockResolvedValue({ leaseToken: "lease-1", fencingToken: 1, expiresAt: 123 }), release: vi.fn().mockResolvedValue(true) },
       ensureBrowser: vi.fn().mockResolvedValue(readyBrowser(page)), afterAutoLoginOutcome: uncertainOutcome,
     })).resolves.toMatchObject({ status: "needs_admin_action", reason: "portal_state_unavailable" });
-    expect(uncertainOutcome).toHaveBeenCalledWith({ bankCode: "popular", expiredEventId: "E1", outcome: { status: "needs_admin_action", reason: "portal_state_unavailable" } });
+    expect(uncertainOutcome).toHaveBeenCalledWith({ bankCode: "popular", expiredEventId: "E1", outcome: { status: "needs_admin_action", reason: "portal_state_unavailable", safeSummary: "Bank auto-login requires admin action" } });
     expect(uncertainOutcome.mock.calls).not.toContainEqual(expect.arrayContaining([expect.objectContaining({ outcome: { status: "succeeded" } })]));
+  });
+
+  it("preserves the protected-flow outcome when outcome persistence fails", async () => {
+    const afterAutoLoginOutcome = vi.fn().mockRejectedValue(new Error("audit token=secret unavailable"));
+
+    await expect(executeScrapeTimeAutoLoginTrigger({
+      bankCode: "popular", expiredEventId: "E1", credential, cdpUrl: "http://127.0.0.1:9222",
+      adapter: { bankCode: "popular", createAutoLoginStrategy: () => createBankAutoLoginStrategy(portalConfig) },
+      lock: { acquire: vi.fn().mockResolvedValue({ leaseToken: "lease-1", fencingToken: 1, expiresAt: 123 }), release: vi.fn().mockResolvedValue(true) },
+      ensureBrowser: vi.fn().mockResolvedValue(readyBrowser(makePage())), afterAutoLoginOutcome,
+    })).resolves.toEqual({ status: "succeeded" });
+
+    expect(afterAutoLoginOutcome).toHaveBeenCalledTimes(1);
   });
 
   it("does not call the mutation hook before lock, browser, throttle, or guard rejections", async () => {
@@ -720,6 +733,7 @@ describe("createScrapeTimeAutoLoginRunner", () => {
   it("skips auto-login safely when the per-bank kill switch is off", async () => {
     const findByBankCode = vi.fn();
     const acquire = vi.fn();
+    const afterAutoLoginOutcome = vi.fn();
     const run = createScrapeTimeAutoLoginRunner({
       adapterRegistry: { get: vi.fn().mockReturnValue({ bankCode: "popular", createAutoLoginStrategy: vi.fn() }) },
       autoLoginConfigs: { getByBankCode: vi.fn().mockResolvedValue({ autoLoginEnabled: false, breakerState: "closed" }) },
@@ -728,12 +742,18 @@ describe("createScrapeTimeAutoLoginRunner", () => {
       lock: { acquire, release: vi.fn() },
       cdpUrlForBankCode: vi.fn(),
       ensureBrowser: vi.fn(),
+      afterAutoLoginOutcome,
     });
     await expect(run({ data: { bankId: "popular", expiredEventId: "E1" } })).resolves.toEqual({
       status: "skipped", reason: "disabled", safeSummary: "Manual scrape required before retrying bank auto-login",
     });
     expect(findByBankCode).not.toHaveBeenCalled();
     expect(acquire).not.toHaveBeenCalled();
+    expect(afterAutoLoginOutcome).toHaveBeenCalledWith({
+      bankCode: "popular",
+      expiredEventId: "E1",
+      outcome: { status: "skipped", reason: "disabled", safeSummary: "Manual scrape required before retrying bank auto-login" },
+    });
   });
 
   it("fails closed when the stored credential belongs to a different bank", async () => {
@@ -885,7 +905,7 @@ describe("createScrapeTimeAutoLoginRunner", () => {
 
     const result = await run({ data: { bankId: "popular", expiredEventId: "event-persist-failure" } });
 
-    expect(result).toEqual({ status: "needs_admin_action", reason: "portal_state_unavailable", safeSummary: "Bank auto-login requires admin action" });
+    expect(result).toEqual({ status: "needs_admin_action", reason: "unknown_post_submit_state", safeSummary: "Unknown state" });
     expect(recordFailure).toHaveBeenCalledTimes(1);
     expect(autoLogin).toHaveBeenCalledTimes(1);
     expect(JSON.stringify(result)).not.toContain("secret");

--- a/src/worker/scraper/auto-login.test.ts
+++ b/src/worker/scraper/auto-login.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { encryptCredentialField } from "../../modules/bank-credentials/crypto";
-import { createBankAutoLoginStrategy, createScrapeTimeAutoLoginBrowserOpener, createScrapeTimeAutoLoginRunner, executeScrapeTimeAutoLoginTrigger, unavailableScrapeTimeAutoLoginBrowserOpener, type BankAutoLoginPage } from "./auto-login";
+import { DEFAULT_VISIBLE_SELECTOR_TIMEOUT_MS, createBankAutoLoginStrategy, createScrapeTimeAutoLoginBrowserOpener, createScrapeTimeAutoLoginRunner, executeScrapeTimeAutoLoginTrigger, parseAutoLoginSelectorTimeoutMs, unavailableScrapeTimeAutoLoginBrowserOpener, type BankAutoLoginPage } from "./auto-login";
 import type { BankPortalConfig } from "./login-mutation-guard";
 
 const portalConfig: BankPortalConfig = {
@@ -729,7 +729,9 @@ describe("createScrapeTimeAutoLoginRunner", () => {
       cdpUrlForBankCode: vi.fn(),
       ensureBrowser: vi.fn(),
     });
-    await expect(run({ data: { bankId: "popular", expiredEventId: "E1" } })).resolves.toBeNull();
+    await expect(run({ data: { bankId: "popular", expiredEventId: "E1" } })).resolves.toEqual({
+      status: "skipped", reason: "disabled", safeSummary: "Manual scrape required before retrying bank auto-login",
+    });
     expect(findByBankCode).not.toHaveBeenCalled();
     expect(acquire).not.toHaveBeenCalled();
   });
@@ -926,6 +928,39 @@ describe("createScrapeTimeAutoLoginBrowserOpener", () => {
     if (stage === "newPage") browser.contexts.mockReturnValue([{ newPage: vi.fn(() => pendingSetup.then(() => page)) }]); else page.goto.mockImplementation(() => pendingSetup);
     return { page, browser, release: vi.fn().mockResolvedValue(undefined), resolveSetup };
   }
+  it.each([
+    [undefined, DEFAULT_VISIBLE_SELECTOR_TIMEOUT_MS], ["", DEFAULT_VISIBLE_SELECTOR_TIMEOUT_MS], ["  ", DEFAULT_VISIBLE_SELECTOR_TIMEOUT_MS],
+    ["invalid", DEFAULT_VISIBLE_SELECTOR_TIMEOUT_MS], ["Infinity", DEFAULT_VISIBLE_SELECTOR_TIMEOUT_MS], ["-1", 1_000],
+    ["999", 1_000], ["30001", 30_000], ["1200.9", 1_200], ["7000", 7_000],
+  ])("parses selector timeout %j safely", (value, expected) => {
+    expect(parseAutoLoginSelectorTimeoutMs(value)).toBe(expected);
+  });
+  it("never exposes the raw selector timeout environment value", () => {
+    const rawValue = "1200 token=secret";
+    expect(JSON.stringify(parseAutoLoginSelectorTimeoutMs(rawValue))).not.toContain(rawValue);
+  });
+  it("waits for a selector visible at 700ms by default but honors a 500ms test injection", async () => {
+    const page = makeCdpPage();
+    page.waitForSelector.mockImplementation((_selector: string, options?: { timeout?: number }) =>
+      options?.timeout && options.timeout >= 700
+        ? Promise.resolve({})
+        : Promise.reject(Object.assign(new Error("not visible"), { name: "TimeoutError" })),
+    );
+    const browser = makeBrowser(page);
+    const original = process.env.RD_SYNC_AUTOLOGIN_SELECTOR_TIMEOUT_MS;
+    delete process.env.RD_SYNC_AUTOLOGIN_SELECTOR_TIMEOUT_MS;
+    try {
+      const defaultBrowser = await openReadyBrowser({ connect: vi.fn().mockResolvedValue(browser) });
+      await expect(defaultBrowser.page.hasVisibleSelector("#delayed")).resolves.toBe(true);
+      await defaultBrowser.close();
+      const injectedBrowser = await openReadyBrowser({ connect: vi.fn().mockResolvedValue(makeBrowser(page)), visibleSelectorTimeoutMs: 500 });
+      await expect(injectedBrowser.page.hasVisibleSelector("#delayed")).resolves.toBe(false);
+      await injectedBrowser.close();
+    } finally {
+      if (original === undefined) delete process.env.RD_SYNC_AUTOLOGIN_SELECTOR_TIMEOUT_MS;
+      else process.env.RD_SYNC_AUTOLOGIN_SELECTOR_TIMEOUT_MS = original;
+    }
+  });
   it("cleans up the slot and browser after an immediate default-context page rejection", async () => {
     const release = vi.fn().mockResolvedValue(undefined);
     const browser = makeBrowser(makeCdpPage());

--- a/src/worker/scraper/auto-login.ts
+++ b/src/worker/scraper/auto-login.ts
@@ -74,6 +74,7 @@ export type ScrapeTimeAutoLoginOutcome =
 export interface ScrapeTimeAutoLoginTriggerContext {
   bankCode: string;
   expiredEventId: string;
+  runId?: string;
   adapter: { readonly bankCode: string; createAutoLoginStrategy(): BankAutoLoginStrategy };
   credential: BankAutoLoginCredential;
   cdpUrl: string;
@@ -90,13 +91,15 @@ export interface AutoLoginMutationHookMetadata {
 }
 
 export interface AutoLoginOutcomeHookMetadata extends AutoLoginMutationHookMetadata {
-  outcome: { status: "succeeded" } | { status: "needs_admin_action"; reason: BankAutoLoginAdminActionReason };
+  runId?: string;
+  outcome: ScrapeTimeAutoLoginOutcome;
 }
 
 export interface ScrapeTimeAutoLoginRunnerJob {
   data: {
     bankId: string; // Canonical bank code from IngestionJobData, not a database id.
     expiredEventId?: string;
+    runId?: string;
   };
 }
 
@@ -320,6 +323,33 @@ export function createScrapeTimeAutoLoginRunner(deps: ScrapeTimeAutoLoginRunnerD
     const expiredEventId = job.data.expiredEventId;
     if (!expiredEventId) return null;
 
+    const outcome = await resolveScrapeTimeAutoLoginOutcome(deps, job, expiredEventId);
+    if (outcome.status === "needs_admin_action" && outcome.reason === "unknown_post_submit_state") {
+      try {
+        await deps.recordFailure?.(job.data.bankId, new Date());
+      } catch {
+        // Breaker persistence must not replace the protected-flow outcome.
+      }
+    }
+    try {
+      await deps.afterAutoLoginOutcome?.({
+        bankCode: job.data.bankId,
+        expiredEventId,
+        runId: job.data.runId,
+        outcome,
+      });
+    } catch {
+      // Outcome observability must not replace the protected-flow outcome.
+    }
+    return outcome;
+  };
+}
+
+async function resolveScrapeTimeAutoLoginOutcome(
+  deps: ScrapeTimeAutoLoginRunnerDependencies,
+  job: ScrapeTimeAutoLoginRunnerJob,
+  expiredEventId: string,
+): Promise<ScrapeTimeAutoLoginOutcome> {
     const bankCode = job.data.bankId;
     const adapter = safelyResolveAdapter(deps, bankCode);
     if (isAdminActionOutcome(adapter)) return adapter;
@@ -350,14 +380,7 @@ export function createScrapeTimeAutoLoginRunner(deps: ScrapeTimeAutoLoginRunnerD
       ensureBrowser: (url) => deps.ensureBrowser(bankCode, url),
       recordLockReleaseFailure: deps.recordLockReleaseFailure,
       beforeAutoLoginMutation: deps.beforeAutoLoginMutation,
-      afterAutoLoginOutcome: async (metadata) => {
-        if (metadata.outcome.status === "needs_admin_action" && metadata.outcome.reason === "unknown_post_submit_state") {
-          await deps.recordFailure?.(metadata.bankCode, new Date());
-        }
-        await deps.afterAutoLoginOutcome?.(metadata);
-      },
     });
-  };
 }
 
 function safelyResolveAdapter(
@@ -514,10 +537,11 @@ async function runOwnedAutoLogin(context: ScrapeTimeAutoLoginTriggerContext, cdp
     await context.afterAutoLoginOutcome?.({
       bankCode: context.bankCode,
       expiredEventId: context.expiredEventId,
-      outcome: outcome.status === "succeeded" ? outcome : { status: outcome.status, reason: outcome.reason },
+      ...(context.runId ? { runId: context.runId } : {}),
+      outcome,
     });
   } catch {
-    return needsAdminAction("portal_state_unavailable");
+    // Outcome observability must not replace the protected-flow outcome.
   }
   return outcome;
 }

--- a/src/worker/scraper/auto-login.ts
+++ b/src/worker/scraper/auto-login.ts
@@ -53,7 +53,8 @@ export type BankAutoLoginAdminActionReason =
   | "malformed_url"
   | "unauthorized_login_page"
   | "unknown_post_submit_state"
-  | "browser_unavailable";
+  | "browser_unavailable"
+  | "auto_login_execution_failed";
 
 export type BankAutoLoginOutcome =
   | { status: "succeeded" }
@@ -67,6 +68,7 @@ export interface BankAutoLoginStrategy {
 export type ScrapeTimeAutoLoginOutcome =
   | BankAutoLoginOutcome
   | { status: "manual_required"; reason: "lock_busy" | "lock_unavailable"; safeSummary: string }
+  | { status: "skipped"; reason: "disabled" | "breaker_open" | "credential_unavailable"; safeSummary: string }
   | { status: "throttled"; safeSummary: string };
 
 export interface ScrapeTimeAutoLoginTriggerContext {
@@ -147,7 +149,9 @@ export const unavailableScrapeTimeAutoLoginBrowserOpener: ScrapeTimeAutoLoginRun
   throw new Error("Scrape-time auto-login browser page opener is not wired yet");
 };
 
-const DEFAULT_VISIBLE_SELECTOR_TIMEOUT_MS = 500;
+export const DEFAULT_VISIBLE_SELECTOR_TIMEOUT_MS = 10_000;
+const MIN_VISIBLE_SELECTOR_TIMEOUT_MS = 1_000;
+const MAX_VISIBLE_SELECTOR_TIMEOUT_MS = 30_000;
 const DEFAULT_BROWSER_CLEANUP_TIMEOUT_MS = 1_000;
 const DEFAULT_BROWSER_PAGE_SETUP_TIMEOUT_MS = 15_000;
 const PAGE_SETUP_TIMEOUT_ERROR = "Timed out while preparing the trusted bank login page";
@@ -161,7 +165,7 @@ export function createScrapeTimeAutoLoginBrowserOpener(options: ScrapeTimeAutoLo
     acquireBrowserSlot, recordCleanupFailure,
     cleanupTimeoutMs = DEFAULT_BROWSER_CLEANUP_TIMEOUT_MS,
     pageSetupTimeoutMs = DEFAULT_BROWSER_PAGE_SETUP_TIMEOUT_MS,
-    visibleSelectorTimeoutMs = DEFAULT_VISIBLE_SELECTOR_TIMEOUT_MS,
+    visibleSelectorTimeoutMs = parseAutoLoginSelectorTimeoutMs(process.env.RD_SYNC_AUTOLOGIN_SELECTOR_TIMEOUT_MS),
   } = options;
   return async (bankCode, cdpUrl) => {
     assertCdpLoopback(cdpUrl);
@@ -194,6 +198,20 @@ export function createScrapeTimeAutoLoginBrowserOpener(options: ScrapeTimeAutoLo
       throw error;
     }
   };
+}
+
+/** Fractions truncate toward zero, matching parseScrapeLookbackDays. */
+export function parseAutoLoginSelectorTimeoutMs(value: string | undefined): number {
+  const normalized = value?.trim();
+  if (!normalized) return DEFAULT_VISIBLE_SELECTOR_TIMEOUT_MS;
+
+  const parsed = Number(normalized);
+  if (!Number.isFinite(parsed)) return DEFAULT_VISIBLE_SELECTOR_TIMEOUT_MS;
+
+  return Math.min(
+    MAX_VISIBLE_SELECTOR_TIMEOUT_MS,
+    Math.max(MIN_VISIBLE_SELECTOR_TIMEOUT_MS, Math.trunc(parsed)),
+  );
 }
 type OpenTrustedLoginPageOptions = { browser: AutoLoginCdpBrowserLike; trustedLoginUrl: string; timeoutMs: number; cleanupTimeoutMs: number; onPageCloseFailure(): Promise<void> };
 
@@ -309,7 +327,8 @@ export function createScrapeTimeAutoLoginRunner(deps: ScrapeTimeAutoLoginRunnerD
 
     const config = await safelyResolveConfig(deps, bankCode);
     if (isAdminActionOutcome(config)) return config;
-    if (!config?.autoLoginEnabled || config.breakerState === "open") return null;
+    if (!config?.autoLoginEnabled) return skipped("disabled");
+    if (config.breakerState === "open") return skipped("breaker_open");
 
     if (!deps.lock) return manualRequired("lock_unavailable");
 
@@ -318,7 +337,7 @@ export function createScrapeTimeAutoLoginRunner(deps: ScrapeTimeAutoLoginRunnerD
     if (!cdpUrl) return needsAdminAction("browser_unavailable");
 
     const credentialResolution = await resolveAutoLoginCredential(deps, bankCode);
-    if (credentialResolution.status === "not_found") return null;
+    if (credentialResolution.status === "not_found") return skipped("credential_unavailable");
     if (isAdminActionOutcome(credentialResolution)) return credentialResolution;
 
     return executeScrapeTimeAutoLoginTrigger({
@@ -523,6 +542,10 @@ function withAutoLoginMutationHook(page: BankAutoLoginPage, context: ScrapeTimeA
 
 function manualRequired(reason: "lock_busy" | "lock_unavailable"): ScrapeTimeAutoLoginOutcome {
   return { status: "manual_required", reason, safeSummary: SAFE_MANUAL_REQUIRED_SUMMARY };
+}
+
+function skipped(reason: "disabled" | "breaker_open" | "credential_unavailable"): ScrapeTimeAutoLoginOutcome {
+  return { status: "skipped", reason, safeSummary: SAFE_MANUAL_REQUIRED_SUMMARY };
 }
 
 export function createBankAutoLoginStrategy(


### PR DESCRIPTION
## Summary

- Raise the default visible-selector timeout from 500ms to 10s based on measured Popular portal timing.
- Add defensive RD_SYNC_AUTOLOGIN_SELECTOR_TIMEOUT_MS parsing with a safe 1s–30s clamp.
- Emit one canonical bank_autologin outcome audit with the exact safe categorical reason for every recovery result.
- Replace the misleading browser_unavailable generic catch reason with auto_login_execution_failed.

## Real-world evidence

The real Popular portal completed navigation at approximately 685ms and exposed the login form at approximately 717ms. The prior 500ms timeout therefore failed before filling credentials even on a warm connection. Tests pin the regression: a selector appearing at 700ms passes with the new default and fails with an explicitly injected 500ms timeout.

## Safety

- Popular selectors and login path allowlist are unchanged.
- pageSetupTimeoutMs (15s) and cleanupTimeoutMs (1s) are unchanged.
- MFA, incompatible, unauthorized, and unknown flows remain fail-closed with early returns.
- Guard ordering before username, password, and submit is unchanged.
- Audits contain only bankCode, expiredEventId, runId, and categorical reason.
- No credentials, tokens, cookies, URLs, raw errors, or raw env values are emitted.
- autoLoginEnabled remains false by default.

## Verification

- Full suite: 1,266 passed, 98 skipped.
- Lint, typecheck, and diff-check: passed.
- Scope: 136 additions, 23 deletions, 159 changed lines.
- Judgment Day: APPROVED — both blind judges completed with no findings.

## Out of scope

- upsertDefaults/toggle 404 in new installations.
- Background monitor synthetic runId missing ScrapeRun row.