### PR TITLE
feat(bank-sessions): add durable authentication attempt foundation

### DIFF
--- a/prisma/migrations/20260813170000_add_bank_session_authentication_attempt/migration.sql
+++ b/prisma/migrations/20260813170000_add_bank_session_authentication_attempt/migration.sql
@@ -1,0 +1,24 @@
+BEGIN;
+
+CREATE TABLE "BankSessionAuthenticationAttempt" (
+  "bankCode" TEXT NOT NULL, "runId" TEXT NOT NULL, "attemptId" TEXT NOT NULL,
+  "status" TEXT NOT NULL DEFAULT 'active', "interactionPhase" TEXT NOT NULL DEFAULT 'no_credential_interaction',
+  "failureClass" TEXT, "operatorReason" TEXT, "retryCount" INTEGER NOT NULL DEFAULT 0,
+  "ownerToken" TEXT, "generation" BIGINT NOT NULL DEFAULT 0, "leaseExpiresAt" TIMESTAMP(3),
+  "terminalAt" TIMESTAMP(3), "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "BankSessionAuthenticationAttempt_pkey" PRIMARY KEY ("bankCode", "runId", "attemptId"),
+  CONSTRAINT "BankSessionAuthenticationAttempt_bankCode_runId_key" UNIQUE ("bankCode", "runId"),
+  CONSTRAINT "BankSessionAuthenticationAttempt_bankCode_fkey" FOREIGN KEY ("bankCode") REFERENCES "Bank"("code") ON DELETE RESTRICT ON UPDATE RESTRICT,
+  CONSTRAINT "BankSessionAuthenticationAttempt_identity_check" CHECK ("bankCode" ~ '[^[:space:]]' AND "runId" ~ '[^[:space:]]' AND "attemptId" ~ '[^[:space:]]'),
+  CONSTRAINT "BankSessionAuthenticationAttempt_status_check" CHECK ("status" IN ('active', 'authenticated', 'failed')),
+  CONSTRAINT "BankSessionAuthenticationAttempt_phase_check" CHECK ("interactionPhase" IN ('no_credential_interaction', 'credentials_may_have_reached_portal', 'submit_may_have_been_dispatched')),
+  CONSTRAINT "BankSessionAuthenticationAttempt_retry_check" CHECK ("retryCount" BETWEEN 0 AND 2),
+  CONSTRAINT "BankSessionAuthenticationAttempt_generation_check" CHECK ("generation" >= 0),
+  CONSTRAINT "BankSessionAuthenticationAttempt_owner_check" CHECK (("status" = 'active' AND (("ownerToken" IS NULL AND "leaseExpiresAt" IS NULL) OR ("ownerToken" ~ '[^[:space:]]' AND "leaseExpiresAt" IS NOT NULL))) OR ("status" <> 'active' AND "ownerToken" IS NULL AND "leaseExpiresAt" IS NULL)),
+  CONSTRAINT "BankSessionAuthenticationAttempt_terminal_check" CHECK (("status" = 'active' AND "failureClass" IS NULL AND "operatorReason" IS NULL AND "terminalAt" IS NULL) OR ("status" = 'authenticated' AND "failureClass" IS NULL AND "operatorReason" IS NULL AND "terminalAt" IS NOT NULL) OR ("status" = 'failed' AND (("failureClass" = 'transient_pre_interaction' AND "operatorReason" = 'temporary_authentication_problem') OR ("failureClass" = 'protected_or_mfa' AND "operatorReason" = 'protected_authentication_step_detected') OR ("failureClass" IN ('incompatible_flow', 'structural_configuration') AND "operatorReason" = 'bank_login_configuration_requires_review') OR ("failureClass" IN ('ownership_lost', 'interaction_outcome_uncertain', 'unclassified_failure') AND "operatorReason" = 'authentication_attempt_requires_review')) AND "terminalAt" IS NOT NULL))
+);
+
+CREATE INDEX "BankSessionAuthenticationAttempt_status_leaseExpiresAt_idx" ON "BankSessionAuthenticationAttempt"("status", "leaseExpiresAt");
+
+COMMIT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -99,6 +99,7 @@ model Bank {
   bankCredential     BankCredential?
   autoLoginConfig    BankAutoLoginConfig?
   adapterConfig      BankAdapterConfig?
+  sessionAuthenticationAttempts BankSessionAuthenticationAttempt[]
   createdAt          DateTime              @default(now())
   updatedAt          DateTime              @updatedAt
 }
@@ -186,6 +187,29 @@ model BankSessionExpiryEpisode {
   terminalFailureReconciledAt  DateTime?
   createdAt                    DateTime @default(now())
   updatedAt                    DateTime @updatedAt
+}
+
+// Independent durable login-attempt fencing state.
+model BankSessionAuthenticationAttempt {
+  bankCode         String
+  bank             Bank     @relation(fields: [bankCode], references: [code], onDelete: Restrict, onUpdate: Restrict)
+  runId            String
+  attemptId        String
+  status           String   @default("active")
+  interactionPhase String   @default("no_credential_interaction")
+  failureClass     String?
+  operatorReason   String?
+  retryCount       Int      @default(0)
+  ownerToken       String?
+  generation       BigInt   @default(0)
+  leaseExpiresAt   DateTime?
+  terminalAt       DateTime?
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+
+  @@id([bankCode, runId, attemptId])
+  @@unique([bankCode, runId])
+  @@index([status, leaseExpiresAt])
 }
 
 // Durable resolution evidence survives deletion of its ephemeral expiry episode.

--- a/src/modules/bank-sessions/session-authentication-attempt-repository.test.ts
+++ b/src/modules/bank-sessions/session-authentication-attempt-repository.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseSessionAuthenticationAttemptRecord,
+  type AcquireSessionAuthenticationLeaseResult,
+  type ClaimSessionAuthenticationRetryResult,
+  type CompleteAuthenticatedInput,
+  type CompleteFailedInput,
+  type GetOrCreateSessionAuthenticationAttemptResult,
+  type RecordSessionAuthenticationSubmitBarrierResult,
+  type ReconcileExpiredLeaseInput,
+  type ReconcileExpiredLeaseResult,
+  type SessionAuthenticationAttemptNotAppliedResult,
+  type SessionAuthenticationAttemptRepository,
+  type SessionAuthenticationAttemptRow,
+} from "./session-authentication-attempt-repository";
+
+const base: SessionAuthenticationAttemptRow = {
+  bankCode: "popular", runId: "run-1", attemptId: "attempt-1", status: "active",
+  interactionPhase: "no_credential_interaction", failureClass: null, operatorReason: null,
+  retryCount: 0, ownerToken: null, generation: 0n, leaseExpiresAt: null, terminalAt: null,
+  createdAt: new Date("2026-08-13T00:00:00.000Z"), updatedAt: new Date("2026-08-13T00:00:00.000Z"),
+};
+
+function parse(row: Partial<SessionAuthenticationAttemptRow>) {
+  return parseSessionAuthenticationAttemptRecord({ ...base, ...row });
+}
+
+describe("parseSessionAuthenticationAttemptRecord", () => {
+  it("parses valid active unowned and owned rows", () => {
+    expect(parse({})).toMatchObject({ status: "active", generation: 0n, ownerToken: null });
+    expect(parse({ ownerToken: "owner-1", leaseExpiresAt: new Date("2026-08-13T01:00:00.000Z") }))
+      .toMatchObject({ status: "active", ownerToken: "owner-1" });
+  });
+
+  it("parses authenticated and failed terminal rows while preserving phase", () => {
+    const terminalAt = new Date("2026-08-13T01:00:00.000Z");
+    expect(parse({ status: "authenticated", interactionPhase: "credentials_may_have_reached_portal", terminalAt }))
+      .toMatchObject({ status: "authenticated", interactionPhase: "credentials_may_have_reached_portal" });
+    expect(parse({ status: "failed", interactionPhase: "submit_may_have_been_dispatched", failureClass: "interaction_outcome_uncertain", operatorReason: "authentication_attempt_requires_review", terminalAt }))
+      .toMatchObject({ status: "failed", interactionPhase: "submit_may_have_been_dispatched", failureClass: "interaction_outcome_uncertain" });
+  });
+
+  it.each([
+    ["transient_pre_interaction", "authentication_attempt_requires_review"],
+    ["protected_or_mfa", "temporary_authentication_problem"],
+    ["incompatible_flow", "protected_authentication_step_detected"],
+    ["structural_configuration", "authentication_attempt_requires_review"],
+    ["ownership_lost", "bank_login_configuration_requires_review"],
+    ["interaction_outcome_uncertain", "temporary_authentication_problem"],
+    ["unclassified_failure", "protected_authentication_step_detected"],
+  ])("rejects mismatched failure class and operator reason: %s/%s", (failureClass, operatorReason) => {
+    expect(parse({ status: "failed", failureClass, operatorReason, terminalAt: new Date() })).toBeNull();
+  });
+
+  it.each([
+    { bankCode: " " }, { runId: "" }, { attemptId: "\t" },
+    { status: "unknown" }, { interactionPhase: "unknown" },
+    { status: "failed", failureClass: "unknown", operatorReason: "authentication_attempt_requires_review", terminalAt: new Date() },
+    { status: "failed", failureClass: "unclassified_failure", operatorReason: "unknown", terminalAt: new Date() },
+    { retryCount: -1 }, { retryCount: 3 }, { generation: -1n },
+    { ownerToken: "owner-1" }, { leaseExpiresAt: new Date() },
+    { status: "authenticated", ownerToken: "owner-1", leaseExpiresAt: new Date(), terminalAt: new Date() },
+    { status: "active", terminalAt: new Date() },
+    { status: "authenticated", failureClass: "unclassified_failure", terminalAt: new Date() },
+    { status: "failed", terminalAt: new Date() },
+  ])("rejects invalid durable row %#", (row) => {
+    expect(parse(row)).toBeNull();
+  });
+});
+
+type RepositoryMethods = Pick<SessionAuthenticationAttemptRepository,
+  "getOrCreate" | "findExact" | "acquireLease" | "renewLease" | "beginCredentialInteraction" |
+  "recordSubmitBarrier" | "claimRetry" | "completeAuthenticated" | "completeFailed" | "reconcileExpiredLease">;
+void (null as unknown as RepositoryMethods);
+declare const repository: SessionAuthenticationAttemptRepository;
+if (false) {
+  // @ts-expect-error The generic repository operation is intentionally unavailable.
+  void repository.execute;
+}
+
+const submitBarrierResults: readonly RecordSessionAuthenticationSubmitBarrierResult[] = [
+  { status: "recorded", record: null as unknown as never },
+  { status: "already_recorded", record: null as unknown as never },
+  { status: "invalid_transition" }, { status: "stale_owner" }, { status: "lease_expired" }, { status: "terminal" }, { status: "missing" },
+];
+const retryResults: readonly ClaimSessionAuthenticationRetryResult[] = [
+  { status: "retry_claimed", retryCount: 1, record: null as unknown as never },
+  { status: "retry_claimed", retryCount: 2, record: null as unknown as never },
+  { status: "retry_exhausted" }, { status: "ineligible" }, { status: "stale_owner" }, { status: "lease_expired" }, { status: "terminal" }, { status: "missing" }, { status: "not_applied" },
+];
+const acquireLeaseResults: readonly AcquireSessionAuthenticationLeaseResult[] = [
+  { status: "lease_acquired", owner: { identity: { bankCode: "popular", runId: "run-1", attemptId: "attempt-1" }, ownerToken: "owner-1", generation: 1n }, record: null as unknown as never },
+  { status: "lease_held", record: null as unknown as never },
+  { status: "reconciliation_required", record: null as unknown as never },
+  { status: "terminal", record: null as unknown as never },
+  { status: "missing" },
+  { status: "not_applied" },
+];
+const owner = { identity: { bankCode: "popular", runId: "run-1", attemptId: "attempt-1" }, ownerToken: "owner-1", generation: 1n } as const;
+const completeAuthenticatedInput: CompleteAuthenticatedInput = { owner };
+const completeFailedInput: CompleteFailedInput = { owner, failureClass: "transient_pre_interaction", operatorReason: "temporary_authentication_problem" };
+const reconcileExpiredLeaseInput: ReconcileExpiredLeaseInput = { identity: owner.identity };
+const reconcileExpiredLeaseResults: readonly ReconcileExpiredLeaseResult[] = [
+  { status: "lease_reconciled", record: null as unknown as never },
+  { status: "lease_still_active", record: null as unknown as never },
+  { status: "unowned", record: null as unknown as never },
+  { status: "terminal", record: null as unknown as never },
+  { status: "missing" }, { status: "not_applied" },
+];
+const notApplied: SessionAuthenticationAttemptNotAppliedResult = { status: "not_applied" };
+const getOrCreateResults: readonly GetOrCreateSessionAuthenticationAttemptResult[] = [
+  { status: "created", record: null as unknown as never },
+  { status: "found", record: null as unknown as never },
+  { status: "identity_conflict", existingAttemptId: "other-attempt" },
+];
+if (false) {
+  const conflict: Extract<GetOrCreateSessionAuthenticationAttemptResult, { status: "identity_conflict" }> = {
+    status: "identity_conflict", existingAttemptId: "other-attempt",
+  };
+  // @ts-expect-error An identity conflict is deliberately non-authorizing.
+  void conflict.ownerToken;
+  // @ts-expect-error An identity conflict does not expose the existing aggregate record.
+  void conflict.record;
+  // @ts-expect-error Terminal timestamps come from PostgreSQL.
+  void ({ owner, terminalAt: new Date() } satisfies CompleteAuthenticatedInput);
+  // @ts-expect-error Terminal timestamps come from PostgreSQL.
+  void ({ owner, failureClass: "transient_pre_interaction", operatorReason: "temporary_authentication_problem", terminalAt: new Date() } satisfies CompleteFailedInput);
+  // @ts-expect-error Lease reconciliation time comes from PostgreSQL.
+  void ({ identity: owner.identity, reconciledAt: new Date() } satisfies ReconcileExpiredLeaseInput);
+}
+void [submitBarrierResults, retryResults, acquireLeaseResults, completeAuthenticatedInput, completeFailedInput, reconcileExpiredLeaseInput, reconcileExpiredLeaseResults, notApplied, getOrCreateResults];

