### PR TITLE
fix(bank-auto-login): provision config row and recover late-redirect expiries

### DIFF
--- a/src/modules/bank-auto-login-config/repository.test.ts
+++ b/src/modules/bank-auto-login-config/repository.test.ts
@@ -219,15 +219,30 @@ describe("BankAutoLoginConfigRepository", () => {
   });
 
   describe("setAutoLoginEnabled", () => {
-    it("is a no-op for unknown bankCode and updates only known rows", async () => {
-      const unknown = makeRepo({ findUnique: null });
-      await expect(unknown.repo.setAutoLoginEnabled("unknown", true, "admin-1")).resolves.toBeNull();
-      expectFindUnique(unknown.bankAutoLoginConfig.findUnique, "unknown", BANK_CODE_SELECT);
-      expect(unknown.bankAutoLoginConfig.update).not.toHaveBeenCalled();
+    it("provisions the row on first use so a never-configured bank can be enabled", async () => {
+      const created = makeRepo({ upsert: row({ autoLoginEnabled: true, updatedBy: "admin-1" }) });
 
-      const known = makeRepo({ findUnique: row(), update: row({ autoLoginEnabled: true, updatedBy: "admin-1" }) });
-      await expect(known.repo.setAutoLoginEnabled("popular", true, "admin-1")).resolves.toMatchObject({ autoLoginEnabled: true, updatedBy: "admin-1" });
-      expectUpdate(known.bankAutoLoginConfig.update, "popular", { autoLoginEnabled: true, updatedBy: "admin-1" });
+      await expect(created.repo.setAutoLoginEnabled("popular", true, "admin-1")).resolves.toMatchObject({ autoLoginEnabled: true, updatedBy: "admin-1" });
+      expect(created.bankAutoLoginConfig.upsert).toHaveBeenCalledWith({
+        where: { bankCode: "popular" },
+        update: { autoLoginEnabled: true, updatedBy: "admin-1" },
+        create: { bankCode: "popular", autoLoginEnabled: true, updatedBy: "admin-1" },
+        select: RECORD_SELECT,
+      });
+    });
+
+    it("fails closed for an unknown bankCode without creating a row", async () => {
+      const unknown = makeRepo();
+      unknown.bankAutoLoginConfig.upsert.mockRejectedValue({ code: "P2003" });
+
+      await expect(unknown.repo.setAutoLoginEnabled("unknown", true, "admin-1")).resolves.toBeNull();
+    });
+
+    it("propagates unexpected repository errors instead of masking them as not-found", async () => {
+      const failing = makeRepo();
+      failing.bankAutoLoginConfig.upsert.mockRejectedValue(new Error("connection lost"));
+
+      await expect(failing.repo.setAutoLoginEnabled("popular", true, "admin-1")).rejects.toThrow("connection lost");
     });
   });
 });

--- a/src/modules/bank-auto-login-config/repository.ts
+++ b/src/modules/bank-auto-login-config/repository.ts
@@ -125,16 +125,32 @@ export class BankAutoLoginConfigRepository {
     return mapRow(row);
   }
 
