### PR TITLE
fix(auto-login): resolve manual recovery episodes from admin UI

### DIFF
--- a/src/app/api/bank-sessions/manual-recovery/route.test.ts
+++ b/src/app/api/bank-sessions/manual-recovery/route.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const repository = vi.hoisted(() => ({
+  findByBankCode: vi.fn(),
+  resolveConsumerManualRecovery: vi.fn(),
+}));
+const getPrismaClient = vi.hoisted(() => vi.fn(() => ({})));
+
+vi.mock("../../../../modules/persistence/prisma-client", () => ({ getPrismaClient }));
+vi.mock("../../../../modules/persistence/prisma-bank-session-expiry-episode-repository", () => ({
+  PrismaBankSessionExpiryEpisodeRepository: class {
+    findByBankCode = repository.findByBankCode;
+    resolveConsumerManualRecovery = repository.resolveConsumerManualRecovery;
+  },
+}));
+
+import { GET, POST } from "./route";
+
+function adminHeaders(): Record<string, string> {
+  return { "x-rd-sync-user-id": "admin-1", "x-rd-sync-role": "admin" };
+}
+
+function episode(state: "manual_recovery_required" | "resolved" = "manual_recovery_required") {
+  return {
+    bankCode: "popular",
+    expiredEventId: "event-1",
+    runId: "run-1",
+    publicationClaimToken: "publication-token",
+    consumerClaimToken: "consumer-token",
+    consumerAttemptState: state,
+  };
+}
+
+function request(method: "GET" | "POST", headers: Record<string, string> = adminHeaders(), body?: unknown): Request {
+  return new Request("http://localhost:3000/api/bank-sessions/manual-recovery?bankCode=popular", {
+    method,
+    headers: { "content-type": "application/json", ...headers },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+describe("/api/bank-sessions/manual-recovery", () => {
+  beforeEach(() => {
+    process.env.RD_SYNC_TRUST_PROXY_HEADERS = "enabled";
+    repository.findByBankCode.mockReset().mockResolvedValue(episode());
+    repository.resolveConsumerManualRecovery.mockReset().mockResolvedValue({ id: "resolution-1" });
+  });
+
+  afterEach(() => {
+    delete process.env.RD_SYNC_TRUST_PROXY_HEADERS;
+    vi.restoreAllMocks();
+  });
+
+  it.each([{}, { "x-rd-sync-user-id": "viewer-1", "x-rd-sync-role": "viewer" }])("rejects non-admin callers before looking up an episode", async (headers) => {
+    const response = await GET(request("GET", headers as Record<string, string>));
+
+    expect(response.status).toBe(Object.keys(headers).length ? 403 : 401);
+    expect(repository.findByBankCode).not.toHaveBeenCalled();
+  });
+
+  it("reports eligibility without exposing episode identifiers or claim tokens", async () => {
+    const response = await GET(request("GET"));
+    const body = JSON.stringify(await response.json());
+
+    expect(response.status).toBe(200);
+    expect(body).toBe(JSON.stringify({ eligible: true }));
+    expect(body).not.toContain("event-1");
+    expect(body).not.toContain("token");
+  });
+
+  it("reports a non-eligible episode without offering its durable state to the browser", async () => {
+    repository.findByBankCode.mockResolvedValue(episode("resolved"));
+
+    const response = await GET(request("GET"));
+
+    expect(await response.json()).toEqual({ eligible: false });
+  });
+
+  it("resolves an eligible episode as the authenticated admin and returns only a safe status", async () => {
+    const response = await POST(request("POST", adminHeaders(), {
+      decision: { outcome: "safe_to_retry", reason: "verified_no_mutation" },
+    }));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ status: "resolved" });
+    expect(repository.resolveConsumerManualRecovery).toHaveBeenCalledWith(
+      expect.objectContaining({ bankCode: "popular", expiredEventId: "event-1", runId: "run-1", token: "publication-token" }),
+      "consumer-token",
+      { operatorId: "admin-1", decision: { outcome: "safe_to_retry", reason: "verified_no_mutation" } },
+    );
+  });
+
+  it("rejects non-eligible and concurrent resolution attempts without writing", async () => {
+    const body = { decision: { outcome: "resolved_no_retry", reason: "closed_without_retry" } };
+    repository.findByBankCode.mockResolvedValue(episode("resolved"));
+
+    await expect(POST(request("POST", adminHeaders(), body))).resolves.toHaveProperty("status", 409);
+    expect(repository.resolveConsumerManualRecovery).not.toHaveBeenCalled();
+
+    repository.findByBankCode.mockResolvedValue(episode());
+    repository.resolveConsumerManualRecovery.mockResolvedValue(null);
+    await expect(POST(request("POST", adminHeaders(), body))).resolves.toHaveProperty("status", 409);
+  });
+
+  it("linearizes concurrent resolution requests into one success and one conflict", async () => {
+    repository.resolveConsumerManualRecovery.mockResolvedValueOnce({ id: "resolution-1" }).mockResolvedValueOnce(null);
+    const body = { decision: { outcome: "safe_to_retry", reason: "verified_no_mutation" } };
+
+    const results = await Promise.all([POST(request("POST", adminHeaders(), body)), POST(request("POST", adminHeaders(), body))]);
+
+    expect(results.map((response) => response.status).sort()).toEqual([200, 409]);
+  });
+
+  it("fails closed with a generic response when persistence fails", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    repository.findByBankCode.mockRejectedValue(new Error("database token=secret"));
+
+    const response = await GET(request("GET"));
+    const body = JSON.stringify(await response.json());
+
+    expect(response.status).toBe(503);
+    expect(body).toBe(JSON.stringify({ error: "Manual recovery is unavailable" }));
+    expect(body).not.toContain("database");
+    expect(body).not.toContain("secret");
+    expect(consoleSpy).toHaveBeenCalledOnce();
+  });
+});