--- a/src/modules/bank-sessions/session-authentication-attempt-repository.ts
+++ b/src/modules/bank-sessions/session-authentication-attempt-repository.ts
@@ -1,0 +1,172 @@
+import type {
+  CredentialInteractionPhase,
+  SessionAuthenticationAttemptIdentity,
+  SessionAuthenticationFailureClass,
+  SessionAuthenticationOperatorReason,
+} from "./session-authentication-attempt";
+
+export type SessionAuthenticationAttemptRow = Readonly<{
+  bankCode: unknown; runId: unknown; attemptId: unknown; status: unknown; interactionPhase: unknown;
+  failureClass: unknown; operatorReason: unknown; retryCount: unknown; ownerToken: unknown;
+  generation: unknown; leaseExpiresAt: unknown; terminalAt: unknown; createdAt: unknown; updatedAt: unknown;
+}>;
+
+type RecordFields = Readonly<{
+  identity: SessionAuthenticationAttemptIdentity;
+  interactionPhase: CredentialInteractionPhase;
+  retryCount: number;
+  generation: bigint;
+  createdAt: Date;
+  updatedAt: Date;
+}>;
+
+type ActiveOwnership =
+  | Readonly<{ ownerToken: null; leaseExpiresAt: null }>
+  | Readonly<{ ownerToken: string; leaseExpiresAt: Date }>;
+
+export type SessionAuthenticationFailurePair =
+  | Readonly<{ failureClass: "transient_pre_interaction"; operatorReason: "temporary_authentication_problem" }>
+  | Readonly<{ failureClass: "protected_or_mfa"; operatorReason: "protected_authentication_step_detected" }>
+  | Readonly<{ failureClass: "incompatible_flow" | "structural_configuration"; operatorReason: "bank_login_configuration_requires_review" }>
+  | Readonly<{ failureClass: "ownership_lost" | "interaction_outcome_uncertain" | "unclassified_failure"; operatorReason: "authentication_attempt_requires_review" }>;
+
+export type SessionAuthenticationAttemptRecord =
+  | (RecordFields & ActiveOwnership & Readonly<{ status: "active"; failureClass: null; operatorReason: null; terminalAt: null }>)
+  | (RecordFields & Readonly<{ status: "authenticated"; ownerToken: null; leaseExpiresAt: null; failureClass: null; operatorReason: null; terminalAt: Date }>)
+  | (RecordFields & SessionAuthenticationFailurePair & Readonly<{ status: "failed"; ownerToken: null; leaseExpiresAt: null; terminalAt: Date }>);
+
+export type SessionAuthenticationLeaseOwner = Readonly<{
+  identity: SessionAuthenticationAttemptIdentity;
+  ownerToken: string;
+  generation: bigint;
+}>;
+
+export type GetOrCreateSessionAuthenticationAttemptInput = Readonly<{ identity: SessionAuthenticationAttemptIdentity }>;
+export type FindExactSessionAuthenticationAttemptInput = Readonly<{ identity: SessionAuthenticationAttemptIdentity }>;
+export type AcquireSessionAuthenticationLeaseInput = Readonly<{ identity: SessionAuthenticationAttemptIdentity; ownerToken: string; leaseDurationMs: number }>;
+export type RenewSessionAuthenticationLeaseInput = Readonly<{ owner: SessionAuthenticationLeaseOwner; leaseDurationMs: number }>;
+export type BeginCredentialInteractionInput = Readonly<{ owner: SessionAuthenticationLeaseOwner }>;
+export type RecordSubmitBarrierInput = Readonly<{ owner: SessionAuthenticationLeaseOwner }>;
+export type ClaimRetryInput = Readonly<{ owner: SessionAuthenticationLeaseOwner }>;
+// PostgreSQL is the authoritative clock for terminal and lease timestamps.
+export type CompleteAuthenticatedInput = Readonly<{ owner: SessionAuthenticationLeaseOwner }>;
+export type CompleteFailedInput = Readonly<{ owner: SessionAuthenticationLeaseOwner } & SessionAuthenticationFailurePair>;
+export type ReconcileExpiredLeaseInput = Readonly<{ identity: SessionAuthenticationAttemptIdentity }>;
+
+export type GetOrCreateSessionAuthenticationAttemptResult =
+  | Readonly<{ status: "created"; record: SessionAuthenticationAttemptRecord }>
+  | Readonly<{ status: "found"; record: SessionAuthenticationAttemptRecord }>
+  /** Same bank/run already exists under a different attemptId; fail closed and do not perform bank mutation. */
+  | Readonly<{ status: "identity_conflict"; existingAttemptId: string }>;
+export type FindExactSessionAuthenticationAttemptResult =
+  | Readonly<{ status: "found"; record: SessionAuthenticationAttemptRecord }>
+  | Readonly<{ status: "missing" }>;
+/** No state transition was proven; caller must refetch/re-evaluate and MUST NOT perform bank mutation. */
+export type SessionAuthenticationAttemptNotAppliedResult = Readonly<{ status: "not_applied" }>;
+export type AcquireSessionAuthenticationLeaseResult =
+  | Readonly<{ status: "lease_acquired"; owner: SessionAuthenticationLeaseOwner; record: SessionAuthenticationAttemptRecord }>
+  | Readonly<{ status: "lease_held"; record: SessionAuthenticationAttemptRecord }>
+  /** Lease is expired but ownership/phase must be reconciled; caller must not proceed or perform bank mutation. */
+  | Readonly<{ status: "reconciliation_required"; record: SessionAuthenticationAttemptRecord }>
+  | Readonly<{ status: "terminal"; record: SessionAuthenticationAttemptRecord }>
+  | Readonly<{ status: "missing" }>
+  | SessionAuthenticationAttemptNotAppliedResult;
+export type RenewSessionAuthenticationLeaseResult =
+  | Readonly<{ status: "lease_renewed"; record: SessionAuthenticationAttemptRecord }>
+  | Readonly<{ status: "stale_owner" }>
+  | Readonly<{ status: "lease_expired" }>
+  | Readonly<{ status: "terminal" }>
+  | Readonly<{ status: "missing" }>
+  | SessionAuthenticationAttemptNotAppliedResult;
+export type BeginCredentialInteractionResult =
+  | Readonly<{ status: "interaction_started"; record: SessionAuthenticationAttemptRecord }>
+  | Readonly<{ status: "already_started"; record: SessionAuthenticationAttemptRecord }>
+  | Readonly<{ status: "stale_owner" }>
+  | Readonly<{ status: "lease_expired" }>
+  | Readonly<{ status: "terminal" }>
+  | Readonly<{ status: "missing" }>
+  | SessionAuthenticationAttemptNotAppliedResult;
+/** Only `recorded` authorizes a future credential-submit click. */
+export type RecordSessionAuthenticationSubmitBarrierResult =
+  | Readonly<{ status: "recorded"; record: SessionAuthenticationAttemptRecord }>
+  | Readonly<{ status: "already_recorded"; record: SessionAuthenticationAttemptRecord }>
+  | Readonly<{ status: "invalid_transition" }>
+  | Readonly<{ status: "stale_owner" }>
+  | Readonly<{ status: "lease_expired" }>
+  | Readonly<{ status: "terminal" }>
+  | Readonly<{ status: "missing" }>
+  | SessionAuthenticationAttemptNotAppliedResult;
+export type ClaimSessionAuthenticationRetryResult =
+  | Readonly<{ status: "retry_claimed"; retryCount: 1 | 2; record: SessionAuthenticationAttemptRecord }>
+  | Readonly<{ status: "retry_exhausted" }>
+  | Readonly<{ status: "ineligible" }>
+  | Readonly<{ status: "stale_owner" }>
+  | Readonly<{ status: "lease_expired" }>
+  | Readonly<{ status: "terminal" }>
+  | Readonly<{ status: "missing" }>
+  | SessionAuthenticationAttemptNotAppliedResult;
+export type CompleteAuthenticatedResult =
+  | Readonly<{ status: "authenticated"; record: SessionAuthenticationAttemptRecord }>
+  | Readonly<{ status: "invalid_transition" }>
+  | Readonly<{ status: "stale_owner" }>
+  | Readonly<{ status: "lease_expired" }>
+  | Readonly<{ status: "terminal" }>
+  | Readonly<{ status: "missing" }>
+  | SessionAuthenticationAttemptNotAppliedResult;
+export type CompleteFailedResult =
+  | Readonly<{ status: "failed"; record: SessionAuthenticationAttemptRecord }>
+  | Readonly<{ status: "stale_owner" }>
+  | Readonly<{ status: "lease_expired" }>
+  | Readonly<{ status: "terminal" }>
+  | Readonly<{ status: "missing" }>
+  | SessionAuthenticationAttemptNotAppliedResult;
+export type ReconcileExpiredLeaseResult =
+  | Readonly<{ status: "lease_reconciled"; record: SessionAuthenticationAttemptRecord }>
+  | Readonly<{ status: "lease_still_active"; record: SessionAuthenticationAttemptRecord }>
+  | Readonly<{ status: "unowned"; record: SessionAuthenticationAttemptRecord }>
+  | Readonly<{ status: "terminal"; record: SessionAuthenticationAttemptRecord }>
+  | Readonly<{ status: "missing" }>
+  | SessionAuthenticationAttemptNotAppliedResult;
+
+export interface SessionAuthenticationAttemptRepository {
+  getOrCreate(input: GetOrCreateSessionAuthenticationAttemptInput): Promise<GetOrCreateSessionAuthenticationAttemptResult>;
+  findExact(input: FindExactSessionAuthenticationAttemptInput): Promise<FindExactSessionAuthenticationAttemptResult>;
+  acquireLease(input: AcquireSessionAuthenticationLeaseInput): Promise<AcquireSessionAuthenticationLeaseResult>;
+  renewLease(input: RenewSessionAuthenticationLeaseInput): Promise<RenewSessionAuthenticationLeaseResult>;
+  beginCredentialInteraction(input: BeginCredentialInteractionInput): Promise<BeginCredentialInteractionResult>;
+  recordSubmitBarrier(input: RecordSubmitBarrierInput): Promise<RecordSessionAuthenticationSubmitBarrierResult>;
+  claimRetry(input: ClaimRetryInput): Promise<ClaimSessionAuthenticationRetryResult>;
+  completeAuthenticated(input: CompleteAuthenticatedInput): Promise<CompleteAuthenticatedResult>;
+  completeFailed(input: CompleteFailedInput): Promise<CompleteFailedResult>;
+  reconcileExpiredLease(input: ReconcileExpiredLeaseInput): Promise<ReconcileExpiredLeaseResult>;
+}
+
+const phases: readonly CredentialInteractionPhase[] = ["no_credential_interaction", "credentials_may_have_reached_portal", "submit_may_have_been_dispatched"];
+const failureClasses: readonly SessionAuthenticationFailureClass[] = ["transient_pre_interaction", "protected_or_mfa", "incompatible_flow", "structural_configuration", "ownership_lost", "interaction_outcome_uncertain", "unclassified_failure"];
+const operatorReasons: readonly SessionAuthenticationOperatorReason[] = ["temporary_authentication_problem", "protected_authentication_step_detected", "bank_login_configuration_requires_review", "authentication_attempt_requires_review"];
+
+export function parseSessionAuthenticationAttemptRecord(row: SessionAuthenticationAttemptRow): SessionAuthenticationAttemptRecord | null {
+  if (![row.bankCode, row.runId, row.attemptId].every(isNonblankString) || !phases.includes(row.interactionPhase as CredentialInteractionPhase)
+    || !Number.isInteger(row.retryCount) || (row.retryCount as number) < 0 || (row.retryCount as number) > 2
+    || typeof row.generation !== "bigint" || row.generation < 0n || !isDate(row.createdAt) || !isDate(row.updatedAt)) return null;
+  const fields: RecordFields = { identity: { bankCode: row.bankCode as string, runId: row.runId as string, attemptId: row.attemptId as string }, interactionPhase: row.interactionPhase as CredentialInteractionPhase, retryCount: row.retryCount as number, generation: row.generation, createdAt: row.createdAt, updatedAt: row.updatedAt };
+  if (row.status === "active" && row.failureClass === null && row.operatorReason === null && row.terminalAt === null) {
+    if (row.ownerToken === null && row.leaseExpiresAt === null) return { ...fields, status: "active", ownerToken: null, leaseExpiresAt: null, failureClass: null, operatorReason: null, terminalAt: null };
+    if (isNonblankString(row.ownerToken) && isDate(row.leaseExpiresAt)) return { ...fields, status: "active", ownerToken: row.ownerToken, leaseExpiresAt: row.leaseExpiresAt, failureClass: null, operatorReason: null, terminalAt: null };
+  }
+  if (row.status === "authenticated" && row.ownerToken === null && row.leaseExpiresAt === null && row.failureClass === null && row.operatorReason === null && isDate(row.terminalAt)) return { ...fields, status: "authenticated", ownerToken: null, leaseExpiresAt: null, failureClass: null, operatorReason: null, terminalAt: row.terminalAt };
+  const failurePair = parseFailurePair(row.failureClass, row.operatorReason);
+  if (row.status === "failed" && row.ownerToken === null && row.leaseExpiresAt === null && failurePair && isDate(row.terminalAt)) return { ...fields, status: "failed", ownerToken: null, leaseExpiresAt: null, ...failurePair, terminalAt: row.terminalAt };
+  return null;
+}
+
+function isNonblankString(value: unknown): value is string { return typeof value === "string" && /\S/.test(value); }
+function isDate(value: unknown): value is Date { return value instanceof Date && !Number.isNaN(value.getTime()); }
+function parseFailurePair(failureClass: unknown, operatorReason: unknown): SessionAuthenticationFailurePair | null {
+  if (!failureClasses.includes(failureClass as SessionAuthenticationFailureClass) || !operatorReasons.includes(operatorReason as SessionAuthenticationOperatorReason)) return null;
+  if (failureClass === "transient_pre_interaction" && operatorReason === "temporary_authentication_problem") return { failureClass, operatorReason };
+  if (failureClass === "protected_or_mfa" && operatorReason === "protected_authentication_step_detected") return { failureClass, operatorReason };
+  if ((failureClass === "incompatible_flow" || failureClass === "structural_configuration") && operatorReason === "bank_login_configuration_requires_review") return { failureClass, operatorReason };
+  if ((failureClass === "ownership_lost" || failureClass === "interaction_outcome_uncertain" || failureClass === "unclassified_failure") && operatorReason === "authentication_attempt_requires_review") return { failureClass, operatorReason };
+  return null;
+}