+  /**
+   * Sets the auto-login kill switch, provisioning the config row on first use.
+   *
+   * A bank that exists in `Bank` but has never been configured has no
+   * `BankAutoLoginConfig` row — nothing provisions one. An update-only
+   * implementation therefore returned `null` forever, which the route maps to
+   * 404, making auto-login impossible to enable on a fresh install.
+   *
+   * The upsert mirrors `BankAdapterConfig.setScrapingEnabled`. Fail-closed
+   * behaviour for a genuinely unknown bank is preserved by the `bankCode`
+   * foreign key: Prisma raises P2003 and this returns `null` (still 404), so no
+   * row is ever created for a bank that does not exist.
+   */
   async setAutoLoginEnabled(bankCode: string, enabled: boolean, updatedBy: string): Promise<BankAutoLoginConfigRecord | null> {
-    const existing = await this.prisma.bankAutoLoginConfig.findUnique({ where: { bankCode }, select: { bankCode: true } });
-    if (!existing) return null;
-
-    const row = await this.prisma.bankAutoLoginConfig.update({
-      where: { bankCode },
-      data: { autoLoginEnabled: enabled, updatedBy },
-      select: RECORD_SELECT,
-    });
-    return mapRow(row);
+    try {
+      const row = await this.prisma.bankAutoLoginConfig.upsert({
+        where: { bankCode },
+        update: { autoLoginEnabled: enabled, updatedBy },
+        create: { bankCode, autoLoginEnabled: enabled, updatedBy },
+        select: RECORD_SELECT,
+      });
+      return mapRow(row);
+    } catch (error: unknown) {
+      if (hasPrismaCode(error, "P2003")) return null;
+      throw error;
+    }
   }
 
   private async runSerializableWithRetry<T>(operation: (tx: BankAutoLoginConfigTx) => Promise<T>): Promise<T> {

--- a/src/modules/persistence/prisma-contracts.test.ts
+++ b/src/modules/persistence/prisma-contracts.test.ts
@@ -31,6 +31,7 @@ import { PrismaBankSessionExpiryEpisodeRepository } from "./prisma-bank-session-
 import { PrismaManualRecoveryResolutionAuditOutboxRepository } from "./prisma-manual-recovery-resolution-audit-outbox-repository";
 import { deliverManualRecoveryResolutionAudit } from "../bank-sessions/manual-recovery-resolution-audit-delivery";
 import { createSetAutoLoginEnabledAndAudit } from "../../app/api/bank-credentials/[bankCode]/auto-login/defaults";
+import { BankAutoLoginConfigRepository } from "../bank-auto-login-config/repository";
 import { PUBLICATION_CLAIM_TIMEOUT_MS, publishExpiryEpisode, type ExpiryPublicationPublisher } from "../bank-sessions/expiry-episodes";
 import { createBankSessionMonitor } from "../bank-sessions";
 import { createManualRecoveryReplayAuthorization } from "../bank-sessions/manual-recovery-replay-authorization";
@@ -919,6 +920,40 @@ describe.skipIf(!hasTestDb)("Prisma atomic auto-login contract (requires RD_SYNC
     await expect(command({ bankCode, enabled: true, adminId: "admin-atomic-contract" })).rejects.toThrow("audit write failed");
     await expect(prisma.bankAutoLoginConfig.findUnique({ where: { bankCode } })).resolves.toMatchObject({ autoLoginEnabled: false });
     await expect(prisma.auditEvent.count({ where: { targetId: bankCode } })).resolves.toBe(0);
+  });
+
+  // A fresh install has a Bank row but no BankAutoLoginConfig row — nothing
+  // provisions one. This is the exact state that made the admin toggle return
+  // 404 forever in production; the previous fake-Prisma unit tests could not
+  // catch it because they pre-seeded the row.
+  it("provisions the config row on first enable when the bank has never been configured", async () => {
+    if (!prisma) throw new Error("prisma not initialized");
+    const bankCode = "auto-login-provisioning-contract";
+    await prisma.bank.create({ data: { code: bankCode, name: "Auto Login Provisioning Contract" } });
+    await expect(prisma.bankAutoLoginConfig.findUnique({ where: { bankCode } })).resolves.toBeNull();
+
+    const repo = new BankAutoLoginConfigRepository(prisma);
+
+    await expect(repo.setAutoLoginEnabled(bankCode, true, "admin-provisioning")).resolves.toMatchObject({
+      bankCode,
+      autoLoginEnabled: true,
+      breakerState: "closed",
+      breakerFailureCount: 0,
+      updatedBy: "admin-provisioning",
+    });
+    await expect(prisma.bankAutoLoginConfig.findUnique({ where: { bankCode } })).resolves.toMatchObject({ autoLoginEnabled: true });
+
+    // Idempotent: a second call updates the same row instead of failing.
+    await expect(repo.setAutoLoginEnabled(bankCode, false, "admin-provisioning")).resolves.toMatchObject({ autoLoginEnabled: false });
+    await expect(prisma.bankAutoLoginConfig.count({ where: { bankCode } })).resolves.toBe(1);
+  });
+
+  it("still fails closed for a bank that does not exist, creating no row", async () => {
+    if (!prisma) throw new Error("prisma not initialized");
+    const repo = new BankAutoLoginConfigRepository(prisma);
+
+    await expect(repo.setAutoLoginEnabled("bank-that-does-not-exist", true, "admin-provisioning")).resolves.toBeNull();
+    await expect(prisma.bankAutoLoginConfig.count({ where: { bankCode: "bank-that-does-not-exist" } })).resolves.toBe(0);
   });
 });
 

