### PR TITLE
feat(bank-sessions): resolve observed restoration atomically

### DIFF
--- a/src/modules/bank-sessions/session-authentication-attempt-repository.test.ts
+++ b/src/modules/bank-sessions/session-authentication-attempt-repository.test.ts
@@ -12,7 +12,10 @@ import {
   type SessionAuthenticationAttemptNotAppliedResult,
   type SessionAuthenticationAttemptRepository,
   type SessionAuthenticationAttemptRow,
+  type ObservedRestorationResolver,
+  type ResolveObservedRestorationResult,
 } from "./session-authentication-attempt-repository";
+import { PrismaBankSessionAuthenticationAttemptRepository } from "../persistence/prisma-bank-session-authentication-attempt-repository";
 
 const base: SessionAuthenticationAttemptRow = {
   bankCode: "popular", runId: "run-1", attemptId: "attempt-1", status: "active",
@@ -68,10 +71,23 @@ describe("parseSessionAuthenticationAttemptRecord", () => {
   });
 });
 
+describe("ObservedRestorationResolver", () => {
+  it.each([
+    { identity: { bankCode: " ", runId: "run", attemptId: "attempt" }, ownerToken: "owner", generation: 0n },
+    { identity: { bankCode: "bank", runId: "run", attemptId: "attempt" }, ownerToken: " ", generation: 0n },
+    { identity: { bankCode: "bank", runId: "run", attemptId: "attempt" }, ownerToken: "owner", generation: -1n },
+  ])("rejects invalid owner input", async (owner) => {
+    const resolver = new PrismaBankSessionAuthenticationAttemptRepository({} as never);
+    await expect(resolver.resolveObservedRestoration(owner)).rejects.toThrow();
+  });
+});
+
 type RepositoryMethods = Pick<SessionAuthenticationAttemptRepository,
   "getOrCreate" | "findExact" | "acquireLease" | "renewLease" | "beginCredentialInteraction" |
   "recordSubmitBarrier" | "claimRetry" | "completeAuthenticated" | "completeFailed" | "reconcileExpiredLease">;
 void (null as unknown as RepositoryMethods);