--- a/src/modules/bank-sessions/session-authentication-attempt.test.ts
+++ b/src/modules/bank-sessions/session-authentication-attempt.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifySessionAuthenticationFailure,
+  createSessionAuthenticationAttempt,
+  deriveSessionAuthenticationRetryDisposition,
+  MAX_SESSION_AUTHENTICATION_RETRIES,
+  transitionSessionAuthenticationAttempt,
+  type CredentialInteractionPhase,
+  type SessionAuthenticationAttempt,
+  type SessionAuthenticationFailureCause,
+} from "./session-authentication-attempt";
+
+const identity = { bankCode: "popular", runId: "run-1", attemptId: "attempt-1" };
+const phases: readonly CredentialInteractionPhase[] = [
+  "no_credential_interaction",
+  "credentials_may_have_reached_portal",
+  "submit_may_have_been_dispatched",
+];
+
+function attemptAt(phase: CredentialInteractionPhase): SessionAuthenticationAttempt {
+  let attempt: SessionAuthenticationAttempt = createSessionAuthenticationAttempt(identity);
+  if (phase !== "no_credential_interaction") {
+    attempt = transitionSessionAuthenticationAttempt(attempt, { type: "begin_credential_interaction" });
+  }
+  if (phase === "submit_may_have_been_dispatched") {
+    attempt = transitionSessionAuthenticationAttempt(attempt, { type: "record_submit_barrier" });
+  }
+  return attempt;
+}
+
+function failAttemptAt(
+  phase: CredentialInteractionPhase,
+  cause: SessionAuthenticationFailureCause,
+): Extract<SessionAuthenticationAttempt, { status: "failed" }> {
+  const attempt = transitionSessionAuthenticationAttempt(attemptAt(phase), { type: "fail", cause });
+  if (attempt.status !== "failed") throw new Error("Expected failed session authentication attempt");
+  return attempt;
+}
+
+function retryDisposition(
+  attempt: Exclude<SessionAuthenticationAttempt, { status: "active" }>,
+  retriesConsumed = 0,
+) {
+  return deriveSessionAuthenticationRetryDisposition(attempt, {
+    retriesConsumed,
+    maxAdditionalRetries: MAX_SESSION_AUTHENTICATION_RETRIES,
+  });
+}
+
+describe("session authentication attempt", () => {
+  it("creates an active attempt with its identity and no credential interaction", () => {
+    expect(createSessionAuthenticationAttempt(identity)).toEqual({
+      status: "active",
+      identity,
+      interactionPhase: "no_credential_interaction",
+    });
+  });
+
+  it("authenticates an already-valid session without advancing interaction", () => {
+    expect(transitionSessionAuthenticationAttempt(attemptAt("no_credential_interaction"), { type: "confirm_authenticated" }))
+      .toMatchObject({ status: "authenticated", interactionPhase: "no_credential_interaction" });
+  });
+
+  it("records the credential interaction boundary", () => {
+    expect(transitionSessionAuthenticationAttempt(attemptAt("no_credential_interaction"), { type: "begin_credential_interaction" }))
+      .toMatchObject({ status: "active", interactionPhase: "credentials_may_have_reached_portal" });
+  });
+
+  it("rejects a submit barrier before credential interaction", () => {
+    expect(() => transitionSessionAuthenticationAttempt(attemptAt("no_credential_interaction"), { type: "record_submit_barrier" }))
+      .toThrow("Invalid session authentication attempt transition");
+  });
+
+  it("records the submit barrier after credential interaction", () => {
+    expect(transitionSessionAuthenticationAttempt(attemptAt("credentials_may_have_reached_portal"), { type: "record_submit_barrier" }))
+      .toMatchObject({ status: "active", interactionPhase: "submit_may_have_been_dispatched" });
+  });
+
+  it("rejects repeated interaction boundary events", () => {
+    expect(() => transitionSessionAuthenticationAttempt(attemptAt("credentials_may_have_reached_portal"), { type: "begin_credential_interaction" }))
+      .toThrow("Invalid session authentication attempt transition");
+    expect(() => transitionSessionAuthenticationAttempt(attemptAt("submit_may_have_been_dispatched"), { type: "record_submit_barrier" }))
+      .toThrow("Invalid session authentication attempt transition");
+  });
+
+  it.each(phases)("preserves %s when authentication succeeds", (phase) => {
+    expect(transitionSessionAuthenticationAttempt(attemptAt(phase), { type: "confirm_authenticated" }))
+      .toMatchObject({ status: "authenticated", interactionPhase: phase });
+  });
+
+  it.each(phases)("preserves %s when failure occurs", (phase) => {
+    expect(transitionSessionAuthenticationAttempt(attemptAt(phase), { type: "fail", cause: "unknown_failure" }))
+      .toMatchObject({ status: "failed", interactionPhase: phase });
+  });
+
+  it.each([0, 1] as const)("retries transient pre-interaction failure with %i of 2 slots consumed", (retriesConsumed) => {
+    const failed = failAttemptAt("no_credential_interaction", "transient_infrastructure");
+    expect(retryDisposition(failed, retriesConsumed)).toBe("retry_automatically");
+  });
+
+  it("does not retry when both automatic retry slots are consumed", () => {
+    const failed = failAttemptAt("no_credential_interaction", "transient_infrastructure");
+    expect(retryDisposition(failed, 2)).toBe("do_not_retry");
+  });
+
+  it("does not retry a correct class in the wrong interaction phase", () => {
+    const failed = {
+      ...failAttemptAt("no_credential_interaction", "transient_infrastructure"),
+      interactionPhase: "credentials_may_have_reached_portal" as const,
+    };
+    expect(retryDisposition(failed)).toBe("do_not_retry");
+  });
+
+  it("does not retry a correct phase with the wrong failure class", () => {
+    const failed = {
+      ...failAttemptAt("no_credential_interaction", "transient_infrastructure"),
+      failureClass: "unclassified_failure" as const,
+    };
+    expect(retryDisposition(failed)).toBe("do_not_retry");
+  });
+
+  it.each([
+    { retriesConsumed: -1, maxAdditionalRetries: 2 },
+    { retriesConsumed: 0.5, maxAdditionalRetries: 2 },
+    { retriesConsumed: 3, maxAdditionalRetries: 2 },
+    { retriesConsumed: 0, maxAdditionalRetries: 1 },
+    { retriesConsumed: 0, maxAdditionalRetries: 3 },
+  ])("fails closed for malformed retry budget %#", (budget) => {
+    const failed = failAttemptAt("no_credential_interaction", "transient_infrastructure");
+    expect(deriveSessionAuthenticationRetryDisposition(failed, budget as never)).toBe("do_not_retry");
+  });
+
+  it.each(["credentials_may_have_reached_portal", "submit_may_have_been_dispatched"] as const)(
+    "classifies transient failure after %s as uncertain and non-retryable",
+    (phase) => {
+      const failed = failAttemptAt(phase, "transient_infrastructure");
+      expect(failed).toMatchObject({ failureClass: "interaction_outcome_uncertain" });
+      expect(retryDisposition(failed)).toBe("do_not_retry");
+    },
+  );
+
+  it.each(phases)("never retries protected or MFA failure at %s", (phase) => {
+    const failed = failAttemptAt(phase, "protected_or_mfa_detected");
+    expect(retryDisposition(failed)).toBe("do_not_retry");
+  });
+
+  it.each(phases)("never retries incompatible flow failure at %s", (phase) => {
+    const failed = failAttemptAt(phase, "incompatible_flow_detected");
+    expect(retryDisposition(failed)).toBe("do_not_retry");
+  });
+
+  it.each(["structural_configuration_error", "ownership_lost", "unknown_failure"] as const)(
+    "does not retry %s",
+    (cause) => {
+      const failed = failAttemptAt("no_credential_interaction", cause);
+      expect(retryDisposition(failed)).toBe("do_not_retry");
+    },
+  );
+
+  it.each([
+    { type: "begin_credential_interaction" },
+    { type: "record_submit_barrier" },
+    { type: "confirm_authenticated" },
+    { type: "fail", cause: "unknown_failure" },
+  ] as const)("rejects $type from every terminal outcome", (event) => {
+    const authenticated = transitionSessionAuthenticationAttempt(attemptAt("no_credential_interaction"), { type: "confirm_authenticated" });
+    const failed = transitionSessionAuthenticationAttempt(attemptAt("no_credential_interaction"), { type: "fail", cause: "unknown_failure" });
+    for (const terminal of [authenticated, failed]) {
+      expect(() => transitionSessionAuthenticationAttempt(terminal, event))
+        .toThrow("Invalid session authentication attempt transition");
+    }
+  });
+
+  it.each(phases)("preserves attempt identity through a terminal transition from %s", (phase) => {
+    expect(transitionSessionAuthenticationAttempt(attemptAt(phase), { type: "confirm_authenticated" }))
+      .toMatchObject({ identity });
+  });
+
+  it.each([
+    ["no_credential_interaction", "transient_infrastructure", "transient_pre_interaction", "temporary_authentication_problem"],
+    ["credentials_may_have_reached_portal", "transient_infrastructure", "interaction_outcome_uncertain", "authentication_attempt_requires_review"],
+    ["no_credential_interaction", "protected_or_mfa_detected", "protected_or_mfa", "protected_authentication_step_detected"],
+    ["no_credential_interaction", "incompatible_flow_detected", "incompatible_flow", "bank_login_configuration_requires_review"],
+    ["no_credential_interaction", "structural_configuration_error", "structural_configuration", "bank_login_configuration_requires_review"],
+    ["no_credential_interaction", "ownership_lost", "ownership_lost", "authentication_attempt_requires_review"],
+    ["no_credential_interaction", "unknown_failure", "unclassified_failure", "authentication_attempt_requires_review"],
+  ] as const)("maps %s and %s to the exact safe classification", (phase, cause, failureClass, operatorReason) => {
+    expect(classifySessionAuthenticationFailure(phase, cause as SessionAuthenticationFailureCause))
+      .toEqual({ failureClass, operatorReason });
+  });
+});