--- a/src/worker/scraper/navigation/popular.test.ts
+++ b/src/worker/scraper/navigation/popular.test.ts
@@ -283,6 +283,61 @@ describe("collectPopularPortalRows — state detection", () => {
     expect(result.cause).toBeUndefined();
   });
 
+  // Observed in production: an expired session is redirected away from
+  // /dashboard, but the redirect can land AFTER the first currentUrl() check.
+  // Classifying that as a render failure drops `cause`, and the worker only
+  // triggers auto-login recovery when cause === "session_expired" — so the
+  // session was never recovered and the operator saw a dead end instead.
+  it("classifies a redirect that lands after the URL check as an expired session, not a render failure", async () => {
+    const date = new Date("2026-06-12T04:00:00Z");
+    const baseUrl = "https://ib.bpd.com.do";
+    const page = new FakePopularPortalPage({
+      dashboardUrl: `${baseUrl}/dashboard`,
+      dashboardUrlAfterRedirect: `${baseUrl}/`,
+      currentUrl: "https://ib.bpd.com.do/accountdetails/transactions",
+      waitForVisibleTextResults: { Produto: false },
+      openDashboardAccountResult: false,
+      pageSnapshots: [],
+    });
+
+    const result = await collectPopularPortalRows(page, { baseUrl, sDate: date, eDate: date, warmupPauseMs: 0, settleIntervalMs: 0, settleFloorMs: 0, settleMaxMs: 0 });
+
+    expect(result.kind).toBe("needs_admin_action");
+    if (result.kind !== "needs_admin_action") throw new Error("unreachable");
+    expect(result.safeErrorSummary).toBe("Bank session expired or requires verification");
+    expect(result.cause).toBe("session_expired");
+  });
+
+  // Recovery must require POSITIVE evidence of the login page. Treating any
+  // non-dashboard URL as expiry would let a maintenance or error page start an
+  // auto-login attempt: credentials stay safe (the guard refuses to fill off
+  // the login page) but the episode burns its single attempt and the breaker
+  // advances, so repeated downtime could lock auto-login out entirely.
+  it.each([
+    ["a maintenance page", "https://ib.bpd.com.do/maintenance"],
+    ["an error page", "https://ib.bpd.com.do/error?code=500"],
+    ["a foreign origin", "https://evil.example.com/"],
+    ["a malformed url", "not-a-url"],
+  ])("does not claim session expiry when the page settles on %s", async (_label, settledUrl) => {
+    const date = new Date("2026-06-12T04:00:00Z");
+    const baseUrl = "https://ib.bpd.com.do";
+    const page = new FakePopularPortalPage({
+      dashboardUrl: `${baseUrl}/dashboard`,
+      dashboardUrlAfterRedirect: settledUrl,
+      currentUrl: "https://ib.bpd.com.do/accountdetails/transactions",
+      waitForVisibleTextResults: { Produto: false },
+      openDashboardAccountResult: false,
+      pageSnapshots: [],
+    });
+
+    const result = await collectPopularPortalRows(page, { baseUrl, sDate: date, eDate: date, warmupPauseMs: 0, settleIntervalMs: 0, settleFloorMs: 0, settleMaxMs: 0 });
+
+    expect(result.kind).toBe("needs_admin_action");
+    if (result.kind !== "needs_admin_action") throw new Error("unreachable");
+    expect(result.safeErrorSummary).toBe("Bank dashboard did not render");
+    expect(result.cause).toBeUndefined();
+  });
+
   it("returns needs_admin_action when openDashboardAccount returns false (row not found)", async () => {
     const date = new Date("2026-06-12T04:00:00Z");
     const baseUrl = "https://ib.bpd.com.do";
@@ -766,6 +821,12 @@ class FakePopularPortalPage implements PopularPortalPage {
       /** URL returned by currentUrl() at all other times (transactions path) */
       currentUrl: string;
       /**
+       * Models the expired-session redirect race: when set, the FIRST dashboard
+       * currentUrl() still reports the dashboard (the redirect has not landed
+       * yet) and every later one reports this URL instead.
+       */
+      dashboardUrlAfterRedirect?: string;
+      /**
        * Per-text results for waitForVisibleText.
        * Key "Produto" matches "Producto" (prefix match for brevity in tests).
        * Any missing key defaults to true.
@@ -785,6 +846,10 @@ class FakePopularPortalPage implements PopularPortalPage {
     // If the last goto was to a dashboard-like URL, return dashboardUrl
     const lastGoto = [...this.operations].reverse().find((op) => op.startsWith("goto:"));
     if (lastGoto !== undefined && lastGoto.includes("/dashboard")) {
+      const dashboardReads = this.operations.filter((op) => op === "currentUrl").length;
+      if (this.state.dashboardUrlAfterRedirect !== undefined && dashboardReads > 1) {
+        return this.state.dashboardUrlAfterRedirect;
+      }
       return this.state.dashboardUrl;
     }
     return this.state.currentUrl;

--- a/src/worker/scraper/navigation/popular.ts
+++ b/src/worker/scraper/navigation/popular.ts
@@ -108,6 +108,29 @@ export type CollectPopularPortalRowsResult =
   | { kind: "needs_admin_action"; safeErrorSummary: string; cause?: never }
   | { kind: "needs_admin_action"; safeErrorSummary: string; cause: "session_expired" };
 
+/** Paths the portal serves its login form on; mirrors popularPortalConfig.loginPathAllowlist. */
+const POPULAR_LOGIN_PATHS = new Set(["/"]);
+
+/**
+ * Positive check that the page is sitting on the portal's own login screen.
+ *
+ * Deliberately conservative: it must be the SAME ORIGIN as the configured portal
+ * and a known login path. Callers use this to decide whether a failed dashboard
+ * render is an expired session (which starts auto-login recovery), so anything
+ * unrecognised — maintenance pages, error pages, foreign origins, malformed
+ * URLs — must answer `false` and be treated as a plain render failure.
+ */
+async function isPortalLoginPage(page: Pick<PopularPortalPage, "currentUrl">, baseUrl: string): Promise<boolean> {
+  try {
+    const current = new URL(await page.currentUrl());
+    const portal = new URL(baseUrl);
+    if (current.origin !== portal.origin) return false;
+    return POPULAR_LOGIN_PATHS.has(current.pathname);
+  } catch {
+    return false;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // buildPopularTransactionsUrl
 // ---------------------------------------------------------------------------
@@ -319,6 +342,30 @@ export async function collectPopularPortalRows(
 
   const dashboardReady = await page.waitForVisibleText(DASHBOARD_WAIT_TEXT, DASHBOARD_WAIT_TIMEOUT_MS);
   if (!dashboardReady) {
+    // The portal redirects an expired session away from /dashboard, but that
+    // redirect can land AFTER the currentUrl() check above — a race the first
+    // check loses roughly half the time. Re-read the URL before classifying:
+    // without this, an expired session is reported as a render failure, which
+    // carries no `cause` and therefore silently skips auto-login recovery
+    // (see the `cause === "session_expired"` guard in worker/queues).
+    //
+    // Requires POSITIVE evidence of the portal's login page — same origin and a
+    // known login path. "Anything that is not the dashboard" is not enough: a
+    // maintenance page, an error page or an unrelated redirect would then be
+    // reported as an expired session, and `cause: "session_expired"` starts a
+    // recovery attempt. That attempt cannot leak credentials (LoginMutationGuard
+    // still refuses to fill or submit off the login page) but it consumes the
+    // episode's single attempt and trips the circuit breaker, so a maintenance
+    // window could lock auto-login out until an admin resets it. Anything we
+    // cannot positively identify stays a render failure with no cause.
+    if (await isPortalLoginPage(page, baseUrl)) {
+      return {
+        kind: "needs_admin_action",
+        safeErrorSummary: "Bank session expired or requires verification",
+        cause: "session_expired",
+      };
+    }
+
     return {
       kind: "needs_admin_action",
       safeErrorSummary: "Bank dashboard did not render",


### PR DESCRIPTION
Two production bugs found while running the app against the real Banco Popular portal.

## a45b71e — the auto-login toggle 404s on a fresh install

`setAutoLoginEnabled` was update-only, returning `null` when no `BankAutoLoginConfig` row existed, which the admin route maps to 404. Nothing ever provisioned that row: `upsertDefaults` exists but has no production callers and the seed does not create it. Auto-login was therefore impossible to enable on a clean database — it only worked here because the row was inserted by hand.

Switched to `upsert`, mirroring `BankAdapterConfig.setScrapingEnabled`. Fail-closed behaviour for a genuinely unknown bank is preserved by the `bankCode` foreign key: Prisma raises P2003 and the method still returns `null`, so no row is created for a bank that does not exist.

The previous unit test encoded the buggy contract using a fake Prisma client, which is why the green suite never caught this. Replaced with tests for the real contract, plus PostgreSQL contract coverage for the exact never-configured state.

## 7386fc4 — an intermittent failure silently disabled recovery

The portal redirects an expired session away from `/dashboard`, but that redirect can land after `collectPopularPortalRows` has already read `currentUrl()`. When it did, the run was reported as "Bank dashboard did not render" — a result carrying no `cause`. The worker only starts auto-login recovery when `cause === "session_expired"`, so losing that race silently disabled recovery: the same expired session was recovered on one run and became a dead end on the next, depending on milliseconds.

The URL is now re-read before classifying a missing dashboard, and expiry requires **positive evidence** of the portal's own login screen (same origin plus a known login path). Anything unrecognised — maintenance pages, error pages, foreign origins, malformed URLs — stays a render failure with no cause, so recovery does not run.

## Verification

- typecheck, lint, `git diff --check`: clean
- 1,276 unit tests; PostgreSQL contracts 100 passing
- Both fixes mutation-verified: reverting each makes its new tests fail
- Live against the real portal: two consecutive successful auto-logins, four real transactions captured, no duplicate `sourceHash`

## Review

Fresh 4R + Judgment Day ran twice. The original CRITICAL (R3-001 — treating any non-dashboard URL as expiry) is fixed and covered by four regression tests (`/maintenance`, error page, foreign origin, malformed URL).

Two WARNINGs were accepted as follow-up work rather than fixed here — see the tracking issue. Neither can expose credentials: `LoginMutationGuard` still refuses to fill or submit anywhere but the login page, and PR #63 makes the rejection reason auditable.

## Pre-existing failures (not caused by this branch)

Two PostgreSQL contract tests already fail on `main`, verified by stashing this work and running against a clean checkout:

- `recovers acknowledgement loss and enforces DB-clock skew constraints through the production publisher`
- `linearizes terminal markers, upgrades missing evidence, and keeps audit metadata allowlisted`

They need a separate fix.