### PR TITLE
fix(auto-login): make the protected-state detection window unshrinkable and bound credential cleanup

### DIFF
--- a/src/worker/scraper/auto-login.test.ts
+++ b/src/worker/scraper/auto-login.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { encryptCredentialField } from "../../modules/bank-credentials/crypto";
 import { DEFAULT_VISIBLE_SELECTOR_TIMEOUT_MS, createBankAutoLoginStrategy, createScrapeTimeAutoLoginBrowserOpener, createScrapeTimeAutoLoginRunner, executeScrapeTimeAutoLoginTrigger, parseAutoLoginSelectorTimeoutMs, unavailableScrapeTimeAutoLoginBrowserOpener, type BankAutoLoginPage } from "./auto-login";
-import type { BankPortalConfig } from "./login-mutation-guard";
+import { MIN_PROTECTED_STATE_DETECTION_WINDOW_MS, type BankPortalConfig } from "./login-mutation-guard";
 
 const portalConfig: BankPortalConfig = {
   bankCode: "popular",
@@ -70,6 +70,55 @@ function readyBrowser(page: BankAutoLoginPage) {
 }
 
 describe("createBankAutoLoginStrategy", () => {
+  // Guarding the composition, not just the guard, and asserting the EFFECTIVE
+  // wait that reaches the page rather than the argument a call site passes. An
+  // earlier version asserted `undefined` at the submit boundary, which proved
+  // only that the call site declined to override — it could not tell a 10s
+  // detection window from a 1s one.
+  async function recordAbsenceProbes(declaredWindowMs?: number): Promise<Array<number | undefined>> {
+    const probes: Array<number | undefined> = [];
+    const page = makePage();
+    const recordingPage = {
+      ...page,
+      protectedStateDetectionWindowMs: declaredWindowMs,
+      hasVisibleSelector: async (selector: string, timeoutMs?: number) => {
+        if (selector === portalConfig.mfaIndicatorSelector || selector === portalConfig.incompatibleFlowSelector) probes.push(timeoutMs);
+        return page.hasVisibleSelector(selector);
+      },
+    };
+
+    await expect(createBankAutoLoginStrategy(portalConfig, { supportedBankCodes: ["popular"] })
+      .autoLogin({ credential, page: recordingPage })).resolves.toEqual({ status: "succeeded" });
+
+    // Three pre-submit passes, two absence selectors each.
+    return probes.slice(0, 6);
+  }
+
+  // Every boundary, not just the submit. A shortened wait before the fills is
+  // what let credentials reach the DOM ahead of a late overlay.
+  it("gives all three mutation boundaries the full detection window", async () => {
+    const preSubmit = await recordAbsenceProbes();
+
+    expect(preSubmit).toEqual(Array<number>(6).fill(MIN_PROTECTED_STATE_DETECTION_WINDOW_MS));
+  });
+
+  // The page's visibility timeout is environment-configurable down to 1s. That
+  // knob must not be able to collapse the window protecting the submit.
+  it("clamps a page-declared detection window narrower than the safety floor", async () => {
+    const preSubmit = await recordAbsenceProbes(1_000);
+
+    expect(preSubmit.slice(4)).toEqual([
+      MIN_PROTECTED_STATE_DETECTION_WINDOW_MS, MIN_PROTECTED_STATE_DETECTION_WINDOW_MS,
+    ]);
+  });
+
+  it("honors a page-declared detection window wider than the safety floor", async () => {
+    const widened = MIN_PROTECTED_STATE_DETECTION_WINDOW_MS * 2;
+    const preSubmit = await recordAbsenceProbes(widened);
+
+    expect(preSubmit.slice(4)).toEqual([widened, widened]);
+  });
+
   it("fills and submits only after the guard authorizes all three mutation boundaries", async () => {
     const fill = vi.fn();
     const page = makePage({ onFill: fill });
@@ -304,6 +353,32 @@ describe("executeScrapeTimeAutoLoginTrigger", () => {
 
     expect(beforeAutoLoginMutation).toHaveBeenCalledTimes(1);
     expect(events).toEqual(["before", "fill:#username", "fill:#password"]);
+  });
+
+  // The mutation hook wraps the page. An adapter that declares fewer parameters
+  // than the interface stays assignable in TypeScript, so a dropped `timeoutMs`
+  // silently reverts every probe to the page default and discards the guard's
+  // choice without a compile error or a failing behavioural test.
+  it("forwards the probe timeout through the mutation-hook page wrapper", async () => {
+    const probes: Array<number | undefined> = [];
+    const page = makePage();
+    const recordingPage = {
+      ...page,
+      hasVisibleSelector: async (selector: string, timeoutMs?: number) => {
+        probes.push(timeoutMs);
+        return page.hasVisibleSelector(selector);
+      },
+    };
+
+    await expect(executeScrapeTimeAutoLoginTrigger({
+      bankCode: "popular", expiredEventId: "E1", credential, cdpUrl: "http://127.0.0.1:9222",
+      adapter: { bankCode: "popular", createAutoLoginStrategy: () => createBankAutoLoginStrategy(portalConfig) },
+      lock: { acquire: vi.fn().mockResolvedValue({ leaseToken: "lease-1", fencingToken: 1, expiresAt: 123 }), release: vi.fn().mockResolvedValue(true) },
+      ensureBrowser: vi.fn().mockResolvedValue(readyBrowser(recordingPage)),
+      beforeAutoLoginMutation: vi.fn().mockResolvedValue(true),
+    })).resolves.toEqual({ status: "succeeded" });
+
+    expect(probes.some((timeoutMs) => timeoutMs === MIN_PROTECTED_STATE_DETECTION_WINDOW_MS)).toBe(true);
   });
 
   it("fails closed when the mutation hook rejects or denies the compare-and-set", async () => {

--- a/src/worker/scraper/auto-login.test.ts
+++ b/src/worker/scraper/auto-login.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { encryptCredentialField } from "../../modules/bank-credentials/crypto";
-import { DEFAULT_VISIBLE_SELECTOR_TIMEOUT_MS, createBankAutoLoginStrategy, createScrapeTimeAutoLoginBrowserOpener, createScrapeTimeAutoLoginRunner, executeScrapeTimeAutoLoginTrigger, parseAutoLoginSelectorTimeoutMs, unavailableScrapeTimeAutoLoginBrowserOpener, type BankAutoLoginPage } from "./auto-login";
+import { CREDENTIAL_SCRUB_TIMEOUT_MS, DEFAULT_VISIBLE_SELECTOR_TIMEOUT_MS, createBankAutoLoginStrategy, createScrapeTimeAutoLoginBrowserOpener, createScrapeTimeAutoLoginRunner, executeScrapeTimeAutoLoginTrigger, parseAutoLoginSelectorTimeoutMs, unavailableScrapeTimeAutoLoginBrowserOpener, type BankAutoLoginPage } from "./auto-login";
 import { MIN_PROTECTED_STATE_DETECTION_WINDOW_MS, type BankPortalConfig } from "./login-mutation-guard";
 
 const portalConfig: BankPortalConfig = {
@@ -52,7 +52,11 @@ function makeMutationBoundaryDriftPage(driftBefore: MutationPhase) {
       }
       return visible.has(selector as (typeof loginControls)[number]);
     },
-    async fill(selector) {
+    // Records credential-bearing fills only. The abort path also clears the
+    // inputs with an empty value; that is cleanup, not a mutation crossing a
+    // boundary, and counting it would blur what these cases assert.
+    async fill(selector, value) {
+      if (value === "") return;
       mutations.push(selector);
       phase = selector === portalConfig.usernameSelector ? "password" : "submit";
     },
@@ -119,6 +123,75 @@ describe("createBankAutoLoginStrategy", () => {
     expect(preSubmit.slice(4)).toEqual([widened, widened]);
   });
 
+  // The detection window closes the gap BETWEEN guard passes; it cannot close
+  // the instant between a pass and the fill that follows it. An overlay landing
+  // there is caught by the next boundary, but the password is already in the
+  // page by then - and must not be left there.
+  it("clears the credential inputs when a protected state appears after the password fill", async () => {
+    let reveal: (selector: string) => void = () => undefined;
+    const fills: Array<{ selector: string; value: string }> = [];
+    const page = makePage({
+      onFill: (selector, value) => {
+        fills.push({ selector, value });
+        if (selector === portalConfig.passwordSelector && value !== "") reveal(portalConfig.mfaIndicatorSelector);
+      },
+    });
+    reveal = page.show;
+
+    await expect(createBankAutoLoginStrategy(portalConfig, { supportedBankCodes: ["popular"] })
+      .autoLogin({ credential, page })).resolves.toMatchObject({ status: "needs_admin_action", reason: "protected_flow" });
+
+    expect(fills.map((entry) => entry.value)).toEqual([credential.username, credential.password, "", ""]);
+    // Password first: it is the value that matters most if clearing is cut short.
+    expect(fills.slice(2).map((entry) => entry.selector)).toEqual([portalConfig.passwordSelector, portalConfig.usernameSelector]);
+  });
+
+  it("reports the abort reason even when clearing the credential inputs fails", async () => {
+    let reveal: (selector: string) => void = () => undefined;
+    const page = makePage({
+      onFill: (selector, value) => {
+        if (value === "") throw new Error("detached frame");
+        if (selector === portalConfig.passwordSelector) reveal(portalConfig.mfaIndicatorSelector);
+      },
+    });
+    reveal = page.show;
+
+    await expect(createBankAutoLoginStrategy(portalConfig, { supportedBankCodes: ["popular"] })
+      .autoLogin({ credential, page })).resolves.toMatchObject({ status: "needs_admin_action", reason: "protected_flow" });
+  });
+
+  // Swallowing rejections is not enough to make cleanup non-blocking. A fill
+  // that never settles would hold the abort outcome forever, and with it the
+  // browser close and the lock release, so each clear carries its own deadline.
+  it("does not hold the abort outcome when clearing an input never settles", async () => {
+    vi.useFakeTimers();
+    try {
+      let reveal: (selector: string) => void = () => undefined;
+      const cleared: string[] = [];
+      const page = makePage({
+        onFill: (selector, value) => {
+          if (value === "") {
+            cleared.push(selector);
+            return new Promise<void>(() => undefined); // never settles
+          }
+          if (selector === portalConfig.passwordSelector) reveal(portalConfig.mfaIndicatorSelector);
+        },
+      });
+      reveal = page.show;
+
+      const pending = createBankAutoLoginStrategy(portalConfig, { supportedBankCodes: ["popular"] })
+        .autoLogin({ credential, page });
+
+      await vi.advanceTimersByTimeAsync(CREDENTIAL_SCRUB_TIMEOUT_MS * 2 + 50);
+
+      await expect(pending).resolves.toMatchObject({ status: "needs_admin_action", reason: "protected_flow" });
+      // A hung password clear must not cost the username its own attempt.
+      expect(cleared).toEqual([portalConfig.passwordSelector, portalConfig.usernameSelector]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("fills and submits only after the guard authorizes all three mutation boundaries", async () => {
     const fill = vi.fn();
     const page = makePage({ onFill: fill });
@@ -177,7 +250,7 @@ describe("createBankAutoLoginStrategy", () => {
 
   it("re-checks the guard before password fill so redirects cannot receive passwords", async () => {
     let setPageUrl: (nextUrl: string) => void = () => undefined;
-    const fill = vi.fn((selector: string) => {
+    const fill = vi.fn<(selector: string, value: string) => void>((selector) => {
       if (selector === portalConfig.usernameSelector) setPageUrl("https://evil.example/login");
     });
     const page = makePage({ onFill: fill });
@@ -188,13 +261,14 @@ describe("createBankAutoLoginStrategy", () => {
       status: "needs_admin_action",
       reason: "unauthorized_login_page",
     });
-    expect(fill.mock.calls).toEqual([["#username", "bank-user"]]);
+    const credentialFills = fill.mock.calls.filter(([, value]) => value !== "");
+    expect(credentialFills).toEqual([["#username", "bank-user"]]);
     expect(click).not.toHaveBeenCalled();
   });
 
   it("re-checks the guard before submit so redirects after password fill cannot submit credentials", async () => {
     let setPageUrl: (nextUrl: string) => void = () => undefined;
-    const fill = vi.fn((selector: string) => {
+    const fill = vi.fn<(selector: string, value: string) => void>((selector) => {
       if (selector === portalConfig.passwordSelector) setPageUrl("https://evil.example/login");
     });
     const page = makePage({ onFill: fill });
@@ -205,7 +279,10 @@ describe("createBankAutoLoginStrategy", () => {
       status: "needs_admin_action",
       reason: "unauthorized_login_page",
     });
-    expect(fill.mock.calls).toEqual([["#username", "bank-user"], ["#password", "bank-password"]]);
+    const credentialFills = fill.mock.calls.filter(([, value]) => value !== "");
+    expect(credentialFills).toEqual([["#username", "bank-user"], ["#password", "bank-password"]]);
+    // Aborting after the password landed must also clear it.
+    expect(fill.mock.calls.slice(credentialFills.length)).toEqual([["#password", ""], ["#username", ""]]);
     expect(click).not.toHaveBeenCalled();
   });
 

--- a/src/worker/scraper/auto-login.ts
+++ b/src/worker/scraper/auto-login.ts
@@ -616,24 +616,75 @@ export function createBankAutoLoginStrategy(
       // the DOM before a late overlay was seen, and `fill` raises browser events
       // the portal's own scripts may react to — so "nothing is transmitted yet"
       // was never a property this code could guarantee. The window stays whole.
+      //
+      // The window closes the gap between guard passes, not the gap between a
+      // pass and the fill that follows it. An overlay landing in that instant is
+      // still caught by the NEXT boundary, but by then a value is in the page,
+      // so aborts after a fill scrub the inputs (see scrubCredentialFields).
       const beforeUsernameFill = await runGuard(() => guard.assertMutationAuthorized(page));
       if (beforeUsernameFill) return beforeUsernameFill;
       const usernameFill = await runBrowserMutation(() => page.fill(portalConfig.usernameSelector, credential.username));
+      // Not scrubbed, and not because the DOM is known to be clean: a fill can
+      // write a value and then fail on navigation, detach, or a later event, so
+      // whether the username landed is undeterminable from here. The reason is
+      // narrower — a failure here may mean the mutation hook denied
+      // authorization, and scrubbing would re-enter that operator callback. The
+      // password is only ever filled after this call succeeds, so the secret
+      // stays covered below; a possibly-partial username is the accepted cost.
       if (usernameFill) return usernameFill;
 
       const beforePasswordFill = await runGuard(() => guard.assertMutationAuthorized(page));
-      if (beforePasswordFill) return beforePasswordFill;
+      if (beforePasswordFill) return scrubCredentialFields(page, portalConfig, beforePasswordFill);
       const passwordFill = await runBrowserMutation(() => page.fill(portalConfig.passwordSelector, credential.password));
-      if (passwordFill) return passwordFill;
+      if (passwordFill) return scrubCredentialFields(page, portalConfig, passwordFill);
 
       const beforeSubmit = await runGuard(() => guard.assertMutationAuthorized(page));
-      if (beforeSubmit) return beforeSubmit;
+      if (beforeSubmit) return scrubCredentialFields(page, portalConfig, beforeSubmit);
 
       const submit = await runBrowserMutation(() => page.click(portalConfig.submitSelector));
-      if (submit) return submit;
+      if (submit) return scrubCredentialFields(page, portalConfig, submit);
       return detectPostSubmitOutcome(page, portalConfig, guard);
     },
   };
+}
+
+/**
+ * Best-effort clearing of the credential inputs when the flow aborts after a
+ * successful fill.
+ *
+ * This does not undo a fill and does not pretend to: the portal's scripts may
+ * already have read the values or reacted to the events, and nothing here can
+ * reach into that. What it bounds is the residual exposure of leaving a
+ * password sitting in a DOM the operator may drive by hand during manual
+ * recovery.
+ *
+ * Failures are swallowed on purpose. The abort outcome is what the caller must
+ * act on, and letting a cleanup error replace it would hide the real reason the
+ * flow stopped. Only called once a fill has succeeded, so the mutation hook has
+ * already authorized and is not re-entered.
+ *
+ * Each clear is bounded by its own deadline. Swallowing rejections is not
+ * enough to make cleanup non-blocking: a `fill` that never settles would hold
+ * the abort outcome forever, and with it the browser close and the lock
+ * release — a secondary cleanup taking the primary path hostage. The deadline
+ * is per field rather than shared so a hung password clear cannot also cost the
+ * username its turn.
+ */
+export const CREDENTIAL_SCRUB_TIMEOUT_MS = 1_000;
+
+async function scrubCredentialFields(
+  page: BankAutoLoginPage,
+  portalConfig: BankPortalConfig,
+  outcome: BankAutoLoginOutcome,
+): Promise<BankAutoLoginOutcome> {
+  for (const selector of [portalConfig.passwordSelector, portalConfig.usernameSelector]) {
+    await runBoundedCleanup(
+      async () => { await page.fill(selector, ""); },
+      CREDENTIAL_SCRUB_TIMEOUT_MS,
+      async () => undefined,
+    );
+  }
+  return outcome;
 }
 
 type GuardResult = { guard: LoginMutationGuard; outcome?: never } | { guard?: never; outcome: BankAutoLoginOutcome };

--- a/src/worker/scraper/auto-login.ts
+++ b/src/worker/scraper/auto-login.ts
@@ -269,13 +269,27 @@ async function openTrustedLoginPage(options: OpenTrustedLoginPageOptions): Promi
   }
 }
 class CdpBankAutoLoginPage implements BankAutoLoginPage {
-  constructor(private readonly page: AutoLoginCdpPageLike, private readonly visibleSelectorTimeoutMs: number) {}
+  /**
+   * Advisory only: the guard clamps this to its own safety floor, so a lowered
+   * `RD_SYNC_AUTOLOGIN_SELECTOR_TIMEOUT_MS` can speed up form-visibility waits
+   * without narrowing the protected-state detection window.
+   */
+  readonly protectedStateDetectionWindowMs: number;
+
+  constructor(private readonly page: AutoLoginCdpPageLike, private readonly visibleSelectorTimeoutMs: number) {
+    this.protectedStateDetectionWindowMs = visibleSelectorTimeoutMs;
+  }
+
   async currentUrl(): Promise<string> { return this.page.url(); }
   async fill(selector: string, value: string): Promise<void> { await this.page.fill(selector, value); }
   async click(selector: string): Promise<void> { await this.page.click(selector); }
-  async hasVisibleSelector(selector: string): Promise<boolean> {
+  async hasVisibleSelector(selector: string, timeoutMs?: number): Promise<boolean> {
+    // `timeoutMs` lets the guard probe for states expected to be ABSENT without
+    // paying the full visibility wait; omitted, it keeps the long default used
+    // when waiting for the login form to render.
+    const timeout = timeoutMs ?? this.visibleSelectorTimeoutMs;
     try {
-      await this.page.waitForSelector(selector, { timeout: this.visibleSelectorTimeoutMs, state: "visible" });
+      await this.page.waitForSelector(selector, { timeout, state: "visible" });
       return true;
     } catch (error) {
       if (isExpectedSelectorTimeout(error)) return false;
@@ -551,7 +565,14 @@ function withAutoLoginMutationHook(page: BankAutoLoginPage, context: ScrapeTimeA
   let mutationAuthorized = false;
   return {
     currentUrl: () => page.currentUrl(),
-    hasVisibleSelector: (selector) => page.hasVisibleSelector(selector),
+    // Forward timeoutMs. Dropping it silently restores the long default and
+    // undoes the caller's probe choice; TypeScript cannot catch that, because a
+    // function declaring fewer parameters stays assignable.
+    hasVisibleSelector: (selector, timeoutMs) => page.hasVisibleSelector(selector, timeoutMs),
+    // Forward the declared detection window too. Dropping it is fail-safe (the
+    // guard falls back to its floor) but would silently discard an operator's
+    // deliberately widened window.
+    protectedStateDetectionWindowMs: page.protectedStateDetectionWindowMs,
     async fill(selector, value) {
       if (!mutationAuthorized) {
         const permitted = await context.beforeAutoLoginMutation?.({ bankCode: context.bankCode, expiredEventId: context.expiredEventId });
@@ -590,6 +611,11 @@ export function createBankAutoLoginStrategy(
       if (guardResult.outcome) return guardResult.outcome;
       const { guard } = guardResult;
 
+      // Every mutation boundary gets the same full detection window. Shortening
+      // the two fill guards was measurably faster, but it let credentials reach
+      // the DOM before a late overlay was seen, and `fill` raises browser events
+      // the portal's own scripts may react to — so "nothing is transmitted yet"
+      // was never a property this code could guarantee. The window stays whole.
       const beforeUsernameFill = await runGuard(() => guard.assertMutationAuthorized(page));
       if (beforeUsernameFill) return beforeUsernameFill;
       const usernameFill = await runBrowserMutation(() => page.fill(portalConfig.usernameSelector, credential.username));

--- a/src/worker/scraper/login-mutation-guard.test.ts
+++ b/src/worker/scraper/login-mutation-guard.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { LOGIN_MUTATION_GUARD_ERROR_SUMMARIES, LoginMutationGuard, LoginMutationGuardError, type BankPortalConfig, type LoginMutationPage } from "./login-mutation-guard";
+import { LOGIN_MUTATION_GUARD_ERROR_SUMMARIES, MIN_PROTECTED_STATE_DETECTION_WINDOW_MS, LoginMutationGuard, LoginMutationGuardError, type BankPortalConfig, type LoginMutationPage } from "./login-mutation-guard";
 
 const portalConfig: BankPortalConfig = {
   bankCode: "popular",
@@ -30,6 +30,100 @@ async function guardedSubmit(guard: LoginMutationGuard, page: LoginMutationPage,
   await guard.assertMutationAuthorized(page);
   submit();
 }
+
+describe("LoginMutationGuard absence probes", () => {
+  // Absence probes resolve by EXPIRING, so every happy-path pass pays the full
+  // window. That cost is accepted: it is the interval in which a protected flow
+  // can still be caught, and it is not negotiable per call site.
+  function makeTimeoutRecordingPage(url: string, visibleSelectors: readonly string[]) {
+    const probes: Array<{ selector: string; timeoutMs?: number }> = [];
+    const page: LoginMutationPage = {
+      async currentUrl() { return url; },
+      async hasVisibleSelector(selector, timeoutMs) {
+        probes.push({ selector, timeoutMs });
+        return visibleSelectors.includes(selector);
+      },
+    };
+    return { page, probes };
+  }
+
+  // Not merely the default — the only option. Callers cannot trade detection
+  // latency for speed at a mutation boundary, because the parameter that once
+  // allowed it no longer exists.
+  it("gives every caller the clamped detection window", async () => {
+    const { page, probes } = makeTimeoutRecordingPage("https://ib.bpd.com.do/login", allLoginControlSelectors);
+
+    await new LoginMutationGuard(portalConfig).assertMutationAuthorized(page);
+
+    const absenceProbes = probes.filter((probe) =>
+      probe.selector === portalConfig.mfaIndicatorSelector || probe.selector === portalConfig.incompatibleFlowSelector);
+    expect(absenceProbes).toHaveLength(2);
+    for (const probe of absenceProbes) expect(probe.timeoutMs).toBe(MIN_PROTECTED_STATE_DETECTION_WINDOW_MS);
+  });
+
+  it("keeps the page default wait for required controls, which must be given time to render", async () => {
+    const { page, probes } = makeTimeoutRecordingPage("https://ib.bpd.com.do/login", allLoginControlSelectors);
+
+    await new LoginMutationGuard(portalConfig).assertMutationAuthorized(page);
+
+    const controlProbes = probes.filter((probe) => allLoginControlSelectors.includes(probe.selector as (typeof allLoginControlSelectors)[number]));
+    expect(controlProbes.length).toBeGreaterThan(0);
+    for (const probe of controlProbes) expect(probe.timeoutMs).toBeUndefined();
+  });
+
+  // The wait is not idle time — it IS the detection window. An overlay that
+  // renders seconds after the form is exactly what it exists to catch.
+  it("catches an overlay that renders late but inside the detection window", async () => {
+    const page: LoginMutationPage = {
+      async currentUrl() { return "https://ib.bpd.com.do/login"; },
+      async hasVisibleSelector(selector, timeoutMs) {
+        if (allLoginControlSelectors.includes(selector as (typeof allLoginControlSelectors)[number])) return true;
+        if (selector !== portalConfig.incompatibleFlowSelector) return false;
+        // Stands in for an overlay that renders a few seconds after the form: a
+        // wait shorter than the window would return false and miss it.
+        return (timeoutMs ?? 0) >= MIN_PROTECTED_STATE_DETECTION_WINDOW_MS;
+      },
+    };
+
+    // The very first boundary rejects, so no credential is ever written.
+    await expect(new LoginMutationGuard(portalConfig).assertMutationAuthorized(page))
+      .rejects.toBeInstanceOf(LoginMutationGuardError);
+  });
+
+  it("keeps the full detection window post-submit, where the bank's MFA screen legitimately appears", async () => {
+    const { page, probes } = makeTimeoutRecordingPage("https://ib.bpd.com.do/dashboard", []);
+
+    await new LoginMutationGuard(portalConfig).assertNoProtectedOrIncompatibleState(page);
+
+    expect(probes).toHaveLength(2);
+    for (const probe of probes) expect(probe.timeoutMs).toBe(MIN_PROTECTED_STATE_DETECTION_WINDOW_MS);
+  });
+
+  // The floor is the guard's, not the page's: a page that declares a narrower
+  // window cannot shrink the protection, but may widen it.
+  it.each([
+    [undefined, MIN_PROTECTED_STATE_DETECTION_WINDOW_MS],
+    [1_000, MIN_PROTECTED_STATE_DETECTION_WINDOW_MS],
+    [Number.NaN, MIN_PROTECTED_STATE_DETECTION_WINDOW_MS],
+    [Number.POSITIVE_INFINITY, MIN_PROTECTED_STATE_DETECTION_WINDOW_MS],
+    [-1, MIN_PROTECTED_STATE_DETECTION_WINDOW_MS],
+    [MIN_PROTECTED_STATE_DETECTION_WINDOW_MS * 3, MIN_PROTECTED_STATE_DETECTION_WINDOW_MS * 3],
+  ])("clamps a page-declared detection window of %j to %j", async (declared, expected) => {
+    const { page, probes } = makeTimeoutRecordingPage("https://ib.bpd.com.do/dashboard", []);
+    const declaringPage: LoginMutationPage = { ...page, protectedStateDetectionWindowMs: declared };
+
+    await new LoginMutationGuard(portalConfig).assertNoProtectedOrIncompatibleState(declaringPage);
+
+    expect(probes).toHaveLength(2);
+    for (const probe of probes) expect(probe.timeoutMs).toBe(expected);
+  });
+
+  it("detects an MFA indicator that is already visible", async () => {
+    const { page } = makeTimeoutRecordingPage("https://ib.bpd.com.do/login", [...allLoginControlSelectors, portalConfig.mfaIndicatorSelector]);
+
+    await expect(new LoginMutationGuard(portalConfig).assertMutationAuthorized(page)).rejects.toBeInstanceOf(LoginMutationGuardError);
+  });
+});
 
 describe("LoginMutationGuard", () => {
   it.each([

--- a/src/worker/scraper/login-mutation-guard.ts
+++ b/src/worker/scraper/login-mutation-guard.ts
@@ -13,8 +13,41 @@ export interface BankPortalConfig {
 
 export interface LoginMutationPage {
   currentUrl(): string | Promise<string>;
-  hasVisibleSelector(selector: string): boolean | Promise<boolean>;
+  /**
+   * Resolves true once the selector is visible, false if it is still absent
+   * when the wait expires. `timeoutMs` overrides the page's default wait; the
+   * guard uses a short override for absence probes, where expiry IS the
+   * expected answer rather than a failure.
+   */
+  hasVisibleSelector(selector: string, timeoutMs?: number): boolean | Promise<boolean>;
+  /**
+   * The page's preferred detection window for absence probes, in milliseconds.
+   * Advisory only: the guard clamps it to
+   * `MIN_PROTECTED_STATE_DETECTION_WINDOW_MS`, so a page can widen this window
+   * but never shrink it below the safe floor.
+   */
+  readonly protectedStateDetectionWindowMs?: number;
 }
+
+/**
+ * Floor for the window the guard keeps open while probing for a state that is
+ * normally ABSENT (an MFA prompt or an incompatible-flow overlay). Such an
+ * overlay can render asynchronously seconds after the login form, so the wait
+ * is not idle time — it is the interval in which a protected flow can still be
+ * caught before credentials are written or submitted.
+ *
+ * The window is deliberately NOT overridable per call. An earlier revision let
+ * callers shorten it at the fill boundaries to save wall-clock, which let
+ * credentials reach the DOM before a late overlay was seen. Trading detection
+ * latency for speed at a mutation boundary is not a per-call-site decision, so
+ * the parameter that allowed it was removed rather than merely left unused.
+ *
+ * The floor lives in the guard, not in the page adapter, for the same reason.
+ * The adapter's visibility timeout is an operational latency knob and is
+ * environment-configurable; this is a safety property. Clamping here means no
+ * page configuration can shrink it — a page may only widen it.
+ */
+export const MIN_PROTECTED_STATE_DETECTION_WINDOW_MS = 5_000;
 
 export const LOGIN_MUTATION_GUARD_ERROR_SUMMARIES = {
   MALFORMED_PORTAL_URL: "Bank portal URL is malformed",
@@ -109,10 +142,16 @@ export class LoginMutationGuard {
    * Guard-owned protected/incompatible state check for both pre-mutation and
    * post-submit observations. Callers must not duplicate this policy.
    */
+  /**
+   * Every caller gets the same clamped detection window, pre-mutation and
+   * post-submit alike. There is no per-call override: see
+   * MIN_PROTECTED_STATE_DETECTION_WINDOW_MS.
+   */
   async assertNoProtectedOrIncompatibleState(page: LoginMutationPage): Promise<void> {
+    const effectiveTimeoutMs = detectionWindowMs(page);
     const [hasMfaIndicator, hasIncompatibleFlow] = await Promise.all([
-      this.hasVisibleSelector(page, this.config.mfaIndicatorSelector),
-      this.hasVisibleSelector(page, this.config.incompatibleFlowSelector),
+      this.hasVisibleSelector(page, this.config.mfaIndicatorSelector, effectiveTimeoutMs),
+      this.hasVisibleSelector(page, this.config.incompatibleFlowSelector, effectiveTimeoutMs),
     ]);
 
     if (hasMfaIndicator) {
@@ -149,13 +188,23 @@ export class LoginMutationGuard {
     }
   }
 
-  private async hasVisibleSelector(page: LoginMutationPage, selector: string): Promise<boolean> {
+  private async hasVisibleSelector(page: LoginMutationPage, selector: string, timeoutMs?: number): Promise<boolean> {
     try {
-      return await page.hasVisibleSelector(selector);
+      return await page.hasVisibleSelector(selector, timeoutMs);
     } catch {
       throw createPortalStateUnavailableError();
     }
   }
+}
+
+/**
+ * Resolves the guard-owned detection window. A page may widen it; a missing,
+ * non-finite, or narrower value falls back to the safe floor.
+ */
+function detectionWindowMs(page: LoginMutationPage): number {
+  const declared = page.protectedStateDetectionWindowMs;
+  if (typeof declared !== "number" || !Number.isFinite(declared)) return MIN_PROTECTED_STATE_DETECTION_WINDOW_MS;
+  return Math.max(declared, MIN_PROTECTED_STATE_DETECTION_WINDOW_MS);
 }
 
 function createPortalStateUnavailableError(): LoginMutationGuardError {


### PR DESCRIPTION
Hardens the window in which `LoginMutationGuard` can detect a protected or incompatible portal state before credentials are written or submitted, and bounds what is left behind when the flow aborts after a fill.

The branch name still says `perf`. It no longer is: the performance change it started as was reverted during review, and what remains is the safety work that came out of it. Both commits are `fix`.

## Background

This branch began as an optimisation. Absence probes ??? waiting for an MFA prompt or an incompatible-flow overlay that is normally *not* there ??? resolve by expiring, so each pass charged the full visibility timeout. Five passes turned a login into roughly 50 seconds of waiting for elements that were never going to appear.

Shortening the probes at the two credential-fill boundaries was measurably faster and wrong. Review established that it let credentials reach the DOM before a late overlay could be seen, justified by a comment asserting that nothing had been transmitted yet ??? a claim about the portal's own JavaScript that no interface here can enforce, since `fill` raises browser events. The maintainer chose to eliminate the risk rather than accept it, so the speedup is gone and a login costs what it did before.

What survived is worth having on its own.

## `c04f94c` ??? clamp the protected-state detection window in the guard

Two problems in how the guard waited.

**The window was environment-configurable all the way down.** Every absence probe resolved to the page adapter's visibility timeout, so `RD_SYNC_AUTOLOGIN_SELECTOR_TIMEOUT_MS=1000` collapsed all of them to one second. This hole predates the branch ??? it arrived with #63, where `main` already routed all five guard passes through the same value. It is closed by clamping to `MIN_PROTECTED_STATE_DETECTION_WINDOW_MS` inside `LoginMutationGuard` rather than inheriting from the page. The adapter's timeout is an operational latency knob; this is a safety property. A page may widen the window via `protectedStateDetectionWindowMs`; nothing can narrow it.

**The window was overridable per call site.** Rather than merely stop passing a short probe, the parameter that allowed it is removed, along with `ABSENT_STATE_PROBE_TIMEOUT_MS`. Trading detection latency for speed at a mutation boundary is not a per-call-site decision, and a dead safety knob left exported is an invitation. All three pre-submit boundaries and the post-submit check now share one clamped window.

Required-control checks deliberately keep the page default. Waiting for the login form to render is a latency concern, and a *positive* check costs nothing on the happy path, so the two purposes stay separated.

`withAutoLoginMutationHook` now forwards `timeoutMs` and `protectedStateDetectionWindowMs`. Dropping either was silent: a function declaring fewer parameters stays assignable, so TypeScript could not catch it and no behavioural test covered it.

## `9ca4b9c` ??? scrub credential inputs when a late guard aborts

Best-effort mitigation for a gap the detection window cannot close.

The window closes the interval *between* guard passes. It cannot close the instant between a pass and the fill that immediately follows it: an overlay landing there is caught by the next boundary, but a credential is already in the page by then. That residual is inherent to filling before submitting, not a consequence of any timeout choice.

Aborts after a successful fill clear both inputs, password first, so a cut-short cleanup still removes the value that matters most. This does not undo a fill and does not pretend to ??? the portal's scripts may already have read the values or reacted to the events they raised. What it bounds is a password left sitting in a DOM the operator may drive by hand during manual recovery.

Each clear carries its own deadline via `runBoundedCleanup`, the helper this file already uses for browser teardown. Swallowing rejections does not make cleanup non-blocking: a `fill` that never settles would hold the abort outcome forever, and with it the browser close and the lock release ??? a secondary cleanup taking the primary path hostage. The deadline is per field rather than shared so a hung password clear cannot also cost the username its turn.

Scrubbing is skipped when the username fill itself failed. Not because the DOM is known to be clean ??? a fill can write a value and then fail on navigation or detach, so that is undeterminable from here ??? but because such a failure may mean the mutation hook denied authorization, and scrubbing would re-enter that operator callback. The password is only ever filled after that call succeeds, so the secret stays covered; a possibly-partial username is the accepted cost.

## Testing

Tests assert the *effective* wait reaching the page rather than the argument a call site passes, at both the guard and composition levels. An earlier revision asserted `undefined` at the submit boundary, which proved only that the call site declined to override ??? it could not distinguish a 10s window from a 1s one.

Each guarantee was mutation-verified:

| Mutation | Result |
| --- | --- |
| Remove the floor clamp | 3 tests fail |
| Shorten the detection window | 13 tests fail |
| Make the scrub inert | 2 tests fail |
| Drop the scrub deadline | new never-settles test fails |

The never-settling case is covered with a `fill` that never resolves, under fake timers, asserting both that the outcome still returns and that each field got its own attempt.

The boundary cases that asserted an exact fill sequence now filter to credential-bearing fills, keeping what they actually verify ??? that no credential value crossed a boundary and no submit occurred.

## Verification

All of the following were run **locally**. This repository has no CI workflow, so GitHub reports zero check runs on this branch ??? the results below are not independently reproduced by automation.

- Lint clean at `--max-warnings=0`
- Typecheck clean
- 1294 tests pass, 100 skipped
- 414 changed lines (393 insertions, 21 deletions) across 4 files
- No runtime behaviour change in `9ca4b9c` beyond the scrub deadline: the lint fix there is a typing-only edit, an explicit generic on a test mock
- Both commits verified independently green ??? lint, typecheck and tests each pass with `c04f94c` alone ??? so a bisect through this branch is safe

## Notes for review

- The performance regression is intentional and is the maintainer's explicit decision, not an oversight.
- The residual gap between a guard pass and its fill is bounded by the scrub, not eliminated. Continuous overlay detection instead of sampled probes is tracked in #65.



- Review size: 414 changed lines. The maintainer explicitly accepts the 14-line overage because the four-file change is cohesive and splitting it would reduce review clarity.