--- a/src/modules/bank-sessions/session-authentication-attempt.ts
+++ b/src/modules/bank-sessions/session-authentication-attempt.ts
@@ -1,0 +1,165 @@
+export type SessionAuthenticationAttemptIdentity = Readonly<{
+  bankCode: string;
+  runId: string;
+  attemptId: string;
+}>;
+
+export type CredentialInteractionPhase =
+  | "no_credential_interaction"
+  | "credentials_may_have_reached_portal"
+  | "submit_may_have_been_dispatched";
+
+export type SessionAuthenticationFailureCause =
+  | "transient_infrastructure"
+  | "protected_or_mfa_detected"
+  | "incompatible_flow_detected"
+  | "structural_configuration_error"
+  | "ownership_lost"
+  | "unknown_failure";
+
+export type SessionAuthenticationFailureClass =
+  | "transient_pre_interaction"
+  | "protected_or_mfa"
+  | "incompatible_flow"
+  | "structural_configuration"
+  | "ownership_lost"
+  | "interaction_outcome_uncertain"
+  | "unclassified_failure";
+
+export type SessionAuthenticationOperatorReason =
+  | "temporary_authentication_problem"
+  | "protected_authentication_step_detected"
+  | "bank_login_configuration_requires_review"
+  | "authentication_attempt_requires_review";
+
+export type SessionAuthenticationAttempt =
+  | Readonly<{
+      status: "active";
+      identity: SessionAuthenticationAttemptIdentity;
+      interactionPhase: CredentialInteractionPhase;
+    }>
+  | Readonly<{
+      status: "authenticated";
+      identity: SessionAuthenticationAttemptIdentity;
+      interactionPhase: CredentialInteractionPhase;
+    }>
+  | Readonly<{
+      status: "failed";
+      identity: SessionAuthenticationAttemptIdentity;
+      interactionPhase: CredentialInteractionPhase;
+      failureClass: SessionAuthenticationFailureClass;
+      operatorReason: SessionAuthenticationOperatorReason;
+    }>;
+
+export type SessionAuthenticationEvent =
+  | Readonly<{ type: "begin_credential_interaction" }>
+  | Readonly<{ type: "record_submit_barrier" }>
+  | Readonly<{ type: "confirm_authenticated" }>
+  | Readonly<{ type: "fail"; cause: SessionAuthenticationFailureCause }>;
+
+export type SessionAuthenticationRetryDisposition =
+  | "retry_automatically"
+  | "do_not_retry";
+
+export const MAX_SESSION_AUTHENTICATION_RETRIES = 2 as const;
+
+export type SessionAuthenticationRetryBudget = Readonly<{
+  retriesConsumed: number;
+  maxAdditionalRetries: typeof MAX_SESSION_AUTHENTICATION_RETRIES;
+}>;
+
+const INVALID_TRANSITION_ERROR = "Invalid session authentication attempt transition";
+
+export function createSessionAuthenticationAttempt(
+  identity: SessionAuthenticationAttemptIdentity,
+): Extract<SessionAuthenticationAttempt, { status: "active" }> {
+  return {
+    status: "active",
+    identity,
+    interactionPhase: "no_credential_interaction",
+  };
+}
+
+export function transitionSessionAuthenticationAttempt(
+  attempt: SessionAuthenticationAttempt,
+  event: SessionAuthenticationEvent,
+): SessionAuthenticationAttempt {
+  if (attempt.status !== "active") throw new Error(INVALID_TRANSITION_ERROR);
+
+  switch (event.type) {
+    case "begin_credential_interaction":
+      if (attempt.interactionPhase !== "no_credential_interaction") throw new Error(INVALID_TRANSITION_ERROR);
+      return { ...attempt, interactionPhase: "credentials_may_have_reached_portal" };
+    case "record_submit_barrier":
+      if (attempt.interactionPhase !== "credentials_may_have_reached_portal") throw new Error(INVALID_TRANSITION_ERROR);
+      return { ...attempt, interactionPhase: "submit_may_have_been_dispatched" };
+    case "confirm_authenticated":
+      return {
+        status: "authenticated",
+        identity: attempt.identity,
+        interactionPhase: attempt.interactionPhase,
+      };
+    case "fail": {
+      const classification = classifySessionAuthenticationFailure(attempt.interactionPhase, event.cause);
+      return {
+        status: "failed",
+        identity: attempt.identity,
+        interactionPhase: attempt.interactionPhase,
+        ...classification,
+      };
+    }
+  }
+}
+
+export function classifySessionAuthenticationFailure(
+  interactionPhase: CredentialInteractionPhase,
+  cause: SessionAuthenticationFailureCause,
+): Readonly<{
+  failureClass: SessionAuthenticationFailureClass;
+  operatorReason: SessionAuthenticationOperatorReason;
+}> {
+  if (cause === "transient_infrastructure") {
+    return interactionPhase === "no_credential_interaction"
+      ? { failureClass: "transient_pre_interaction", operatorReason: "temporary_authentication_problem" }
+      : { failureClass: "interaction_outcome_uncertain", operatorReason: "authentication_attempt_requires_review" };
+  }
+
+  switch (cause) {
+    case "protected_or_mfa_detected":
+      return { failureClass: "protected_or_mfa", operatorReason: "protected_authentication_step_detected" };
+    case "incompatible_flow_detected":
+      return { failureClass: "incompatible_flow", operatorReason: "bank_login_configuration_requires_review" };
+    case "structural_configuration_error":
+      return { failureClass: "structural_configuration", operatorReason: "bank_login_configuration_requires_review" };
+    case "ownership_lost":
+      return { failureClass: "ownership_lost", operatorReason: "authentication_attempt_requires_review" };
+    case "unknown_failure":
+      return { failureClass: "unclassified_failure", operatorReason: "authentication_attempt_requires_review" };
+  }
+}
+
+/**
+ * Automatic retry is bounded to two slots, which callers must durably claim.
+ * After credential interaction begins, portal-observable events or partial
+ * mutation make even transient failures non-retryable; this never authorizes
+ * an unbounded retry loop.
+ */
+export function deriveSessionAuthenticationRetryDisposition(
+  attempt: Exclude<SessionAuthenticationAttempt, { status: "active" }>,
+  budget: SessionAuthenticationRetryBudget,
+): SessionAuthenticationRetryDisposition {
+  return isValidSessionAuthenticationRetryBudget(budget)
+    && attempt.status === "failed"
+    && attempt.interactionPhase === "no_credential_interaction"
+    && attempt.failureClass === "transient_pre_interaction"
+    && budget.retriesConsumed < budget.maxAdditionalRetries
+    ? "retry_automatically"
+    : "do_not_retry";
+}
+
+function isValidSessionAuthenticationRetryBudget(budget: SessionAuthenticationRetryBudget): boolean {
+  return Number.isInteger(budget.retriesConsumed)
+    && budget.retriesConsumed >= 0
+    && budget.maxAdditionalRetries === MAX_SESSION_AUTHENTICATION_RETRIES
+    && budget.retriesConsumed <= budget.maxAdditionalRetries;
+}

