### PR TITLE
test(persistence): enforce migrated expiry contracts

### DIFF
--- a/src/modules/persistence/prisma-contracts.test.ts
+++ b/src/modules/persistence/prisma-contracts.test.ts
@@ -53,6 +53,11 @@ const TEST_DB_URL = process.env.RD_SYNC_TEST_DATABASE_URL;
 const hasTestDb = Boolean(TEST_DB_URL);
 const MAX_POSTGRES_LOCK_WAIT_ATTEMPTS = 100;
 const POSTGRES_CHECK_VIOLATION = "23514";
+const requiredExpiryCheckConstraints = [
+  "BankSessionExpiryEpisode_publicationState_check",
+  "BankSessionExpiryEpisode_consumerAttempt_check",
+  "BankSessionExpiryEpisode_terminalFailure_check",
+] as const;
 const recoveryMigrationPath = fileURLToPath(new URL("../../../prisma/migrations/20260718014500_add_expiry_consumer_recovery_state/migration.sql", import.meta.url));
 const schemaPath = fileURLToPath(new URL("../../../prisma/schema.prisma", import.meta.url));
 const manualRecoveryResolutionMigrationPath = fileURLToPath(new URL("../../../prisma/migrations/20260728120000_add_manual_recovery_resolution_outbox/migration.sql", import.meta.url));
@@ -66,16 +71,24 @@ const terminalFailureMigrationPath = fileURLToPath(new URL("../../../prisma/migr
 
 let prisma: PrismaClient | undefined;
 
+function missingExpiryCheckConstraints(rows: readonly { conname: string }[]): string[] {
+  const present = new Set(rows.map((row) => row.conname));
+  return requiredExpiryCheckConstraints.filter((name) => !present.has(name));
+}
+
 // Capture original so we can restore it after the suite.
 const _originalDatabaseUrl = process.env.DATABASE_URL;
 
 if (hasTestDb) {
-  beforeAll(() => {
+  beforeAll(async () => {
     // Repositories call getPrismaClient() which reads DATABASE_URL.
     // Mirror the test URL there so repositories target the same test DB.
     process.env.DATABASE_URL = TEST_DB_URL!;
     const adapter = new PrismaPg({ connectionString: TEST_DB_URL! });
     prisma = new PrismaClient({ adapter });
+    const constraints = await prisma.$queryRaw<{ conname: string }[]>`SELECT conname FROM pg_constraint WHERE conrelid = '"BankSessionExpiryEpisode"'::regclass AND contype = 'c'`;
+    const missing = missingExpiryCheckConstraints(constraints);
+    if (missing.length > 0) throw new Error(`Missing expiry CHECK constraints: ${missing.join(", ")}; use migrate deploy, not db push`);
   });
 
   afterAll(async () => {
@@ -640,7 +653,7 @@ describe.skipIf(!hasTestDb)("Prisma bank-session expiry episode repository (requ
     await expect(first.reconcileTerminalFailure(envelope, "job_failed", new Date("2026-07-28T13:00:02.000Z"))).resolves.toMatchObject({ status: "already_reconciled" });
     await expect(first.findByBankCode(envelope.bankCode)).resolves.toMatchObject({ terminalFailureReason: "job_failed", terminalFailureReconciledAt: expect.any(Date) });
     const audit = await prisma.auditEvent.findUnique({ where: { id: `bank-session-expiry-terminal:${envelope.bankCode}:${envelope.expiredEventId}:${envelope.runId}` } });
-    expect(audit).toMatchObject({ action: "needs_admin_action", metadata: { bankCode: envelope.bankCode, expiredEventId: envelope.expiredEventId, runId: envelope.runId, reason: "job_failed" } });
+    expect(audit).toMatchObject({ action: "bank_autologin.needs_admin_action", metadata: { bankCode: envelope.bankCode, expiredEventId: envelope.expiredEventId, runId: envelope.runId, reason: "job_failed" } });
     expect(JSON.stringify(audit?.metadata)).not.toContain(envelope.token);
     await expect(prisma.auditEvent.count({ where: { id: audit!.id } })).resolves.toBe(1);
   });


### PR DESCRIPTION
Closes #68

## Summary
- Enforces that PostgreSQL expiry contracts run only against schemas provisioned with `migrate deploy`.
- Updates the terminal audit-action assertion to the canonical production action.

## Diagnosis
1. **Terminal-marker failure:** stale assertion after the canonical audit-action migration. Production correctly stores `bank_autologin.needs_admin_action`, so the test expectation was updated.
2. **Acknowledgement-loss failure:** historical provisioning artifact. The failing database had been created with Prisma `db push`, which omits the three CHECK constraints defined only in migration SQL. On a fresh `migrate deploy` database, the production contract passes unchanged.
3. The suite now verifies these preconditions before contract tests and fails with `use migrate deploy, not db push` when any is absent:
   - `BankSessionExpiryEpisode_publicationState_check`
   - `BankSessionExpiryEpisode_consumerAttempt_check`
   - `BankSessionExpiryEpisode_terminalFailure_check`

## Evidence
- `db push` provisioning: expected precondition failure, naming all three checks.
- `migrate deploy`: 102/102 Prisma contracts pass.
- Full suite: 1392 passed, 2 skipped.
- Build, typecheck, lint, and diff check pass.
- PostgreSQL 16 was local, loopback-only, and disposable. The database and container were removed.

## Changes
| File | Change |
|---|---|
| `src/modules/persistence/prisma-contracts.test.ts` | Adds migration-only CHECK precondition validation and aligns the terminal audit assertion with the canonical action. |

## Checklist
- [x] Linked approved issue
- [x] Added exactly one `type:*` label (`type:chore`)
- [x] No scripts modified, shellcheck N/A
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
- [x] No excluded artifacts included