--- a/src/app/api/bank-sessions/manual-recovery/route.ts
+++ b/src/app/api/bank-sessions/manual-recovery/route.ts
@@ -1,0 +1,93 @@
+import { resolvePrincipal, requireRole } from "../../../../modules/auth";
+import { InMemoryRateLimiter } from "../../../../modules/auth/rate-limiter";
+import {
+  authorizeManualRecoveryResolution,
+  type ManualRecoveryResolutionDecision,
+  type ManualRecoveryResolutionRateLimitGate,
+} from "../../../../modules/bank-sessions/manual-recovery-resolution";
+import type { BankSessionExpiryEpisodeRepository } from "../../../../modules/bank-sessions/expiry-episodes";
+import { getPrismaClient } from "../../../../modules/persistence/prisma-client";
+import { PrismaBankSessionExpiryEpisodeRepository } from "../../../../modules/persistence/prisma-bank-session-expiry-episode-repository";
+
+interface ManualRecoveryHandlerDeps {
+  episodes: Pick<BankSessionExpiryEpisodeRepository, "findByBankCode" | "resolveConsumerManualRecovery">;
+  rateLimitGate: ManualRecoveryResolutionRateLimitGate;
+}
+
+const rateLimiter = new InMemoryRateLimiter({ maxAttempts: 10, windowMs: 60_000 });
+const defaultRateLimitGate: ManualRecoveryResolutionRateLimitGate = {
+  async allow(operatorId) {
+    const key = `manual-recovery:${operatorId}`;
+    const result = rateLimiter.check(key);
+    if (result.allowed) rateLimiter.recordFailure(key);
+    return result.allowed;
+  },
+};
+
+function defaultDependencies(): ManualRecoveryHandlerDeps {
+  return {
+    episodes: new PrismaBankSessionExpiryEpisodeRepository(getPrismaClient()),
+    rateLimitGate: defaultRateLimitGate,
+  };
+}
+
+function createManualRecoveryHandler(provided?: ManualRecoveryHandlerDeps) {
+  return async function handleManualRecovery(request: Request): Promise<Response> {
+    const principal = resolvePrincipal(request);
+    try {
+      requireRole(principal, ["admin"]);
+    } catch {
+      return Response.json({ error: principal ? "Forbidden" : "Authentication required" }, { status: principal ? 403 : 401 });
+    }
+
+    const bankCode = new URL(request.url).searchParams.get("bankCode")?.trim();
+    if (!bankCode) return Response.json({ error: "bankCode is required" }, { status: 400 });
+
+    let dependencies: ManualRecoveryHandlerDeps;
+    try {
+      dependencies = provided ?? defaultDependencies();
+      const episode = await dependencies.episodes.findByBankCode(bankCode);
+      const eligible = episode?.consumerAttemptState === "manual_recovery_required"
+        && Boolean(episode.publicationClaimToken?.trim())
+        && Boolean(episode.consumerClaimToken?.trim());
+
+      if (request.method === "GET") return Response.json({ eligible });
+      if (request.method !== "POST") return Response.json({ error: "Method not allowed" }, { status: 405 });
+      if (!eligible || !episode) return Response.json({ error: "No manual recovery is available" }, { status: 409 });
+
+      const body = await readBody(request);
+      const command = await authorizeManualRecoveryResolution({
+        actor: { operatorId: principal!.id, roles: [principal!.role] },
+        decision: body.decision as ManualRecoveryResolutionDecision,
+      }, dependencies.rateLimitGate);
+      const resolution = await dependencies.episodes.resolveConsumerManualRecovery({
+        bankCode: episode.bankCode,
+        expiredEventId: episode.expiredEventId,
+        runId: episode.runId,
+        token: episode.publicationClaimToken!,
+      }, episode.consumerClaimToken!, command);
+
+      return resolution
+        ? Response.json({ status: "resolved" })
+        : Response.json({ error: "No manual recovery is available" }, { status: 409 });
+    } catch (error) {
+      if (error instanceof Error && (error.message === "Manual recovery decision is invalid" || error.message === "Manual recovery resolution rate limited")) {
+        return Response.json({ error: "Invalid manual recovery request" }, { status: 400 });
+      }
+      console.error("[bank-sessions/manual-recovery] request failed", { bankCode, error: error instanceof Error ? error.name : "unknown" });
+      return Response.json({ error: "Manual recovery is unavailable" }, { status: 503 });
+    }
+  };
+}
+
+async function readBody(request: Request): Promise<{ decision?: unknown }> {
+  try {
+    const body: unknown = await request.json();
+    return typeof body === "object" && body !== null && !Array.isArray(body) ? body as { decision?: unknown } : {};
+  } catch {
+    return {};
+  }
+}
+
+export const GET = createManualRecoveryHandler();
+export const POST = createManualRecoveryHandler();