--- a/src/modules/persistence/prisma-bank-session-authentication-attempt-repository.ts
+++ b/src/modules/persistence/prisma-bank-session-authentication-attempt-repository.ts
@@ -1,0 +1,174 @@
+import type { PrismaClient } from "../../generated/prisma/client";
+import {
+  parseSessionAuthenticationAttemptRecord,
+  type AcquireSessionAuthenticationLeaseInput,
+  type AcquireSessionAuthenticationLeaseResult,
+  type BeginCredentialInteractionInput,
+  type BeginCredentialInteractionResult,
+  type ClaimRetryInput,
+  type ClaimSessionAuthenticationRetryResult,
+  type CompleteAuthenticatedInput,
+  type CompleteAuthenticatedResult,
+  type CompleteFailedInput,
+  type CompleteFailedResult,
+  type FindExactSessionAuthenticationAttemptInput,
+  type FindExactSessionAuthenticationAttemptResult,
+  type GetOrCreateSessionAuthenticationAttemptInput,
+  type GetOrCreateSessionAuthenticationAttemptResult,
+  type RecordSessionAuthenticationSubmitBarrierResult,
+  type RecordSubmitBarrierInput,
+  type ReconcileExpiredLeaseInput,
+  type ReconcileExpiredLeaseResult,
+  type RenewSessionAuthenticationLeaseInput,
+  type RenewSessionAuthenticationLeaseResult,
+  type SessionAuthenticationAttemptRecord,
+  type SessionAuthenticationAttemptRepository,
+} from "../bank-sessions/session-authentication-attempt-repository";
+
+type Row = {
+  bankCode: unknown; runId: unknown; attemptId: unknown; status: unknown; interactionPhase: unknown;
+  failureClass: unknown; operatorReason: unknown; retryCount: unknown; ownerToken: unknown;
+  generation: unknown; leaseExpiresAt: unknown; terminalAt: unknown; createdAt: unknown; updatedAt: unknown;
+};
+
+function record(row: Row): SessionAuthenticationAttemptRecord {
+  const parsed = parseSessionAuthenticationAttemptRecord(row);
+  if (!parsed) throw new Error("Invalid durable session authentication attempt record");
+  return parsed;
+}
+
+function assertLease(ownerToken: string, duration: number): void {
+  if (!ownerToken.trim()) throw new Error("Session authentication owner token must be nonblank");
+  if (!Number.isFinite(duration) || duration <= 0) throw new Error("Session authentication lease duration must be positive and finite");
+}
+
+function sameOwner(current: SessionAuthenticationAttemptRecord, owner: { ownerToken: string; generation: bigint }): boolean {
+  return current.status === "active" && current.ownerToken === owner.ownerToken && current.generation === owner.generation;
+}
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null;
+}
+
+function isUniqueViolation(error: unknown): boolean {
+  if (!isRecord(error)) return false;
+  if (error.code === "23505") return true;
+  if (!isRecord(error.meta)) return false;
+  if (error.meta.code === "23505") return true;
+  if (!isRecord(error.meta.driverAdapterError)) return false;
+  // Prisma 7 raw queries wrap PostgreSQL 23505 as P2010 and preserve the SQLSTATE only in the driver-adapter cause.
+  const cause = error.meta.driverAdapterError.cause;
+  return isRecord(cause) && cause.kind === "UniqueConstraintViolation" && cause.originalCode === "23505";
+}
+
+export class PrismaBankSessionAuthenticationAttemptRepository implements SessionAuthenticationAttemptRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  private async find(input: { identity: { bankCode: string; runId: string; attemptId: string } }): Promise<SessionAuthenticationAttemptRecord | null> {
+    const { identity } = input;
+    const rows = await this.prisma.$queryRaw<Row[]>`SELECT "bankCode", "runId", "attemptId", "status", "interactionPhase", "failureClass", "operatorReason", "retryCount", "ownerToken", "generation", "leaseExpiresAt", "terminalAt", "createdAt", "updatedAt" FROM "BankSessionAuthenticationAttempt" WHERE "bankCode" = ${identity.bankCode} AND "runId" = ${identity.runId} AND "attemptId" = ${identity.attemptId}`;
+    return rows[0] ? record(rows[0]) : null;
+  }
+
+  private async findByBankRun(identity: { bankCode: string; runId: string }): Promise<SessionAuthenticationAttemptRecord | null> {
+    const rows = await this.prisma.$queryRaw<Row[]>`SELECT "bankCode", "runId", "attemptId", "status", "interactionPhase", "failureClass", "operatorReason", "retryCount", "ownerToken", "generation", "leaseExpiresAt", "terminalAt", "createdAt", "updatedAt" FROM "BankSessionAuthenticationAttempt" WHERE "bankCode" = ${identity.bankCode} AND "runId" = ${identity.runId}`;
+    return rows[0] ? record(rows[0]) : null;
+  }
+
+  private async ownerState(owner: { identity: { bankCode: string; runId: string; attemptId: string }; ownerToken: string; generation: bigint }) {
+    const rows = await this.prisma.$queryRaw<Array<Row & { leaseActive: boolean }>>`SELECT "bankCode", "runId", "attemptId", "status", "interactionPhase", "failureClass", "operatorReason", "retryCount", "ownerToken", "generation", "leaseExpiresAt", "terminalAt", "createdAt", "updatedAt", COALESCE("leaseExpiresAt" > NOW(), FALSE) AS "leaseActive" FROM "BankSessionAuthenticationAttempt" WHERE "bankCode" = ${owner.identity.bankCode} AND "runId" = ${owner.identity.runId} AND "attemptId" = ${owner.identity.attemptId}`;
+    const row = rows[0];
+    if (!row) return { status: "missing" } as const;
+    const current = record(row);
+    if (current.status !== "active") return { status: "terminal" } as const;
+    if (!sameOwner(current, owner)) return { status: "stale_owner" } as const;
+    if (!row.leaseActive) return { status: "lease_expired" } as const;
+    return { status: "current", record: current } as const;
+  }
+
+  async getOrCreate({ identity }: GetOrCreateSessionAuthenticationAttemptInput): Promise<GetOrCreateSessionAuthenticationAttemptResult> {
+    let inserted: Row[] = [];
+    try {
+      inserted = await this.prisma.$queryRaw<Row[]>`INSERT INTO "BankSessionAuthenticationAttempt" ("bankCode", "runId", "attemptId", "updatedAt") VALUES (${identity.bankCode}, ${identity.runId}, ${identity.attemptId}, NOW()) RETURNING "bankCode", "runId", "attemptId", "status", "interactionPhase", "failureClass", "operatorReason", "retryCount", "ownerToken", "generation", "leaseExpiresAt", "terminalAt", "createdAt", "updatedAt"`;
+    } catch (error) {
+      if (!isUniqueViolation(error)) throw error;
+    }
+    if (inserted[0]) return { status: "created", record: record(inserted[0]) };
+    const existing = await this.findByBankRun(identity);
+    if (!existing) throw new Error("Session authentication attempt unavailable after insert conflict");
+    return existing.identity.attemptId === identity.attemptId
+      ? { status: "found", record: existing }
+      : { status: "identity_conflict", existingAttemptId: existing.identity.attemptId };
+  }
+
+  async findExact({ identity }: FindExactSessionAuthenticationAttemptInput): Promise<FindExactSessionAuthenticationAttemptResult> {
+    const current = await this.find({ identity });
+    return current ? { status: "found", record: current } : { status: "missing" };
+  }
+
+  async acquireLease({ identity, ownerToken, leaseDurationMs }: AcquireSessionAuthenticationLeaseInput): Promise<AcquireSessionAuthenticationLeaseResult> {
+    assertLease(ownerToken, leaseDurationMs);
+    const rows = await this.prisma.$queryRaw<Row[]>`UPDATE "BankSessionAuthenticationAttempt" SET "ownerToken" = ${ownerToken}, "generation" = "generation" + 1, "leaseExpiresAt" = NOW() + (${leaseDurationMs} * INTERVAL '1 millisecond'), "updatedAt" = NOW() WHERE "bankCode" = ${identity.bankCode} AND "runId" = ${identity.runId} AND "attemptId" = ${identity.attemptId} AND "status" = 'active' AND "ownerToken" IS NULL AND "leaseExpiresAt" IS NULL RETURNING "bankCode", "runId", "attemptId", "status", "interactionPhase", "failureClass", "operatorReason", "retryCount", "ownerToken", "generation", "leaseExpiresAt", "terminalAt", "createdAt", "updatedAt"`;
+    if (rows[0]) { const current = record(rows[0]); return { status: "lease_acquired", owner: { identity, ownerToken, generation: current.generation }, record: current }; }
+    const diagnostics = await this.prisma.$queryRaw<Array<Row & { leaseActive: boolean }>>`SELECT "bankCode", "runId", "attemptId", "status", "interactionPhase", "failureClass", "operatorReason", "retryCount", "ownerToken", "generation", "leaseExpiresAt", "terminalAt", "createdAt", "updatedAt", COALESCE("leaseExpiresAt" > NOW(), FALSE) AS "leaseActive" FROM "BankSessionAuthenticationAttempt" WHERE "bankCode" = ${identity.bankCode} AND "runId" = ${identity.runId} AND "attemptId" = ${identity.attemptId}`;
+    const current = diagnostics[0];
+    if (!current) return { status: "missing" };
+    const parsed = record(current);
+    if (parsed.status !== "active") return { status: "terminal", record: parsed };
+    if (parsed.ownerToken === null) return { status: "not_applied" };
+    return current.leaseActive ? { status: "lease_held", record: parsed } : { status: "reconciliation_required", record: parsed };
+  }
+
+  async renewLease({ owner, leaseDurationMs }: RenewSessionAuthenticationLeaseInput): Promise<RenewSessionAuthenticationLeaseResult> {
+    assertLease(owner.ownerToken, leaseDurationMs);
+    const rows = await this.prisma.$queryRaw<Row[]>`UPDATE "BankSessionAuthenticationAttempt" SET "leaseExpiresAt" = NOW() + (${leaseDurationMs} * INTERVAL '1 millisecond'), "updatedAt" = NOW() WHERE "bankCode" = ${owner.identity.bankCode} AND "runId" = ${owner.identity.runId} AND "attemptId" = ${owner.identity.attemptId} AND "status" = 'active' AND "ownerToken" = ${owner.ownerToken} AND "generation" = ${owner.generation} AND "leaseExpiresAt" > NOW() RETURNING "bankCode", "runId", "attemptId", "status", "interactionPhase", "failureClass", "operatorReason", "retryCount", "ownerToken", "generation", "leaseExpiresAt", "terminalAt", "createdAt", "updatedAt"`;
+    if (rows[0]) return { status: "lease_renewed", record: record(rows[0]) };
+    const state = await this.ownerState(owner); return state.status === "current" ? { status: "not_applied" } : state;
+  }
+
+  async beginCredentialInteraction({ owner }: BeginCredentialInteractionInput): Promise<BeginCredentialInteractionResult> {
+    const rows = await this.prisma.$queryRaw<Row[]>`UPDATE "BankSessionAuthenticationAttempt" SET "interactionPhase" = 'credentials_may_have_reached_portal', "updatedAt" = NOW() WHERE "bankCode" = ${owner.identity.bankCode} AND "runId" = ${owner.identity.runId} AND "attemptId" = ${owner.identity.attemptId} AND "status" = 'active' AND "ownerToken" = ${owner.ownerToken} AND "generation" = ${owner.generation} AND "leaseExpiresAt" > NOW() AND "interactionPhase" = 'no_credential_interaction' RETURNING "bankCode", "runId", "attemptId", "status", "interactionPhase", "failureClass", "operatorReason", "retryCount", "ownerToken", "generation", "leaseExpiresAt", "terminalAt", "createdAt", "updatedAt"`;
+    if (rows[0]) return { status: "interaction_started", record: record(rows[0]) };
+    const state = await this.ownerState(owner); return state.status === "current" ? { status: "already_started", record: state.record } : state;
+  }
+
+  async recordSubmitBarrier({ owner }: RecordSubmitBarrierInput): Promise<RecordSessionAuthenticationSubmitBarrierResult> {
+    const rows = await this.prisma.$queryRaw<Row[]>`UPDATE "BankSessionAuthenticationAttempt" SET "interactionPhase" = 'submit_may_have_been_dispatched', "updatedAt" = NOW() WHERE "bankCode" = ${owner.identity.bankCode} AND "runId" = ${owner.identity.runId} AND "attemptId" = ${owner.identity.attemptId} AND "status" = 'active' AND "ownerToken" = ${owner.ownerToken} AND "generation" = ${owner.generation} AND "leaseExpiresAt" > NOW() AND "interactionPhase" = 'credentials_may_have_reached_portal' RETURNING "bankCode", "runId", "attemptId", "status", "interactionPhase", "failureClass", "operatorReason", "retryCount", "ownerToken", "generation", "leaseExpiresAt", "terminalAt", "createdAt", "updatedAt"`;
+    if (rows[0]) return { status: "recorded", record: record(rows[0]) };
+    const state = await this.ownerState(owner);
+    if (state.status !== "current") return state;
+    return state.record.interactionPhase === "submit_may_have_been_dispatched" ? { status: "already_recorded", record: state.record } : { status: "invalid_transition" };
+  }
+
+  async claimRetry({ owner }: ClaimRetryInput): Promise<ClaimSessionAuthenticationRetryResult> {
+    const retry = await this.prisma.$queryRaw<Row[]>`UPDATE "BankSessionAuthenticationAttempt" SET "retryCount" = "retryCount" + 1, "ownerToken" = NULL, "leaseExpiresAt" = NULL, "generation" = "generation" + 1, "updatedAt" = NOW() WHERE "bankCode" = ${owner.identity.bankCode} AND "runId" = ${owner.identity.runId} AND "attemptId" = ${owner.identity.attemptId} AND "status" = 'active' AND "ownerToken" = ${owner.ownerToken} AND "generation" = ${owner.generation} AND "leaseExpiresAt" > NOW() AND "interactionPhase" = 'no_credential_interaction' AND "retryCount" < 2 RETURNING "bankCode", "runId", "attemptId", "status", "interactionPhase", "failureClass", "operatorReason", "retryCount", "ownerToken", "generation", "leaseExpiresAt", "terminalAt", "createdAt", "updatedAt"`;
+    if (retry[0]) { const current = record(retry[0]); return { status: "retry_claimed", retryCount: current.retryCount as 1 | 2, record: current }; }
+    const exhausted = await this.prisma.$queryRaw<Row[]>`UPDATE "BankSessionAuthenticationAttempt" SET "status" = 'failed', "failureClass" = 'transient_pre_interaction', "operatorReason" = 'temporary_authentication_problem', "ownerToken" = NULL, "leaseExpiresAt" = NULL, "terminalAt" = NOW(), "generation" = "generation" + 1, "updatedAt" = NOW() WHERE "bankCode" = ${owner.identity.bankCode} AND "runId" = ${owner.identity.runId} AND "attemptId" = ${owner.identity.attemptId} AND "status" = 'active' AND "ownerToken" = ${owner.ownerToken} AND "generation" = ${owner.generation} AND "leaseExpiresAt" > NOW() AND "interactionPhase" = 'no_credential_interaction' AND "retryCount" = 2 RETURNING "bankCode"`;
+    if (exhausted[0]) return { status: "retry_exhausted" };
+    const state = await this.ownerState(owner); return state.status === "current" ? state.record.interactionPhase === "no_credential_interaction" ? { status: "not_applied" } : { status: "ineligible" } : state;
+  }
+
+  async completeAuthenticated({ owner }: CompleteAuthenticatedInput): Promise<CompleteAuthenticatedResult> { return this.complete(owner, "authenticated"); }
+
+  async completeFailed({ owner, failureClass, operatorReason }: CompleteFailedInput): Promise<CompleteFailedResult> {
+    const permitted = (failureClass === "transient_pre_interaction" && operatorReason === "temporary_authentication_problem") || (failureClass === "protected_or_mfa" && operatorReason === "protected_authentication_step_detected") || ((failureClass === "incompatible_flow" || failureClass === "structural_configuration") && operatorReason === "bank_login_configuration_requires_review") || ((failureClass === "ownership_lost" || failureClass === "interaction_outcome_uncertain" || failureClass === "unclassified_failure") && operatorReason === "authentication_attempt_requires_review");
+    if (!permitted) throw new Error("Invalid session authentication failure pair");
+    const rows = await this.prisma.$queryRaw<Row[]>`UPDATE "BankSessionAuthenticationAttempt" SET "status" = 'failed', "failureClass" = ${failureClass}, "operatorReason" = ${operatorReason}, "ownerToken" = NULL, "leaseExpiresAt" = NULL, "terminalAt" = NOW(), "generation" = "generation" + 1, "updatedAt" = NOW() WHERE "bankCode" = ${owner.identity.bankCode} AND "runId" = ${owner.identity.runId} AND "attemptId" = ${owner.identity.attemptId} AND "status" = 'active' AND "ownerToken" = ${owner.ownerToken} AND "generation" = ${owner.generation} AND "leaseExpiresAt" > NOW() RETURNING "bankCode", "runId", "attemptId", "status", "interactionPhase", "failureClass", "operatorReason", "retryCount", "ownerToken", "generation", "leaseExpiresAt", "terminalAt", "createdAt", "updatedAt"`;
+    if (rows[0]) return { status: "failed", record: record(rows[0]) };
+    const state = await this.ownerState(owner); return state.status === "current" ? { status: "not_applied" } : state;
+  }
+
+  private async complete(owner: CompleteAuthenticatedInput["owner"], status: "authenticated"): Promise<CompleteAuthenticatedResult> {
+    const rows = await this.prisma.$queryRaw<Row[]>`UPDATE "BankSessionAuthenticationAttempt" SET "status" = ${status}, "ownerToken" = NULL, "leaseExpiresAt" = NULL, "terminalAt" = NOW(), "generation" = "generation" + 1, "updatedAt" = NOW() WHERE "bankCode" = ${owner.identity.bankCode} AND "runId" = ${owner.identity.runId} AND "attemptId" = ${owner.identity.attemptId} AND "status" = 'active' AND "ownerToken" = ${owner.ownerToken} AND "generation" = ${owner.generation} AND "leaseExpiresAt" > NOW() RETURNING "bankCode", "runId", "attemptId", "status", "interactionPhase", "failureClass", "operatorReason", "retryCount", "ownerToken", "generation", "leaseExpiresAt", "terminalAt", "createdAt", "updatedAt"`;
+    if (rows[0]) return { status: "authenticated", record: record(rows[0]) };
+    const state = await this.ownerState(owner); return state.status === "current" ? { status: "not_applied" } : state;
+  }
+
+  async reconcileExpiredLease({ identity }: ReconcileExpiredLeaseInput): Promise<ReconcileExpiredLeaseResult> {
+    const retry = await this.prisma.$queryRaw<Row[]>`UPDATE "BankSessionAuthenticationAttempt" SET "retryCount" = "retryCount" + 1, "ownerToken" = NULL, "leaseExpiresAt" = NULL, "generation" = "generation" + 1, "updatedAt" = NOW() WHERE "bankCode" = ${identity.bankCode} AND "runId" = ${identity.runId} AND "attemptId" = ${identity.attemptId} AND "status" = 'active' AND "ownerToken" IS NOT NULL AND "leaseExpiresAt" <= NOW() AND "interactionPhase" = 'no_credential_interaction' AND "retryCount" < 2 RETURNING "bankCode", "runId", "attemptId", "status", "interactionPhase", "failureClass", "operatorReason", "retryCount", "ownerToken", "generation", "leaseExpiresAt", "terminalAt", "createdAt", "updatedAt"`;
+    if (retry[0]) return { status: "lease_reconciled", record: record(retry[0]) };
+    const terminal = await this.prisma.$queryRaw<Row[]>`UPDATE "BankSessionAuthenticationAttempt" SET "status" = 'failed', "failureClass" = CASE WHEN "interactionPhase" = 'no_credential_interaction' THEN 'transient_pre_interaction' ELSE 'interaction_outcome_uncertain' END, "operatorReason" = CASE WHEN "interactionPhase" = 'no_credential_interaction' THEN 'temporary_authentication_problem' ELSE 'authentication_attempt_requires_review' END, "ownerToken" = NULL, "leaseExpiresAt" = NULL, "terminalAt" = NOW(), "generation" = "generation" + 1, "updatedAt" = NOW() WHERE "bankCode" = ${identity.bankCode} AND "runId" = ${identity.runId} AND "attemptId" = ${identity.attemptId} AND "status" = 'active' AND "ownerToken" IS NOT NULL AND "leaseExpiresAt" <= NOW() AND (("interactionPhase" = 'no_credential_interaction' AND "retryCount" = 2) OR "interactionPhase" IN ('credentials_may_have_reached_portal', 'submit_may_have_been_dispatched')) RETURNING "bankCode", "runId", "attemptId", "status", "interactionPhase", "failureClass", "operatorReason", "retryCount", "ownerToken", "generation", "leaseExpiresAt", "terminalAt", "createdAt", "updatedAt"`;
+    if (terminal[0]) return { status: "lease_reconciled", record: record(terminal[0]) };
+    return { status: "not_applied" };
+  }
+}