+type ResolverMethods = Pick<ObservedRestorationResolver, "resolveObservedRestoration">;
+void (null as unknown as ResolverMethods);
 declare const repository: SessionAuthenticationAttemptRepository;
 if (false) {
   // @ts-expect-error The generic repository operation is intentionally unavailable.
@@ -108,6 +124,13 @@ const reconcileExpiredLeaseResults: readonly ReconcileExpiredLeaseResult[] = [
   { status: "missing" }, { status: "not_applied" },
 ];
 const notApplied: SessionAuthenticationAttemptNotAppliedResult = { status: "not_applied" };
+const observedRestorationResults: readonly ResolveObservedRestorationResult[] = [
+  { status: "resolved", evidence: { authenticatedAt: new Date("2026-08-13T01:00:00.000Z") } },
+  { status: "already_resolved" }, { status: "missing", missing: "authentication_attempt" },
+  { status: "missing", missing: "expiry_episode" }, { status: "identity_mismatch" },
+  { status: "stale_owner" }, { status: "lease_expired" }, { status: "active_mutation_owner" },
+  { status: "episode_not_resolvable" }, { status: "terminal_conflict" }, { status: "not_applied" },
+];
 const getOrCreateResults: readonly GetOrCreateSessionAuthenticationAttemptResult[] = [
   { status: "created", record: null as unknown as never },
   { status: "found", record: null as unknown as never },
@@ -127,5 +150,9 @@ if (false) {
   void ({ owner, failureClass: "transient_pre_interaction", operatorReason: "temporary_authentication_problem", terminalAt: new Date() } satisfies CompleteFailedInput);
   // @ts-expect-error Lease reconciliation time comes from PostgreSQL.
   void ({ identity: owner.identity, reconciledAt: new Date() } satisfies ReconcileExpiredLeaseInput);
+  // @ts-expect-error The resolver owns no ordinary repository operations.
+  void (null as unknown as ObservedRestorationResolver).completeAuthenticated;
+  // @ts-expect-error Resolution evidence never exposes expiry ownership.
+  void (observedRestorationResults[0] as Extract<ResolveObservedRestorationResult, { status: "resolved" }>).evidence.consumerClaimToken;
 }
-void [submitBarrierResults, retryResults, acquireLeaseResults, completeAuthenticatedInput, completeFailedInput, reconcileExpiredLeaseInput, reconcileExpiredLeaseResults, notApplied, getOrCreateResults];
+void [submitBarrierResults, retryResults, acquireLeaseResults, completeAuthenticatedInput, completeFailedInput, reconcileExpiredLeaseInput, reconcileExpiredLeaseResults, notApplied, observedRestorationResults, getOrCreateResults];

--- a/src/modules/bank-sessions/session-authentication-attempt-repository.ts
+++ b/src/modules/bank-sessions/session-authentication-attempt-repository.ts
@@ -52,6 +52,13 @@ export type ClaimRetryInput = Readonly<{ owner: SessionAuthenticationLeaseOwner 
 export type CompleteAuthenticatedInput = Readonly<{ owner: SessionAuthenticationLeaseOwner }>;
 export type CompleteFailedInput = Readonly<{ owner: SessionAuthenticationLeaseOwner } & SessionAuthenticationFailurePair>;
 export type ReconcileExpiredLeaseInput = Readonly<{ identity: SessionAuthenticationAttemptIdentity }>;
+export type ObservedRestorationEvidence = Readonly<{ authenticatedAt: Date }>;
+export type ResolveObservedRestorationResult =
+  | Readonly<{ status: "resolved"; evidence: ObservedRestorationEvidence }>
+  | Readonly<{ status: "already_resolved" }>
+  | Readonly<{ status: "missing"; missing: "authentication_attempt" | "expiry_episode" }>
+  | Readonly<{ status: "identity_mismatch" | "stale_owner" | "lease_expired" | "active_mutation_owner" | "episode_not_resolvable" | "terminal_conflict" }>
+  | SessionAuthenticationAttemptNotAppliedResult;
 
 export type GetOrCreateSessionAuthenticationAttemptResult =
   | Readonly<{ status: "created"; record: SessionAuthenticationAttemptRecord }>
@@ -139,6 +146,10 @@ export interface SessionAuthenticationAttemptRepository {
   completeAuthenticated(input: CompleteAuthenticatedInput): Promise<CompleteAuthenticatedResult>;
   completeFailed(input: CompleteFailedInput): Promise<CompleteFailedResult>;
   reconcileExpiredLease(input: ReconcileExpiredLeaseInput): Promise<ReconcileExpiredLeaseResult>;
+}
+/** Atomic, production-inert capability for durable observed-restoration evidence. */
+export interface ObservedRestorationResolver {
+  resolveObservedRestoration(owner: SessionAuthenticationLeaseOwner): Promise<ResolveObservedRestorationResult>;
 }
 
 const phases: readonly CredentialInteractionPhase[] = ["no_credential_interaction", "credentials_may_have_reached_portal", "submit_may_have_been_dispatched"];

--- a/src/modules/persistence/prisma-bank-session-authentication-attempt-repository.ts
+++ b/src/modules/persistence/prisma-bank-session-authentication-attempt-repository.ts
@@ -23,6 +23,9 @@ import {
   type RenewSessionAuthenticationLeaseResult,
   type SessionAuthenticationAttemptRecord,
   type SessionAuthenticationAttemptRepository,
+  type ObservedRestorationResolver,
+  type ResolveObservedRestorationResult,
+  type SessionAuthenticationLeaseOwner,
 } from "../bank-sessions/session-authentication-attempt-repository";
 
 type Row = {
@@ -40,6 +43,10 @@ function record(row: Row): SessionAuthenticationAttemptRecord {
 function assertLease(ownerToken: string, duration: number): void {
   if (!ownerToken.trim()) throw new Error("Session authentication owner token must be nonblank");
   if (!Number.isFinite(duration) || duration <= 0) throw new Error("Session authentication lease duration must be positive and finite");
+}
+function assertObservedOwner(owner: SessionAuthenticationLeaseOwner): void {
+  if (![owner.identity.bankCode, owner.identity.runId, owner.identity.attemptId, owner.ownerToken].every((value) => value.trim())) throw new Error("Observed restoration identity and owner must be nonblank");
+  if (owner.generation < 0n) throw new Error("Observed restoration generation must be nonnegative");
 }
 
 function sameOwner(current: SessionAuthenticationAttemptRecord, owner: { ownerToken: string; generation: bigint }): boolean {
@@ -61,7 +68,7 @@ function isUniqueViolation(error: unknown): boolean {
   return isRecord(cause) && cause.kind === "UniqueConstraintViolation" && cause.originalCode === "23505";
 }
 
-export class PrismaBankSessionAuthenticationAttemptRepository implements SessionAuthenticationAttemptRepository {
+export class PrismaBankSessionAuthenticationAttemptRepository implements SessionAuthenticationAttemptRepository, ObservedRestorationResolver {
   constructor(private readonly prisma: PrismaClient) {}
 
   private async find(input: { identity: { bankCode: string; runId: string; attemptId: string } }): Promise<SessionAuthenticationAttemptRecord | null> {
@@ -170,5 +177,41 @@ export class PrismaBankSessionAuthenticationAttemptRepository implements Session
     const terminal = await this.prisma.$queryRaw<Row[]>`UPDATE "BankSessionAuthenticationAttempt" SET "status" = 'failed', "failureClass" = CASE WHEN "interactionPhase" = 'no_credential_interaction' THEN 'transient_pre_interaction' ELSE 'interaction_outcome_uncertain' END, "operatorReason" = CASE WHEN "interactionPhase" = 'no_credential_interaction' THEN 'temporary_authentication_problem' ELSE 'authentication_attempt_requires_review' END, "ownerToken" = NULL, "leaseExpiresAt" = NULL, "terminalAt" = NOW(), "generation" = "generation" + 1, "updatedAt" = NOW() WHERE "bankCode" = ${identity.bankCode} AND "runId" = ${identity.runId} AND "attemptId" = ${identity.attemptId} AND "status" = 'active' AND "ownerToken" IS NOT NULL AND "leaseExpiresAt" <= NOW() AND (("interactionPhase" = 'no_credential_interaction' AND "retryCount" = 2) OR "interactionPhase" IN ('credentials_may_have_reached_portal', 'submit_may_have_been_dispatched')) RETURNING "bankCode", "runId", "attemptId", "status", "interactionPhase", "failureClass", "operatorReason", "retryCount", "ownerToken", "generation", "leaseExpiresAt", "terminalAt", "createdAt", "updatedAt"`;
     if (terminal[0]) return { status: "lease_reconciled", record: record(terminal[0]) };
     return { status: "not_applied" };
+  }
+
+  async resolveObservedRestoration(owner: SessionAuthenticationLeaseOwner, retry = true): Promise<ResolveObservedRestorationResult> {
+    assertObservedOwner(owner);
+    try {
+      return await this.prisma.$transaction(async (tx) => {
+        const attempts = await tx.$queryRaw<Array<Row & { leaseActive: boolean }>>`SELECT "bankCode", "runId", "attemptId", "status", "interactionPhase", "failureClass", "operatorReason", "retryCount", "ownerToken", "generation", "leaseExpiresAt", "terminalAt", "createdAt", "updatedAt", COALESCE("leaseExpiresAt" > NOW(), FALSE) AS "leaseActive" FROM "BankSessionAuthenticationAttempt" WHERE "bankCode" = ${owner.identity.bankCode} AND "runId" = ${owner.identity.runId} FOR UPDATE`;
+        const attempt = attempts[0];
+        if (!attempt) return { status: "missing", missing: "authentication_attempt" };
+        if (attempt.attemptId !== owner.identity.attemptId) return { status: "identity_mismatch" };
+        if (attempt.status !== "active") {
+          if (attempt.status !== "authenticated") return { status: "terminal_conflict" };
+          const episode = (await tx.$queryRaw<Array<{ runId: string; consumerAttemptState: string | null }>>`SELECT "runId", "consumerAttemptState" FROM "BankSessionExpiryEpisode" WHERE "bankCode" = ${owner.identity.bankCode} FOR UPDATE`)[0];
+          if (!episode) return { status: "already_resolved" };
+          if (episode.runId !== owner.identity.runId) return { status: "identity_mismatch" };
+          return episode.consumerAttemptState === "resolved" ? { status: "already_resolved" } : { status: "terminal_conflict" };
+        }
+        if (attempt.ownerToken !== owner.ownerToken || attempt.generation !== owner.generation) return { status: "stale_owner" };
+        if (!attempt.leaseActive) return { status: "lease_expired" };
+        const episode = (await tx.$queryRaw<Array<{ runId: string; consumerAttemptState: string | null; consumerClaimToken: string | null; consumerLeaseExpiresAt: Date | null; leaseActive: boolean }>>`SELECT "runId", "consumerAttemptState", "consumerClaimToken", "consumerLeaseExpiresAt", COALESCE("consumerLeaseExpiresAt" > NOW(), FALSE) AS "leaseActive" FROM "BankSessionExpiryEpisode" WHERE "bankCode" = ${owner.identity.bankCode} FOR UPDATE`)[0];
+        if (!episode) return { status: "missing", missing: "expiry_episode" };
+        if (episode.runId !== owner.identity.runId) return { status: "identity_mismatch" };
+        const mutation = episode.consumerAttemptState === "mutation_started";
+        if (mutation && (!episode.consumerClaimToken || !episode.consumerLeaseExpiresAt || episode.leaseActive)) return { status: "active_mutation_owner" };
+        if (episode.consumerAttemptState !== "manual_recovery_required" && !mutation) return { status: "episode_not_resolvable" };
+        const authenticated = await tx.$queryRaw<Array<{ terminalAt: Date }>>`UPDATE "BankSessionAuthenticationAttempt" SET "status" = 'authenticated', "ownerToken" = NULL, "leaseExpiresAt" = NULL, "terminalAt" = NOW(), "generation" = "generation" + 1, "updatedAt" = NOW() WHERE "bankCode" = ${owner.identity.bankCode} AND "runId" = ${owner.identity.runId} AND "attemptId" = ${owner.identity.attemptId} AND "status" = 'active' AND "ownerToken" = ${owner.ownerToken} AND "generation" = ${owner.generation} AND "leaseExpiresAt" > NOW() RETURNING "terminalAt"`;
+        if (authenticated.length !== 1) throw new Error("Observed restoration authentication CAS lost");
+        const resolved = await tx.$executeRaw`UPDATE "BankSessionExpiryEpisode" SET "consumerAttemptState" = 'resolved', "consumerLeaseExpiresAt" = NULL, "updatedAt" = NOW() WHERE "bankCode" = ${owner.identity.bankCode} AND "runId" = ${owner.identity.runId} AND "consumerAttemptState" IN ('manual_recovery_required', 'mutation_started')`;
+        if (resolved !== 1) throw new Error("Observed restoration expiry CAS lost");
+        return { status: "resolved", evidence: { authenticatedAt: authenticated[0].terminalAt } };
+      }, { isolationLevel: "Serializable" });
+    } catch (error) {
+      const code = isRecord(error) && typeof error.code === "string" ? error.code : undefined;
+      if (retry && (code === "P2034" || code === "40001" || /40001|serialize access/.test(String(error)))) return this.resolveObservedRestoration(owner, false);
+      throw error;
+    }
   }
 }

--- a/src/modules/persistence/session-authentication-attempt.postgres.test.ts
+++ b/src/modules/persistence/session-authentication-attempt.postgres.test.ts
@@ -247,13 +247,34 @@ describe.skipIf(!url)("Session authentication attempt PostgreSQL contract", () =
     await expect(repo().resolveObservedRestoration(conflict.owner)).resolves.toEqual({ status: "terminal_conflict" });
   });
 
-  it("uses database time, preserves episode evidence, and rolls back on an episode write failure", async () => {
-    const { id, owner } = await lease("observed-evidence"); await episode(id, "mutation_started");
-    const before = await pool!.query('SELECT "expiredEventId", "publicationClaimToken", "consumerClaimToken", "consumerAttemptSource" FROM "BankSessionExpiryEpisode" WHERE "bankCode" = $1', [id.bankCode]);
-    const result = await repo().resolveObservedRestoration(owner);
-    expect(result).toMatchObject({ status: "resolved", evidence: { authenticatedAt: expect.any(Date) } });
-    await expect(pool!.query('SELECT "expiredEventId", "publicationClaimToken", "consumerClaimToken", "consumerAttemptSource", "consumerAttemptState", "consumerLeaseExpiresAt" FROM "BankSessionExpiryEpisode" WHERE "bankCode" = $1', [id.bankCode])).resolves.toMatchObject({ rows: [{ ...before.rows[0], consumerAttemptState: "resolved", consumerLeaseExpiresAt: null }] });
+  it("uses PostgreSQL time and preserves every maximal legal episode evidence set", async () => {
+    const { id, owner } = await lease("observed-evidence"); await episode(id);
+    await pool!.query('UPDATE "BankSessionExpiryEpisode" SET "publicationState" = \'published\', "publicationClaimToken" = \'publication\', "consumerAttemptSource" = \'scheduled\', "expiredAuditDeliveredAt" = NOW() - INTERVAL \'3 minutes\', "restoredAuditDeliveredAt" = NOW() - INTERVAL \'2 minutes\', "terminalFailureReason" = \'job_missing\', "terminalFailureReconciledAt" = NOW() - INTERVAL \'1 minute\', "updatedAt" = NOW() - INTERVAL \'4 minutes\' WHERE "bankCode" = $1', [id.bankCode]);
+    const before = (await pool!.query('SELECT "expiredEventId", "runId", "expiredAuditDeliveredAt", "restoredAuditDeliveredAt", "publicationState", "publicationClaimToken", "publicationFailureReportedAt", "consumerClaimToken", "consumerAttemptSource", "consumerAttemptState", "consumerLeaseExpiresAt", "terminalFailureReason", "terminalFailureReconciledAt", "updatedAt" FROM "BankSessionExpiryEpisode" WHERE "bankCode" = $1', [id.bankCode])).rows[0];
+    const clock = await pool!.connect(); let authenticatedAt!: Date;
+    try {
+      const lower = (await clock.query<{ now: Date }>('SELECT NOW() AS "now"')).rows[0].now;
+      const result = await repo().resolveObservedRestoration(owner);
+      const upper = (await clock.query<{ now: Date }>('SELECT NOW() AS "now"')).rows[0].now;
+      if (result.status !== "resolved") throw new Error("Expected observed restoration");
+      authenticatedAt = result.evidence.authenticatedAt;
+      expect(authenticatedAt.getTime()).toBeGreaterThanOrEqual(lower.getTime());
+      expect(authenticatedAt.getTime()).toBeLessThanOrEqual(upper.getTime());
+    } finally { clock.release(); }
+    const resolved = (await pool!.query('SELECT "expiredEventId", "runId", "expiredAuditDeliveredAt", "restoredAuditDeliveredAt", "publicationState", "publicationClaimToken", "publicationFailureReportedAt", "consumerClaimToken", "consumerAttemptSource", "consumerAttemptState", "consumerLeaseExpiresAt", "terminalFailureReason", "terminalFailureReconciledAt", "updatedAt" FROM "BankSessionExpiryEpisode" WHERE "bankCode" = $1', [id.bankCode])).rows[0];
+    const { updatedAt: _beforeUpdatedAt, ...preserved } = before;
+    void _beforeUpdatedAt;
+    expect(resolved).toMatchObject({ ...preserved, consumerAttemptState: "resolved", consumerLeaseExpiresAt: null });
+    expect(resolved.updatedAt.getTime()).toBeGreaterThan(before.updatedAt.getTime());
+    await expect(repo().findExact({ identity: id })).resolves.toMatchObject({ status: "found", record: { status: "authenticated", ownerToken: null, leaseExpiresAt: null, generation: owner.generation + 1n, terminalAt: authenticatedAt } });
     await pool!.query('DELETE FROM "BankSessionExpiryEpisode" WHERE "bankCode" = $1', [id.bankCode]);
+    const failure = await lease("observed-publication-failure"); await episode(failure.id);
+    await pool!.query('UPDATE "BankSessionExpiryEpisode" SET "publicationState" = \'publishing\', "publicationClaimToken" = \'failed-publication\', "publicationFailureReportedAt" = NOW() - INTERVAL \'1 minute\', "expiredAuditDeliveredAt" = NOW() - INTERVAL \'3 minutes\', "restoredAuditDeliveredAt" = NOW() - INTERVAL \'2 minutes\', "updatedAt" = NOW() - INTERVAL \'4 minutes\' WHERE "bankCode" = $1', [failure.id.bankCode]);
+    const failedPublication = (await pool!.query('SELECT "expiredEventId", "runId", "expiredAuditDeliveredAt", "restoredAuditDeliveredAt", "publicationState", "publicationClaimToken", "publicationFailureReportedAt", "consumerClaimToken", "consumerAttemptSource", "consumerAttemptState", "consumerLeaseExpiresAt", "terminalFailureReason", "terminalFailureReconciledAt" FROM "BankSessionExpiryEpisode" WHERE "bankCode" = $1', [failure.id.bankCode])).rows[0];
+    await expect(repo().resolveObservedRestoration(failure.owner)).resolves.toMatchObject({ status: "resolved" });
+    await expect(pool!.query('SELECT "expiredEventId", "runId", "expiredAuditDeliveredAt", "restoredAuditDeliveredAt", "publicationState", "publicationClaimToken", "publicationFailureReportedAt", "consumerClaimToken", "consumerAttemptSource", "consumerAttemptState", "consumerLeaseExpiresAt", "terminalFailureReason", "terminalFailureReconciledAt" FROM "BankSessionExpiryEpisode" WHERE "bankCode" = $1', [failure.id.bankCode])).resolves.toMatchObject({ rows: [{ ...failedPublication, consumerAttemptState: "resolved", consumerLeaseExpiresAt: null }] });
+    // PostgreSQL permits terminal evidence only for published episodes, but a publication failure only for publishing episodes.
+    await pool!.query('DELETE FROM "BankSessionExpiryEpisode" WHERE "bankCode" = $1', [failure.id.bankCode]);
     const rollback = await lease("observed-rollback"); await episode(rollback.id);
     await pool!.query('CREATE FUNCTION fail_observed_episode() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION \'forced\'; END $$; CREATE TRIGGER fail_observed_episode BEFORE UPDATE ON "BankSessionExpiryEpisode" FOR EACH ROW EXECUTE FUNCTION fail_observed_episode()');
     await expect(repo().resolveObservedRestoration(rollback.owner)).rejects.toThrow("forced");
@@ -261,15 +282,19 @@ describe.skipIf(!url)("Session authentication attempt PostgreSQL contract", () =
     await expect(repo().findExact({ identity: rollback.id })).resolves.toMatchObject({ status: "found", record: { status: "active", ownerToken: rollback.owner.ownerToken, generation: rollback.owner.generation } });
   });
 
-  it("serializes concurrent resolvers and an overlapping close without partial terminalization", async () => {
+  it("serializes concurrent resolvers and close into only coherent durable states", async () => {
     const concurrent = await lease("observed-concurrent"); await episode(concurrent.id);
     const results = await Promise.all([repo().resolveObservedRestoration(concurrent.owner), repo().resolveObservedRestoration(concurrent.owner)]);
     expect(results.map(({ status }) => status).sort()).toEqual(["already_resolved", "resolved"]);
     await pool!.query('DELETE FROM "BankSessionExpiryEpisode" WHERE "bankCode" = $1', [concurrent.id.bankCode]);
     const closing = await lease("observed-close"); await episode(closing.id);
-    const [result] = await Promise.all([repo().resolveObservedRestoration(closing.owner), pool!.query('DELETE FROM "BankSessionExpiryEpisode" WHERE "bankCode" = $1 AND "runId" = $2', [closing.id.bankCode, closing.id.runId])]);
-    const attempt = await repo().findExact({ identity: closing.id });
-    expect(result.status === "resolved" ? attempt : result).not.toMatchObject({ status: "not_applied" });
+    const [result, closed] = await Promise.all([repo().resolveObservedRestoration(closing.owner), pool!.query('DELETE FROM "BankSessionExpiryEpisode" WHERE "bankCode" = $1 AND "runId" = $2 AND "expiredEventId" = $3 AND ("consumerAttemptState" IS NULL OR "consumerAttemptState" = \'resolved\')', [closing.id.bankCode, closing.id.runId, `expired-${closing.id.runId}`])]);
+    expect(result).toMatchObject({ status: "resolved" });
+    const attempt = (await pool!.query('SELECT "status", "ownerToken", "leaseExpiresAt", "generation" FROM "BankSessionAuthenticationAttempt" WHERE "bankCode" = $1 AND "runId" = $2', [closing.id.bankCode, closing.id.runId])).rows[0];
+    const finalEpisode = (await pool!.query('SELECT "consumerAttemptState", "consumerLeaseExpiresAt" FROM "BankSessionExpiryEpisode" WHERE "bankCode" = $1', [closing.id.bankCode])).rows[0];
+    expect(attempt).toMatchObject({ status: "authenticated", ownerToken: null, leaseExpiresAt: null, generation: String(closing.owner.generation + 1n) });
+    if (closed.rowCount === 1) expect(finalEpisode).toBeUndefined();
+    else expect(finalEpisode).toEqual({ consumerAttemptState: "resolved", consumerLeaseExpiresAt: null });
   });
 
   it.each([

--- a/src/modules/persistence/session-authentication-attempt.postgres.test.ts
+++ b/src/modules/persistence/session-authentication-attempt.postgres.test.ts
@@ -12,6 +12,7 @@ const attemptIdentity = (name: string, attemptId = "attempt") => ({ bankCode: "a
 
 describe.skipIf(!url)("Session authentication attempt PostgreSQL contract", () => {
   beforeEach(async () => {
+    await pool!.query('DELETE FROM "BankSessionExpiryEpisode" WHERE "bankCode" LIKE \'auth-contract-%\'');
     await pool!.query('DELETE FROM "BankSessionAuthenticationAttempt" WHERE "bankCode" LIKE \'auth-contract-%\'');
     await pool!.query('DELETE FROM "Bank" WHERE "code" LIKE \'auth-contract-%\'');
     await pool!.query('INSERT INTO "Bank" ("id", "code", "name", "updatedAt") VALUES ($1, $2, $3, NOW())', ["auth-contract-bank-id", "auth-contract-bank", "Authentication contract bank"]);
@@ -36,6 +37,10 @@ describe.skipIf(!url)("Session authentication attempt PostgreSQL contract", () =
     await pool!.query('INSERT INTO "Bank" ("id", "code", "name", "updatedAt") VALUES ($1, $2, $3, NOW())', [`${bankCode}-id`, bankCode, bankCode]);
   }
   async function expire(id: ReturnType<typeof attemptIdentity>) { await pool!.query('UPDATE "BankSessionAuthenticationAttempt" SET "leaseExpiresAt" = NOW() WHERE "bankCode" = $1 AND "runId" = $2 AND "attemptId" = $3', [id.bankCode, id.runId, id.attemptId]); }
+  async function episode(id: ReturnType<typeof attemptIdentity>, state = "manual_recovery_required", lease = "NOW() - INTERVAL '1 second'") {
+    const mutation = state === "mutation_started";
+    await pool!.query(`INSERT INTO "BankSessionExpiryEpisode" ("bankCode", "expiredEventId", "runId", "publicationState", "publicationClaimToken", "consumerClaimToken", "consumerAttemptState", "consumerAttemptSource", "consumerLeaseExpiresAt", "updatedAt") VALUES ($1, $2, $3, ${mutation ? "'published', 'publication'" : "'pending', NULL"}, 'consumer', $4, ${mutation && lease !== "NULL" ? "'scheduled'" : "NULL"}, ${mutation ? lease : "NULL"}, NOW())`, [id.bankCode, `expired-${id.runId}`, id.runId, state]);
+  }
   function diagnosticRow(record: SessionAuthenticationAttemptRecord) {
     return {
       bankCode: record.identity.bankCode, runId: record.identity.runId, attemptId: record.identity.attemptId,
@@ -190,6 +195,81 @@ describe.skipIf(!url)("Session authentication attempt PostgreSQL contract", () =
       expect(reconciled).toMatchObject(phase === "no" ? { status: "lease_reconciled", record: { retryCount: 1, status: "active" } } : { status: "lease_reconciled", record: { status: "failed", failureClass: "interaction_outcome_uncertain" } });
       await expect(repo().completeAuthenticated({ owner: current.owner })).resolves.toMatchObject({ status: phase === "no" ? "stale_owner" : "terminal" });
     }
+  });
+
+  it.each(["no_credential_interaction", "credentials_may_have_reached_portal", "submit_may_have_been_dispatched"])("resolves manual recovery while preserving %s", async (phase) => {
+    const { id, owner } = await lease(`observed-${phase}`); await episode(id);
+    if (phase !== "no_credential_interaction") await repo().beginCredentialInteraction({ owner });
+    if (phase === "submit_may_have_been_dispatched") await repo().recordSubmitBarrier({ owner });
+    await expect(repo().resolveObservedRestoration(owner)).resolves.toMatchObject({ status: "resolved" });
+    await expect(repo().findExact({ identity: id })).resolves.toMatchObject({ status: "found", record: { status: "authenticated", interactionPhase: phase, ownerToken: null, leaseExpiresAt: null, generation: owner.generation + 1n } });
+    await expect(pool!.query('SELECT "consumerAttemptState", "consumerLeaseExpiresAt" FROM "BankSessionExpiryEpisode" WHERE "bankCode" = $1', [id.bankCode])).resolves.toMatchObject({ rows: [{ consumerAttemptState: "resolved", consumerLeaseExpiresAt: null }] });
+  });
+
+  it.each([
+    ["expired mutation lease", "mutation_started", "NOW() - INTERVAL '1 second'", "resolved"],
+    ["active mutation lease", "mutation_started", "NOW() + INTERVAL '1 hour'", "active_mutation_owner"],
+    ["legacy mutation", "mutation_started", "NULL", "active_mutation_owner"],
+    ["reserved episode", "reserved", "NULL", "episode_not_resolvable"],
+  ])("classifies %s", async (_name, state, expiry, status) => {
+    const { id, owner } = await lease(`observed-${status}-${expiry === "NULL"}`); await episode(id, state, expiry);
+    await expect(repo().resolveObservedRestoration(owner)).resolves.toMatchObject({ status });
+  });
+
+  it.each([
+    ["wrong owner", async (_id: ReturnType<typeof attemptIdentity>, owner: Awaited<ReturnType<typeof lease>>["owner"]) => ({ ...owner, ownerToken: "wrong" }), "stale_owner"],
+    ["stale generation", async (_id: ReturnType<typeof attemptIdentity>, owner: Awaited<ReturnType<typeof lease>>["owner"]) => ({ ...owner, generation: owner.generation + 1n }), "stale_owner"],
+    ["expired auth lease", async (id: ReturnType<typeof attemptIdentity>, owner: Awaited<ReturnType<typeof lease>>["owner"]) => { await expire(id); return owner; }, "lease_expired"],
+  ])("rejects %s", async (_name, change, status) => {
+    const { id, owner } = await lease(`observed-${status}-${_name}`); await episode(id);
+    await expect(repo().resolveObservedRestoration(await change(id, owner))).resolves.toMatchObject({ status });
+  });
+
+  it("fails closed for missing and mismatched durable identities", async () => {
+    const { id, owner } = await lease("observed-identities"); await episode(id);
+    await expect(repo().resolveObservedRestoration({ ...owner, identity: { ...id, attemptId: "other" } })).resolves.toEqual({ status: "identity_mismatch" });
+    await pool!.query('UPDATE "BankSessionExpiryEpisode" SET "runId" = $2 WHERE "bankCode" = $1', [id.bankCode, "replacement"]);
+    await expect(repo().resolveObservedRestoration(owner)).resolves.toEqual({ status: "identity_mismatch" });
+    await expect(repo().resolveObservedRestoration({ ...owner, identity: { ...id, runId: "missing" } })).resolves.toEqual({ status: "missing", missing: "authentication_attempt" });
+    await pool!.query('DELETE FROM "BankSessionExpiryEpisode" WHERE "bankCode" = $1', [id.bankCode]);
+    await expect(repo().resolveObservedRestoration(owner)).resolves.toEqual({ status: "missing", missing: "expiry_episode" });
+  });
+
+  it("classifies terminal attempts and supports only exact resolved idempotence", async () => {
+    const failed = await lease("observed-failed"); await episode(failed.id); await repo().completeFailed({ owner: failed.owner, failureClass: "transient_pre_interaction", operatorReason: "temporary_authentication_problem" });
+    await expect(repo().resolveObservedRestoration(failed.owner)).resolves.toEqual({ status: "terminal_conflict" });
+    await pool!.query('DELETE FROM "BankSessionExpiryEpisode" WHERE "bankCode" = $1', [failed.id.bankCode]);
+    const resolved = await lease("observed-resolved"); await episode(resolved.id); await repo().resolveObservedRestoration(resolved.owner);
+    await expect(repo().resolveObservedRestoration(resolved.owner)).resolves.toEqual({ status: "already_resolved" });
+    await pool!.query('DELETE FROM "BankSessionExpiryEpisode" WHERE "bankCode" = $1', [resolved.id.bankCode]);
+    await expect(repo().resolveObservedRestoration(resolved.owner)).resolves.toEqual({ status: "already_resolved" });
+    const conflict = await lease("observed-terminal-conflict"); await episode(conflict.id); await repo().completeAuthenticated({ owner: conflict.owner });
+    await expect(repo().resolveObservedRestoration(conflict.owner)).resolves.toEqual({ status: "terminal_conflict" });
+  });
+
+  it("uses database time, preserves episode evidence, and rolls back on an episode write failure", async () => {
+    const { id, owner } = await lease("observed-evidence"); await episode(id, "mutation_started");
+    const before = await pool!.query('SELECT "expiredEventId", "publicationClaimToken", "consumerClaimToken", "consumerAttemptSource" FROM "BankSessionExpiryEpisode" WHERE "bankCode" = $1', [id.bankCode]);
+    const result = await repo().resolveObservedRestoration(owner);
+    expect(result).toMatchObject({ status: "resolved", evidence: { authenticatedAt: expect.any(Date) } });
+    await expect(pool!.query('SELECT "expiredEventId", "publicationClaimToken", "consumerClaimToken", "consumerAttemptSource", "consumerAttemptState", "consumerLeaseExpiresAt" FROM "BankSessionExpiryEpisode" WHERE "bankCode" = $1', [id.bankCode])).resolves.toMatchObject({ rows: [{ ...before.rows[0], consumerAttemptState: "resolved", consumerLeaseExpiresAt: null }] });
+    await pool!.query('DELETE FROM "BankSessionExpiryEpisode" WHERE "bankCode" = $1', [id.bankCode]);
+    const rollback = await lease("observed-rollback"); await episode(rollback.id);
+    await pool!.query('CREATE FUNCTION fail_observed_episode() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION \'forced\'; END $$; CREATE TRIGGER fail_observed_episode BEFORE UPDATE ON "BankSessionExpiryEpisode" FOR EACH ROW EXECUTE FUNCTION fail_observed_episode()');
+    await expect(repo().resolveObservedRestoration(rollback.owner)).rejects.toThrow("forced");
+    await pool!.query('DROP TRIGGER fail_observed_episode ON "BankSessionExpiryEpisode"; DROP FUNCTION fail_observed_episode()');
+    await expect(repo().findExact({ identity: rollback.id })).resolves.toMatchObject({ status: "found", record: { status: "active", ownerToken: rollback.owner.ownerToken, generation: rollback.owner.generation } });
+  });
+
+  it("serializes concurrent resolvers and an overlapping close without partial terminalization", async () => {
+    const concurrent = await lease("observed-concurrent"); await episode(concurrent.id);
+    const results = await Promise.all([repo().resolveObservedRestoration(concurrent.owner), repo().resolveObservedRestoration(concurrent.owner)]);
+    expect(results.map(({ status }) => status).sort()).toEqual(["already_resolved", "resolved"]);
+    await pool!.query('DELETE FROM "BankSessionExpiryEpisode" WHERE "bankCode" = $1', [concurrent.id.bankCode]);
+    const closing = await lease("observed-close"); await episode(closing.id);
+    const [result] = await Promise.all([repo().resolveObservedRestoration(closing.owner), pool!.query('DELETE FROM "BankSessionExpiryEpisode" WHERE "bankCode" = $1 AND "runId" = $2', [closing.id.bankCode, closing.id.runId])]);
+    const attempt = await repo().findExact({ identity: closing.id });
+    expect(result.status === "resolved" ? attempt : result).not.toMatchObject({ status: "not_applied" });
   });
 
   it.each([


### PR DESCRIPTION
## Summary

Closes #80

The exact live authentication owner can atomically terminalize an attempt as authenticated and resolve its matching recoverable expiry episode. #67 and #69 are related follow-up context only.

## Invariant and transaction

- Runs in a Serializable Prisma transaction and locks the authentication attempt before the expiry episode.
- Uses the database clock for lease and terminal timestamps.
- Requires an exact bank, run, attempt, owner, and generation match.
- Does not displace an active or unprovable mutation owner; both writes commit or roll back together.

## Eligible states

| State | Result |
|---|---|
| `manual_recovery_required` | Eligible for authenticated terminalization and matching episode resolution. |
| `expired` leased `mutation_started` | Eligible for the same atomic restoration. |
| Active or unleased mutation owner | Fails closed. |

## Idempotency and conflicts

- Exact `authenticated` plus resolved/deleted state returns `already_resolved`.
- `authenticated` plus unresolved state returns `terminal_conflict`.
- Identity, stale-generation, missing-record, and lease outcomes are preserved.

## Evidence preservation

The expiry episode is not deleted. Existing audit and close ordering remains owned by the existing owner. Maximal legal evidence sets are tested separately because publication-failure and terminal-failure constraints cannot coexist.

## Inertness

There are zero production consumers. Coordinator wiring, pre-click integration, runtime activation, legacy recover/recollect neutralization, and worker, queue, browser, API, and UI work are future slices and out of scope.

## Review path

1. Contract in `session-authentication-attempt-repository.ts`
2. Serializable Prisma transaction in `prisma-bank-session-authentication-attempt-repository.ts`
3. PostgreSQL race and rollback proofs in `session-authentication-attempt.postgres.test.ts`

## Changes

| File | Change |
|---|---|
| `src/modules/bank-sessions/session-authentication-attempt-repository.ts` | Adds the atomic observed-restoration repository contract. |
| `src/modules/bank-sessions/session-authentication-attempt-repository.test.ts` | Covers repository contract behavior and outcomes. |
| `src/modules/persistence/prisma-bank-session-authentication-attempt-repository.ts` | Implements serializable, ordered-lock terminalization and expiry resolution. |
| `src/modules/persistence/session-authentication-attempt.postgres.test.ts` | Proves PostgreSQL races, rollback, and evidence preservation. |

## Change budget

190 changed lines: 188 additions and 2 deletions. This is within the 400-line budget; no size exception is requested.

## Verification

- PostgreSQL 16 fresh database: all 16 migrations applied; 36/36 database tests passed.
- Pure tests: 28/28 passed.
- Full suite: 1,394 passed and 2 skipped.
- `pnpm lint`, `pnpm typecheck`, Prisma validation, and `git diff --check` passed.
- This repository has no CI workflow. Zero checks are expected; this PR relies on local evidence and does not claim CI is green.

## Rollback

Revert commits `663a99b` and `cf7b649` (the four files above). No schema or runtime state changed.

## Commits

- `663a99b feat(bank-sessions): resolve observed restoration atomically` - behavior
- `cf7b649 test(bank-sessions): strengthen restoration transaction proofs` - proof strengthening