--- a/src/components/admin/bank-auto-login-settings.test.tsx
+++ b/src/components/admin/bank-auto-login-settings.test.tsx
@@ -8,6 +8,8 @@ import {
   fetchCredentialMetadata,
   saveBankCredentials,
   toggleAutoLogin,
+  fetchManualRecoveryEligibility,
+  resolveManualRecovery,
 } from "./bank-auto-login-settings";
 
 describe("BankAutoLoginSettings", () => {
@@ -81,6 +83,17 @@ describe("BankAutoLoginSettings", () => {
     expect(fetchImpl).toHaveBeenCalledWith(
       "/api/bank-credentials/popular/auto-login",
       expect.objectContaining({ method: "PATCH", body: JSON.stringify({ enabled: true }) }),
+    );
+  });
+
+  it("uses the manual recovery endpoint without exposing episode details to the browser", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(new Response(JSON.stringify({ eligible: true }), { status: 200 }));
+
+    await expect(fetchManualRecoveryEligibility("popular", fetchImpl)).resolves.toBe(true);
+    await expect(resolveManualRecovery({ bankCode: "popular", decision: { outcome: "resolved_no_retry", reason: "closed_without_retry" }, fetchImpl })).resolves.toBe(true);
+    expect(fetchImpl).toHaveBeenLastCalledWith(
+      "/api/bank-sessions/manual-recovery?bankCode=popular",
+      expect.objectContaining({ method: "POST", body: JSON.stringify({ decision: { outcome: "resolved_no_retry", reason: "closed_without_retry" } }) }),
     );
   });
 });