--- a/src/modules/persistence/session-authentication-attempt.postgres.test.ts
+++ b/src/modules/persistence/session-authentication-attempt.postgres.test.ts
@@ -1,0 +1,206 @@
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { Pool } from "pg";
+import { PrismaClient } from "../../generated/prisma/client";
+import type { SessionAuthenticationAttemptRecord } from "../bank-sessions/session-authentication-attempt-repository";
+import { PrismaBankSessionAuthenticationAttemptRepository } from "./prisma-bank-session-authentication-attempt-repository";
+
+const url = process.env.RD_SYNC_TEST_DATABASE_URL;
+const pool = url ? new Pool({ connectionString: url }) : undefined;
+const prisma = url ? new PrismaClient({ adapter: new PrismaPg({ connectionString: url }) }) : undefined;
+const attemptIdentity = (name: string, attemptId = "attempt") => ({ bankCode: "auth-contract-bank", runId: name, attemptId });
+
+describe.skipIf(!url)("Session authentication attempt PostgreSQL contract", () => {
+  beforeEach(async () => {
+    await pool!.query('DELETE FROM "BankSessionAuthenticationAttempt" WHERE "bankCode" LIKE \'auth-contract-%\'');
+    await pool!.query('DELETE FROM "Bank" WHERE "code" LIKE \'auth-contract-%\'');
+    await pool!.query('INSERT INTO "Bank" ("id", "code", "name", "updatedAt") VALUES ($1, $2, $3, NOW())', ["auth-contract-bank-id", "auth-contract-bank", "Authentication contract bank"]);
+    const checks = await pool!.query<{ conname: string }>("SELECT conname FROM pg_constraint WHERE conrelid = '\"BankSessionAuthenticationAttempt\"'::regclass AND contype = 'c'");
+    expect(checks.rows.map(({ conname }) => conname)).toEqual(expect.arrayContaining([
+      "BankSessionAuthenticationAttempt_identity_check", "BankSessionAuthenticationAttempt_status_check",
+      "BankSessionAuthenticationAttempt_phase_check", "BankSessionAuthenticationAttempt_retry_check",
+      "BankSessionAuthenticationAttempt_generation_check", "BankSessionAuthenticationAttempt_owner_check",
+      "BankSessionAuthenticationAttempt_terminal_check",
+    ]));
+  });
+
+  afterAll(async () => { await pool?.end(); await prisma?.$disconnect(); });
+  const repo = () => new PrismaBankSessionAuthenticationAttemptRepository(prisma!);
+  async function lease(name: string, token = "owner") {
+    const id = attemptIdentity(name); await repo().getOrCreate({ identity: id });
+    const result = await repo().acquireLease({ identity: id, ownerToken: token, leaseDurationMs: 10_000 });
+    if (result.status !== "lease_acquired") throw new Error("Expected lease acquisition");
+    return { id, owner: result.owner };
+  }
+  async function createBank(bankCode: string) {
+    await pool!.query('INSERT INTO "Bank" ("id", "code", "name", "updatedAt") VALUES ($1, $2, $3, NOW())', [`${bankCode}-id`, bankCode, bankCode]);
+  }
+  async function expire(id: ReturnType<typeof attemptIdentity>) { await pool!.query('UPDATE "BankSessionAuthenticationAttempt" SET "leaseExpiresAt" = NOW() WHERE "bankCode" = $1 AND "runId" = $2 AND "attemptId" = $3', [id.bankCode, id.runId, id.attemptId]); }
+  function diagnosticRow(record: SessionAuthenticationAttemptRecord) {
+    return {
+      bankCode: record.identity.bankCode, runId: record.identity.runId, attemptId: record.identity.attemptId,
+      status: record.status, interactionPhase: record.interactionPhase, failureClass: record.failureClass,
+      operatorReason: record.operatorReason, retryCount: record.retryCount, ownerToken: record.ownerToken,
+      generation: record.generation, leaseExpiresAt: record.leaseExpiresAt, terminalAt: record.terminalAt,
+      createdAt: record.createdAt, updatedAt: record.updatedAt, leaseActive: true,
+    };
+  }
+
+  it("creates one exact tuple concurrently and reports creation once", async () => {
+    const id = attemptIdentity("create"); const results = await Promise.all([repo().getOrCreate({ identity: id }), repo().getOrCreate({ identity: id })]);
+    expect(results.filter((result) => result.status === "created")).toHaveLength(1);
+    expect(await repo().findExact({ identity: { ...id, attemptId: "other" } })).toEqual({ status: "missing" });
+    expect((await repo().findExact({ identity: id })).status).toBe("found");
+  });
+
+  it("fails closed for a sequential different attempt identity without mutating the existing aggregate", async () => {
+    const id = attemptIdentity("identity-conflict");
+    await expect(repo().getOrCreate({ identity: id })).resolves.toMatchObject({ status: "created" });
+    const acquired = await repo().acquireLease({ identity: id, ownerToken: "existing-owner", leaseDurationMs: 10_000 });
+    if (acquired.status !== "lease_acquired") throw new Error("Expected lease acquisition");
+
+    const conflict = await repo().getOrCreate({ identity: { ...id, attemptId: "different-attempt" } });
+    expect(conflict).toEqual({ status: "identity_conflict", existingAttemptId: id.attemptId });
+    expect(conflict).not.toHaveProperty("ownerToken");
+    expect(conflict).not.toHaveProperty("record");
+    await expect(repo().findExact({ identity: id })).resolves.toMatchObject({ status: "found", record: { retryCount: 0, generation: 1n, interactionPhase: "no_credential_interaction", ownerToken: "existing-owner" } });
+    await expect(pool!.query('SELECT COUNT(*)::int AS count FROM "BankSessionAuthenticationAttempt" WHERE "bankCode" = $1 AND "runId" = $2', [id.bankCode, id.runId])).resolves.toMatchObject({ rows: [{ count: 1 }] });
+  });
+
+  it("creates one aggregate and reports identity conflict for concurrent different attempt identities", async () => {
+    const first = attemptIdentity("concurrent-identity-conflict", "first-attempt");
+    const second = { ...first, attemptId: "second-attempt" };
+    const results = await Promise.all([repo().getOrCreate({ identity: first }), repo().getOrCreate({ identity: second })]);
+    expect(results.filter((result) => result.status === "created")).toHaveLength(1);
+    expect(results.filter((result) => result.status === "identity_conflict")).toHaveLength(1);
+    await expect(pool!.query('SELECT COUNT(*)::int AS count FROM "BankSessionAuthenticationAttempt" WHERE "bankCode" = $1 AND "runId" = $2', [first.bankCode, first.runId])).resolves.toMatchObject({ rows: [{ count: 1 }] });
+  });
+
+  it("enforces aggregate uniqueness and restrictive bank references in PostgreSQL", async () => {
+    const bankCode = "auth-contract-fk";
+    await createBank(bankCode);
+    await pool!.query('INSERT INTO "BankSessionAuthenticationAttempt" ("bankCode", "runId", "attemptId", "updatedAt") VALUES ($1, $2, $3, NOW())', [bankCode, "run", "first"]);
+    await expect(pool!.query('INSERT INTO "BankSessionAuthenticationAttempt" ("bankCode", "runId", "attemptId", "retryCount", "updatedAt") VALUES ($1, $2, $3, 1, NOW())', [bankCode, "run", "second"])).rejects.toMatchObject({ code: "23505" });
+    await expect(pool!.query('DELETE FROM "Bank" WHERE "code" = $1', [bankCode])).rejects.toMatchObject({ code: "23503" });
+    await expect(pool!.query('UPDATE "Bank" SET "code" = $2 WHERE "code" = $1', [bankCode, `${bankCode}-renamed`])).rejects.toMatchObject({ code: "23503" });
+  });
+
+  it("rejects unknown bank codes through the foreign key", async () => {
+    const id = { bankCode: "auth-contract-unknown-bank", runId: "run", attemptId: "attempt" };
+    await expect(pool!.query('INSERT INTO "BankSessionAuthenticationAttempt" ("bankCode", "runId", "attemptId", "updatedAt") VALUES ($1, $2, $3, NOW())', [id.bankCode, id.runId, id.attemptId])).rejects.toMatchObject({ code: "23503" });
+    await expect(repo().getOrCreate({ identity: id })).rejects.toBeDefined();
+  });
+
+  it("acquires once, fences generation, and renews only the exact active owner", async () => {
+    const id = attemptIdentity("lease"); await repo().getOrCreate({ identity: id });
+    const [first, second] = await Promise.all(["one", "two"].map((ownerToken) => repo().acquireLease({ identity: id, ownerToken, leaseDurationMs: 10_000 })));
+    const acquired = [first, second].find((result) => result.status === "lease_acquired");
+    expect([first, second].filter((result) => result.status === "lease_acquired")).toHaveLength(1);
+    if (!acquired || acquired.status !== "lease_acquired") throw new Error("Expected acquired lease");
+    expect(acquired.record).toMatchObject({ generation: 1n, retryCount: 0 });
+    await expect(repo().renewLease({ owner: { ...acquired.owner, ownerToken: "wrong" }, leaseDurationMs: 10_000 })).resolves.toEqual({ status: "stale_owner" });
+    await expire(id);
+    await expect(repo().renewLease({ owner: acquired.owner, leaseDurationMs: 10_000 })).resolves.toEqual({ status: "lease_expired" });
+  });
+
+  it("requires reconciliation before replacing an expired owner and fences that owner afterward", async () => {
+    const { id, owner: old } = await lease("expired-owner-acquire");
+    await expire(id);
+    const before = await repo().findExact({ identity: id });
+    if (before.status !== "found" || before.record.status !== "active") throw new Error("Expected expired owned attempt");
+
+    await expect(repo().acquireLease({ identity: id, ownerToken: "replacement", leaseDurationMs: 10_000 }))
+      .resolves.toMatchObject({ status: "reconciliation_required" });
+    await expect(repo().findExact({ identity: id })).resolves.toEqual(before);
+
+    await expect(repo().reconcileExpiredLease({ identity: id })).resolves.toMatchObject({
+      status: "lease_reconciled", record: { ownerToken: null, leaseExpiresAt: null, retryCount: 1, generation: old.generation + 1n },
+    });
+    const replacement = await repo().acquireLease({ identity: id, ownerToken: "replacement", leaseDurationMs: 10_000 });
+    if (replacement.status !== "lease_acquired") throw new Error("Expected replacement owner after reconciliation");
+    expect(replacement.owner.generation).toBeGreaterThan(old.generation);
+    await expect(repo().beginCredentialInteraction({ owner: old })).resolves.toEqual({ status: "stale_owner" });
+  });
+
+  it("does not label a failed renew CAS as expired when its diagnostic still sees an active current owner", async () => {
+    const { owner } = await lease("renew-not-applied");
+    const current = await repo().findExact({ identity: owner.identity });
+    if (current.status !== "found" || current.record.status !== "active") throw new Error("Expected active attempt");
+    const calls: unknown[] = [[], [diagnosticRow(current.record)]];
+    const diagnosticRepo = new PrismaBankSessionAuthenticationAttemptRepository({ $queryRaw: async () => calls.shift() } as unknown as typeof prisma extends undefined ? never : NonNullable<typeof prisma>);
+    await expect(diagnosticRepo.renewLease({ owner, leaseDurationMs: 10_000 })).resolves.toEqual({ status: "not_applied" });
+  });
+
+  it("preserves monotonic interaction and requires one recorded submit barrier", async () => {
+    const { id, owner: current } = await lease("barrier");
+    await expect(repo().recordSubmitBarrier({ owner: current })).resolves.toEqual({ status: "invalid_transition" });
+    await expect(repo().beginCredentialInteraction({ owner: current })).resolves.toMatchObject({ status: "interaction_started" });
+    await expect(repo().beginCredentialInteraction({ owner: current })).resolves.toMatchObject({ status: "already_started" });
+    await expect(repo().recordSubmitBarrier({ owner: current })).resolves.toMatchObject({ status: "recorded" });
+    await expect(repo().recordSubmitBarrier({ owner: current })).resolves.toMatchObject({ status: "already_recorded" });
+    expect((await repo().findExact({ identity: id }))).toMatchObject({ status: "found", record: { interactionPhase: "submit_may_have_been_dispatched" } });
+  });
+
+  it("does not authorize a second submit barrier", async () => {
+    const { owner } = await lease("second-submit");
+    await repo().beginCredentialInteraction({ owner });
+    await expect(repo().recordSubmitBarrier({ owner })).resolves.toMatchObject({ status: "recorded" });
+    const second = await repo().recordSubmitBarrier({ owner });
+    expect(second.status).toBe("already_recorded");
+    expect(second.status === "recorded").toBe(false);
+  });
+
+  it("returns not_applied for ambiguous retry and completion diagnostics", async () => {
+    const { owner } = await lease("diagnostic-not-applied");
+    const current = await repo().findExact({ identity: owner.identity });
+    if (current.status !== "found" || current.record.status !== "active") throw new Error("Expected active attempt");
+    const currentDiagnosticRow = diagnosticRow(current.record);
+    const fake = (responses: unknown[]) => new PrismaBankSessionAuthenticationAttemptRepository({ $queryRaw: async () => responses.shift() } as unknown as typeof prisma extends undefined ? never : NonNullable<typeof prisma>);
+    await expect(fake([[], [], [currentDiagnosticRow]]).claimRetry({ owner })).resolves.toEqual({ status: "not_applied" });
+    await expect(fake([[], [currentDiagnosticRow]]).completeAuthenticated({ owner })).resolves.toEqual({ status: "not_applied" });
+    await expect(fake([[], [currentDiagnosticRow]]).completeFailed({ owner, failureClass: "transient_pre_interaction", operatorReason: "temporary_authentication_problem" })).resolves.toEqual({ status: "not_applied" });
+  });
+
+  it("fences stale owners after retry and terminal completion is immutable", async () => {
+    const { id, owner: old } = await lease("fence");
+    await expect(repo().claimRetry({ owner: old })).resolves.toMatchObject({ status: "retry_claimed", retryCount: 1 });
+    const next = await repo().acquireLease({ identity: id, ownerToken: "next", leaseDurationMs: 10_000 });
+    if (next.status !== "lease_acquired") throw new Error("Expected replacement owner");
+    expect(next.owner.generation).toBeGreaterThan(old.generation);
+    await expect(repo().beginCredentialInteraction({ owner: old })).resolves.toEqual({ status: "stale_owner" });
+    await expect(repo().recordSubmitBarrier({ owner: old })).resolves.toEqual({ status: "stale_owner" });
+    await expect(repo().completeAuthenticated({ owner: old })).resolves.toEqual({ status: "stale_owner" });
+    await expect(repo().completeAuthenticated({ owner: next.owner })).resolves.toMatchObject({ status: "authenticated", record: { retryCount: 1 } });
+    await expect(repo().completeFailed({ owner: next.owner, failureClass: "transient_pre_interaction", operatorReason: "temporary_authentication_problem" })).resolves.toEqual({ status: "terminal" });
+  });
+
+  it("serializes authentication/failure, bounded retries, and expiration reconciliation", async () => {
+    const auth = await lease("race");
+    const race = await Promise.all([repo().completeAuthenticated({ owner: auth.owner }), repo().completeFailed({ owner: auth.owner, failureClass: "transient_pre_interaction", operatorReason: "temporary_authentication_problem" })]);
+    expect(race.filter((result) => result.status === "authenticated" || result.status === "failed")).toHaveLength(1);
+    const retry = await lease("retry");
+    expect((await Promise.all([repo().claimRetry({ owner: retry.owner }), repo().claimRetry({ owner: retry.owner })])).filter((result) => result.status === "retry_claimed")).toHaveLength(1);
+    for (const token of ["two", "three"]) { const acquired = await repo().acquireLease({ identity: retry.id, ownerToken: token, leaseDurationMs: 10_000 }); if (acquired.status !== "lease_acquired") throw new Error("Expected retry lease"); await repo().claimRetry({ owner: acquired.owner }); }
+    await expect(repo().findExact({ identity: retry.id })).resolves.toMatchObject({ status: "found", record: { status: "failed", retryCount: 2, generation: 6n, failureClass: "transient_pre_interaction", operatorReason: "temporary_authentication_problem" } });
+    for (const phase of ["no", "credentials", "submit"] as const) {
+      const current = await lease(`expired-${phase}`);
+      if (phase !== "no") await repo().beginCredentialInteraction({ owner: current.owner });
+      if (phase === "submit") await repo().recordSubmitBarrier({ owner: current.owner });
+      await expire(current.id); const reconciled = await repo().reconcileExpiredLease({ identity: current.id });
+      expect(reconciled).toMatchObject(phase === "no" ? { status: "lease_reconciled", record: { retryCount: 1, status: "active" } } : { status: "lease_reconciled", record: { status: "failed", failureClass: "interaction_outcome_uncertain" } });
+      await expect(repo().completeAuthenticated({ owner: current.owner })).resolves.toMatchObject({ status: phase === "no" ? "stale_owner" : "terminal" });
+    }
+  });
+
+  it.each([
+    ["invalid enum", "INSERT INTO \"BankSessionAuthenticationAttempt\" (\"bankCode\", \"runId\", \"attemptId\", \"status\", \"interactionPhase\", \"updatedAt\") VALUES ('auth-contract-invalid-enum', 'run', 'attempt', 'bad', 'no_credential_interaction', NOW())"],
+    ["blank identity", "INSERT INTO \"BankSessionAuthenticationAttempt\" (\"bankCode\", \"runId\", \"attemptId\", \"updatedAt\") VALUES (' ', 'run', 'attempt', NOW())"],
+    ["invalid retry", "INSERT INTO \"BankSessionAuthenticationAttempt\" (\"bankCode\", \"runId\", \"attemptId\", \"retryCount\", \"updatedAt\") VALUES ('auth-contract-invalid-retry', 'run', 'attempt', 3, NOW())"],
+    ["invalid generation", "INSERT INTO \"BankSessionAuthenticationAttempt\" (\"bankCode\", \"runId\", \"attemptId\", \"generation\", \"updatedAt\") VALUES ('auth-contract-invalid-generation', 'run', 'attempt', -1, NOW())"],
+    ["invalid ownership tuple", "INSERT INTO \"BankSessionAuthenticationAttempt\" (\"bankCode\", \"runId\", \"attemptId\", \"ownerToken\", \"updatedAt\") VALUES ('auth-contract-invalid-owner', 'run', 'attempt', 'owner', NOW())"],
+    ["mismatched safe failure pair", "INSERT INTO \"BankSessionAuthenticationAttempt\" (\"bankCode\", \"runId\", \"attemptId\", \"status\", \"failureClass\", \"operatorReason\", \"terminalAt\", \"updatedAt\") VALUES ('auth-contract-invalid-failure-pair', 'run', 'attempt', 'failed', 'transient_pre_interaction', 'authentication_attempt_requires_review', NOW(), NOW())"],
+    ["authenticated failure fields", "INSERT INTO \"BankSessionAuthenticationAttempt\" (\"bankCode\", \"runId\", \"attemptId\", \"status\", \"failureClass\", \"terminalAt\", \"updatedAt\") VALUES ('auth-contract-authenticated-failure', 'run', 'attempt', 'authenticated', 'unclassified_failure', NOW(), NOW())"],
+    ["active terminal timestamp", "INSERT INTO \"BankSessionAuthenticationAttempt\" (\"bankCode\", \"runId\", \"attemptId\", \"terminalAt\", \"updatedAt\") VALUES ('auth-contract-active-terminal', 'run', 'attempt', NOW(), NOW())"],
+    ["terminal owner and lease", "INSERT INTO \"BankSessionAuthenticationAttempt\" (\"bankCode\", \"runId\", \"attemptId\", \"status\", \"ownerToken\", \"leaseExpiresAt\", \"terminalAt\", \"updatedAt\") VALUES ('auth-contract-terminal-owner', 'run', 'attempt', 'authenticated', 'owner', NOW(), NOW(), NOW())"],
+  ])("migration rejects %s", async (_name, sql) => { await expect(pool!.query(sql)).rejects.toMatchObject({ code: "23514" }); });
+});


### PR DESCRIPTION
Closes #78

## Type
- [x] New feature

## Summary
- Adds the inert Slices 1-2 durable authentication-attempt domain contract, Prisma schema/migration, and raw-SQL CAS repository.
- Establishes durable ownership, generation fencing, terminal evidence, interaction barriers, and a bounded retry protocol without activating any runtime path.
- Slice 3 runtime activation remains a separate future PR.

## Contract Decisions

### Aggregate identity
The aggregate is `UNIQUE (bankCode, runId)`, not `(bankCode, runId, retryCount)`. `retryCount` is mutable state inside one aggregate; including it neither bounds aggregate count nor permits legitimate transitions reliably. Counterexample: an active row at `(popular, run-1, 0)` could coexist with another row at `(popular, run-1, 1)`, creating two owners for one run; updating the first row from retry count 0 to 1 would then collide rather than represent its legitimate transition.

### Restrictive configuration ownership
The `Bank.code` foreign key uses `RESTRICT`, not `CASCADE`. Bank configuration rows may be removed, but authentication attempts contain active ownership, fencing, and terminal evidence. Cascading deletion could erase coordination while a worker is alive.

### Retry budget is four safeguards
The retry budget is not guaranteed by one database constraint alone. It relies on four pieces: one aggregate per bank/run; `retryCount` constrained to 0-2; CAS-only increment guarded by current owner, generation, lease, and phase; and this repository being the only writer. The prior claim that the database alone makes excess retries impossible was too strong.