--- a/src/components/admin/bank-auto-login-settings.tsx
+++ b/src/components/admin/bank-auto-login-settings.tsx
@@ -7,6 +7,11 @@ import { Button } from "../ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../ui/card";
 import { Input } from "../ui/input";
 
+type ManualRecoveryDecision =
+  | { outcome: "safe_to_retry"; reason: "verified_no_mutation" }
+  | { outcome: "mutation_confirmed"; reason: "verified_mutation" }
+  | { outcome: "resolved_no_retry"; reason: "closed_without_retry" };
+
 const SAFE_FAILURE_MESSAGE = "No se pudo actualizar la configuración. Inténtalo nuevamente.";
 const METADATA_FAILURE_MESSAGE = "No se pudo consultar la configuración. Inténtalo nuevamente.";
 
@@ -47,6 +52,9 @@ export function BankAutoLoginSettings({
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [statusMessage, setStatusMessage] = useState("Cargando configuración…");
+  const [manualRecoveryEligible, setManualRecoveryEligible] = useState(false);
+  const [manualRecoveryDecision, setManualRecoveryDecision] = useState<ManualRecoveryDecision | null>(null);
+  const [isResolvingManualRecovery, setIsResolvingManualRecovery] = useState(false);
 
   useEffect(() => {
     let active = true;
@@ -70,6 +78,14 @@ export function BankAutoLoginSettings({
     return () => {
       active = false;
     };
+  }, [bankCode]);
+
+  useEffect(() => {
+    let active = true;
+    void fetchManualRecoveryEligibility(bankCode, fetch)
+      .then((eligible) => { if (active) setManualRecoveryEligible(eligible); })
+      .catch(() => { if (active) setManualRecoveryEligible(false); });
+    return () => { active = false; };
   }, [bankCode]);
 
   async function handleCredentialsSubmit(event: FormEvent<HTMLFormElement>) {
@@ -120,6 +136,22 @@ export function BankAutoLoginSettings({
       toast.error(SAFE_FAILURE_MESSAGE);
     } finally {
       setIsToggling(false);
+    }
+  }
+
+  async function handleManualRecoveryResolution() {
+    if (!manualRecoveryDecision) return;
+    setIsResolvingManualRecovery(true);
+    try {
+      if (!await resolveManualRecovery({ bankCode, decision: manualRecoveryDecision, fetchImpl: fetch })) throw new Error("resolution request failed");
+      setManualRecoveryEligible(false);
+      setStatusMessage("Recuperación manual resuelta.");
+      toast.success("Recuperación manual resuelta");
+    } catch {
+      setStatusMessage(SAFE_FAILURE_MESSAGE);
+      toast.error(SAFE_FAILURE_MESSAGE);
+    } finally {
+      setIsResolvingManualRecovery(false);
     }
   }
 
@@ -179,6 +211,26 @@ export function BankAutoLoginSettings({
             {isToggling ? "Actualizando…" : autoLoginEnabled ? "Desactivar auto-login" : "Activar auto-login"}
           </Button>
         </div>
+        {manualRecoveryEligible && (
+          <div className="grid gap-3 rounded-lg border border-warning/60 bg-warning/10 p-4">
+            <p className="text-sm font-medium">Se requiere resolver una recuperación manual</p>
+            <select
+              aria-label="Resultado de la recuperación manual"
+              className="h-9 rounded-md border bg-background px-3 text-sm"
+              disabled={isResolvingManualRecovery}
+              value={manualRecoveryDecision?.outcome ?? ""}
+              onChange={(event) => setManualRecoveryDecision(decisionForOutcome(event.target.value))}
+            >
+              <option value="">Seleccione el resultado verificado</option>
+              <option value="safe_to_retry">No hubo cambios; permitir nuevo intento</option>
+              <option value="mutation_confirmed">Cambios confirmados</option>
+              <option value="resolved_no_retry">Cerrar sin nuevo intento</option>
+            </select>
+            <Button type="button" className="w-fit" disabled={!manualRecoveryDecision || isResolvingManualRecovery} onClick={handleManualRecoveryResolution}>
+              {isResolvingManualRecovery ? "Resolviendo…" : "Resolver recuperación manual"}
+            </Button>
+          </div>
+        )}
       </CardContent>
     </Card>
   );
@@ -233,6 +285,33 @@ export async function toggleAutoLogin({
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ enabled }),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+function decisionForOutcome(outcome: string): ManualRecoveryDecision | null {
+  if (outcome === "safe_to_retry") return { outcome, reason: "verified_no_mutation" };
+  if (outcome === "mutation_confirmed") return { outcome, reason: "verified_mutation" };
+  if (outcome === "resolved_no_retry") return { outcome, reason: "closed_without_retry" };
+  return null;
+}
+
+export async function fetchManualRecoveryEligibility(bankCode: string, fetchImpl: typeof fetch): Promise<boolean> {
+  const response = await fetchImpl(`/api/bank-sessions/manual-recovery?bankCode=${encodeURIComponent(bankCode)}`);
+  if (!response.ok) throw new Error("manual recovery status request failed");
+  const body = await response.json() as { eligible?: unknown };
+  return body.eligible === true;
+}
+
+export async function resolveManualRecovery({ bankCode, decision, fetchImpl }: { bankCode: string; decision: ManualRecoveryDecision; fetchImpl: typeof fetch }): Promise<boolean> {
+  try {
+    const response = await fetchImpl(`/api/bank-sessions/manual-recovery?bankCode=${encodeURIComponent(bankCode)}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ decision }),
     });
     return response.ok;
   } catch {


### PR DESCRIPTION
Closes #67

## Summary
- Adds an admin-only eligibility and resolution endpoint for manual-recovery bank-session episodes.
- Adds explicit operator outcome choices to the localized admin UI.
- Resolves episodes with safe compare-and-swap semantics and audit coverage.

## Changes
| File | Change |
| --- | --- |
| `src/app/api/bank-sessions/manual-recovery/route.ts` | Adds the admin-only eligibility and resolution API with safe, audited resolution behavior. |
| `src/app/api/bank-sessions/manual-recovery/route.test.ts` | Covers authorization, eligibility, resolution outcomes, and safe failure responses. |
| `src/components/admin/bank-auto-login-settings.tsx` | Adds localized, explicit operator controls for resolving manual-recovery episodes. |
| `src/components/admin/bank-auto-login-settings.test.tsx` | Covers the admin UI's recovery controls and operator outcome selection. |

## Test Plan
- [x] Focused API tests: 8/8 passed.
- [x] `pnpm test`: 1303 passed, 100 skipped.
- [x] `pnpm lint`: passed.
- [x] `pnpm typecheck`: passed.
- [x] `pnpm build`: passed after the correction.
- [x] `git diff --check`: passed.

## Review Note
Native reliability review found and corrected an invalid App Router runtime export. The corrected build passed.

## Limitation
The focused PostgreSQL contract was not executed because the harness does not verify that `RD_SYNC_TEST_DATABASE_URL` is non-production.

## Checklist
- [x] Linked approved issue.
- [x] Added exactly one `type:*` label (`type:bug`).
- [x] Conventional commit format.
- [x] No `Co-Authored-By` trailer.
- [x] No scripts changed, shellcheck is not applicable.
- [x] No internal diagnostics leaked.