### Prisma 7 unique races
Prisma 7 raw-query failures wrap PostgreSQL `23505` in `P2010`; the SQLSTATE is preserved under `meta.driverAdapterError.cause`. The required nearby code comment documents this driver-adapter contract, and PostgreSQL tests preserve the behavior.

## Inertness Proof
CodeGraph and repository-wide `rg` found references only in the new domain/repository definitions and their tests. There are zero production consumers and no runtime, worker, queue, browser, API, UI, or composition wiring.

## Size Exception And Scope
This is a deliberate, maintainer-approved `size:exception`: exactly 1,087 authored additions across 8 files, 687 lines above the normal ~400-line review budget. No `size:exception` label exists in this repository, so the exception is recorded in this PR body, consistent with prior oversized PRs.

The pure domain contract, repository port, Prisma implementation, migration, and PostgreSQL contracts form one coherent, independently verified review and rollback unit. Splitting code from its contracts and tests would weaken review clarity. Slice 3 production activation remains separate and out of scope.

Rollback boundary: revert these eight files and the migration before Slice 3 activation; this removes only the inert foundation and does not alter any existing runtime path.

## Related Work
#67 and #69 are related follow-up context only. This PR does not close either issue.

## Test Evidence
- [x] This repository has no CI workflow, so GitHub reports zero check runs/status contexts. All merge evidence is local and this PR does not claim CI is green.
- [x] Disposable PostgreSQL 16 from zero: `docker run ... postgres:16-alpine`, `pnpm exec prisma migrate deploy`, and `RD_SYNC_TEST_DATABASE_URL=... pnpm test:postgres -- src/modules/persistence/session-authentication-attempt.postgres.test.ts` applied all 16 migrations and passed 22/22 tests. Container was removed afterward.
- [x] `pnpm test -- src/modules/bank-sessions/session-authentication-attempt-repository.test.ts` passed 25/25 tests.
- [x] `pnpm test -- src/modules/bank-sessions/session-authentication-attempt.test.ts` passed 47/47 tests.
- [x] `pnpm test` passed 1,391 tests; 2 existing tests skipped.
- [x] `pnpm lint` passed.
- [x] `pnpm typecheck` passed.
- [x] `pnpm exec prisma validate` passed.
- [x] `git diff --check` passed.
- [x] No live-bank credentials, portal activity, or browser activity was used.

## Contributor Checklist
- [x] Linked approved issue #78.
- [x] Added exactly one `type:*` label.
- [x] Conventional commit format.
- [x] No `Co-Authored-By` or AI attribution.
- [x] No runtime harness applies because this intentionally has no runtime boundary; database contract coverage is provided by the disposable PostgreSQL 16 suite.