### PR TITLE
feat(bank-sessions): coordinate authenticated session state

### DIFF
--- a/src/modules/bank-sessions/ensure-authenticated-session.test.ts
+++ b/src/modules/bank-sessions/ensure-authenticated-session.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from "vitest";
+import { coordinateAuthenticatedSessionState, type AuthenticatedSessionCoordinatorDependencies } from "./ensure-authenticated-session";
+import type { SessionAuthenticationAttemptRecord } from "./session-authentication-attempt-repository";
+
+const identity = { bankCode: "popular", runId: "run-1", attemptId: "attempt-1" };
+const owner = { identity, ownerToken: "db-owner", generation: 1n };
+const fields = () => ({ identity, interactionPhase: "no_credential_interaction" as const, retryCount: 0, generation: 0n, createdAt: new Date(), updatedAt: new Date() });
+const active = (): SessionAuthenticationAttemptRecord => ({ ...fields(), status: "active", ownerToken: null, leaseExpiresAt: null, failureClass: null, operatorReason: null, terminalAt: null });
+const owned = (): SessionAuthenticationAttemptRecord => ({ ...fields(), status: "active", ownerToken: "other", leaseExpiresAt: new Date(), failureClass: null, operatorReason: null, terminalAt: null });
+const authenticated = (): SessionAuthenticationAttemptRecord => ({ ...fields(), status: "authenticated", ownerToken: null, leaseExpiresAt: null, failureClass: null, operatorReason: null, terminalAt: new Date() });
+function failed(operatorReason: "temporary_authentication_problem" | "protected_authentication_step_detected" | "bank_login_configuration_requires_review" | "authentication_attempt_requires_review"): SessionAuthenticationAttemptRecord {
+  if (operatorReason === "temporary_authentication_problem") return { ...fields(), status: "failed", ownerToken: null, leaseExpiresAt: null, terminalAt: new Date(), operatorReason, failureClass: "transient_pre_interaction" };
+  if (operatorReason === "protected_authentication_step_detected") return { ...fields(), status: "failed", ownerToken: null, leaseExpiresAt: null, terminalAt: new Date(), operatorReason, failureClass: "protected_or_mfa" };
+  if (operatorReason === "bank_login_configuration_requires_review") return { ...fields(), status: "failed", ownerToken: null, leaseExpiresAt: null, terminalAt: new Date(), operatorReason, failureClass: "incompatible_flow" };
+  return { ...fields(), status: "failed", ownerToken: null, leaseExpiresAt: null, terminalAt: new Date(), operatorReason, failureClass: "ownership_lost" };
+}
+
+function setup(overrides: Partial<AuthenticatedSessionCoordinatorDependencies> = {}) {
+  const attempts = {
+    getOrCreate: vi.fn().mockResolvedValue({ status: "found", record: active() }),
+    findExact: vi.fn().mockResolvedValue({ status: "missing" }),
+    acquireLease: vi.fn().mockResolvedValue({ status: "lease_acquired", owner, record: owned() }),
+    reconcileExpiredLease: vi.fn().mockResolvedValue({ status: "unowned", record: active() }),
+    completeAuthenticated: vi.fn().mockResolvedValue({ status: "authenticated", record: authenticated() }),
+  };
+  const probe = { observe: vi.fn().mockResolvedValue({ status: "authenticated", observedAt: new Date() }) };
+  const resolver = { resolveObservedRestoration: vi.fn().mockResolvedValue({ status: "resolved", evidence: { authenticatedAt: new Date() } }) };
+  return { attempts, probe, resolver, dependencies: { attempts, probe, completion: { mode: "attempt_only" }, ...overrides } as AuthenticatedSessionCoordinatorDependencies };
+}
+function coordinate(dependencies: AuthenticatedSessionCoordinatorDependencies, input = {}) { return coordinateAuthenticatedSessionState({ identity, ownerToken: "caller-owner", leaseDurationMs: 1_000, ...input }, dependencies); }
+
+describe("coordinateAuthenticatedSessionState", () => {
+  it.each([{ identity: { ...identity, bankCode: " " } }, { ownerToken: " " }, { leaseDurationMs: 0 }, { leaseDurationMs: 1.5 }])("rejects invalid durable input without dependencies: %#", async (input) => {
+    const { attempts, probe, dependencies } = setup();
+    await expect(coordinate(dependencies, input)).resolves.toEqual({ status: "invalid_request" });
+    expect(attempts.getOrCreate).not.toHaveBeenCalled(); expect(probe.observe).not.toHaveBeenCalled();
+  });
+
+  it("returns cancelled before dependencies for an aborted signal", async () => {
+    const controller = new AbortController(); controller.abort(); const { attempts, dependencies } = setup();
+    await expect(coordinate(dependencies, { signal: controller.signal })).resolves.toEqual({ status: "cancelled" }); expect(attempts.getOrCreate).not.toHaveBeenCalled();
+  });
+  it("maps terminal records without probing", async () => {
+    const { attempts, probe, dependencies } = setup(); attempts.getOrCreate.mockResolvedValueOnce({ status: "found", record: authenticated() });
+    await expect(coordinate(dependencies)).resolves.toEqual({ status: "authenticated", source: "existing" }); expect(probe.observe).not.toHaveBeenCalled();
+  });
+  it.each(["temporary_authentication_problem", "protected_authentication_step_detected", "bank_login_configuration_requires_review", "authentication_attempt_requires_review"] as const)("maps durable failure %s safely", async (reason) => {
+    const { attempts, dependencies } = setup(); attempts.getOrCreate.mockResolvedValueOnce({ status: "found", record: failed(reason) });
+    await expect(coordinate(dependencies)).resolves.toEqual({ status: "needs_operator_action", reason });
+  });
+  it("hides identity-conflict attempt IDs", async () => {
+    const { attempts, dependencies } = setup(); attempts.getOrCreate.mockResolvedValueOnce({ status: "identity_conflict", existingAttemptId: "conflicting-attempt-id" });
+    const result = await coordinate(dependencies); expect(result).toEqual({ status: "needs_operator_action", reason: "identity_conflict" }); expect(JSON.stringify(result)).not.toContain("conflicting-attempt-id");
+  });
+  it("requires authentication without leasing or retrying when unowned probe is unauthenticated", async () => {
+    const { attempts, probe, dependencies } = setup(); probe.observe.mockResolvedValueOnce({ status: "unauthenticated" });
+    await expect(coordinate(dependencies)).resolves.toEqual({ status: "authentication_required" }); expect(attempts.acquireLease).not.toHaveBeenCalled(); expect("claimRetry" in attempts).toBe(false);
+  });
+  it.each(["unavailable", "throws"] as const)("maps probe %s to a safe retry", async (outcome) => {
+    const { probe, dependencies } = setup();
+    if (outcome === "throws") probe.observe.mockRejectedValueOnce(new Error("internal")); else probe.observe.mockResolvedValueOnce({ status: "unavailable" });
+    await expect(coordinate(dependencies)).resolves.toEqual({ status: "retry_later", reason: "session_probe_unavailable" });
+  });
+  it("cancels when the caller aborts during probing", async () => {
+    const controller = new AbortController(); const { probe, attempts, dependencies } = setup(); probe.observe.mockImplementationOnce(async () => { controller.abort(); return { status: "authenticated", observedAt: new Date() }; });
+    await expect(coordinate(dependencies, { signal: controller.signal })).resolves.toEqual({ status: "cancelled" }); expect(attempts.acquireLease).not.toHaveBeenCalled();
+  });
+  it("classifies an owned active attempt from the lease path without probing", async () => {
+    const { attempts, probe, dependencies } = setup(); attempts.getOrCreate.mockResolvedValueOnce({ status: "found", record: owned() }); attempts.acquireLease.mockResolvedValueOnce({ status: "lease_held", record: owned() });
+    await expect(coordinate(dependencies)).resolves.toEqual({ status: "in_progress", reason: "lease_held" }); expect(probe.observe).not.toHaveBeenCalled();
+  });
+  it("closes observed authentication in attempt-only mode", async () => {
+    const { attempts, dependencies } = setup(); await expect(coordinate(dependencies)).resolves.toEqual({ status: "authenticated", source: "observed" }); expect(attempts.completeAuthenticated).toHaveBeenCalledWith({ owner });
+  });
+  it("allows only the lease owner to complete concurrent observations", async () => {
+    const { attempts, dependencies } = setup(); attempts.acquireLease.mockResolvedValueOnce({ status: "lease_acquired", owner, record: owned() }).mockResolvedValueOnce({ status: "lease_held", record: owned() });
+    const results = await Promise.all([coordinate(dependencies), coordinate(dependencies)]); expect(results).toContainEqual({ status: "authenticated", source: "observed" }); expect(attempts.completeAuthenticated).toHaveBeenCalledTimes(1);
+  });
+  it("reconciles once, then re-probes unowned state before reacquiring", async () => {
+    const { attempts, probe, dependencies } = setup(); attempts.acquireLease.mockResolvedValueOnce({ status: "reconciliation_required", record: owned() });
+    await expect(coordinate(dependencies)).resolves.toEqual({ status: "authenticated", source: "observed" }); expect(attempts.reconcileExpiredLease).toHaveBeenCalledTimes(1); expect(probe.observe).toHaveBeenCalledTimes(2); expect(attempts.acquireLease).toHaveBeenCalledTimes(2);
+  });
+  it("maps reconciled terminal state without reacquiring", async () => {
+    const { attempts, dependencies } = setup(); attempts.acquireLease.mockResolvedValueOnce({ status: "reconciliation_required", record: owned() }); attempts.reconcileExpiredLease.mockResolvedValueOnce({ status: "terminal", record: authenticated() });
+    await expect(coordinate(dependencies)).resolves.toEqual({ status: "authenticated", source: "existing" }); expect(attempts.acquireLease).toHaveBeenCalledTimes(1);
+  });
+  it.each(["stale_owner", "lease_expired", "not_applied"] as const)("maps completion %s without a second close", async (status) => {
+    const { attempts, dependencies } = setup(); attempts.completeAuthenticated.mockResolvedValueOnce({ status });
+    await expect(coordinate(dependencies)).resolves.toEqual({ status: "retry_later", reason: "ownership_changed" }); expect(attempts.completeAuthenticated).toHaveBeenCalledTimes(1);
+  });
+  it.each(["missing", "not_applied"] as const)("refetches acquire race %s and maps its terminal state", async (status) => {
+    const { attempts, dependencies } = setup(); attempts.acquireLease.mockResolvedValueOnce({ status }); attempts.findExact.mockResolvedValueOnce({ status: "found", record: authenticated() });
+    await expect(coordinate(dependencies)).resolves.toEqual({ status: "authenticated", source: "existing" }); expect(attempts.findExact).toHaveBeenCalledTimes(1);
+  });
+  it.each(["resolved", "already_resolved"] as const)("uses only resolver for expiry restoration %s", async (status) => {
+    const { attempts, resolver, dependencies: base } = setup(); const dependencies = { ...base, completion: { mode: "expiry_restoration" as const, resolver } }; resolver.resolveObservedRestoration.mockResolvedValueOnce(status === "resolved" ? { status, evidence: { authenticatedAt: new Date() } } : { status });
+    await expect(coordinate(dependencies)).resolves.toEqual({ status: "authenticated", source: "observed" }); expect(resolver.resolveObservedRestoration).toHaveBeenCalledWith(owner); expect(attempts.completeAuthenticated).not.toHaveBeenCalled();
+  });
+  it.each(["active_mutation_owner", "missing", "identity_mismatch", "episode_not_resolvable", "terminal_conflict"] as const)("maps expiry resolver %s safely without fallback", async (status) => {
+    const { attempts, resolver, dependencies: base } = setup(); const dependencies = { ...base, completion: { mode: "expiry_restoration" as const, resolver } }; resolver.resolveObservedRestoration.mockResolvedValueOnce(status === "missing" ? { status, missing: "expiry_episode" } : { status });
+    const expected = status === "active_mutation_owner" ? { status: "in_progress", reason: "active_mutation_owner" } : { status: "needs_operator_action", reason: "restoration_state_conflict" };
+    await expect(coordinate(dependencies)).resolves.toEqual(expected); expect(attempts.completeAuthenticated).not.toHaveBeenCalled();
+  });
+  it("completes after acquisition even when the caller cancels", async () => {
+    const controller = new AbortController(); const { attempts, dependencies } = setup(); attempts.acquireLease.mockImplementationOnce(async () => { controller.abort(); return { status: "lease_acquired", owner, record: owned() }; });
+    await expect(coordinate(dependencies, { signal: controller.signal })).resolves.toEqual({ status: "authenticated", source: "observed" }); expect(attempts.completeAuthenticated).toHaveBeenCalledTimes(1);
+  });
+  it("declares only the narrow repository operation surface", () => {
+    const { attempts } = setup(); expect(Object.keys(attempts).sort()).toEqual(["acquireLease", "completeAuthenticated", "findExact", "getOrCreate", "reconcileExpiredLease"]);
+  });
+});

--- a/src/modules/bank-sessions/ensure-authenticated-session.test.ts
+++ b/src/modules/bank-sessions/ensure-authenticated-session.test.ts
@@ -28,6 +28,9 @@ function setup(overrides: Partial<AuthenticatedSessionCoordinatorDependencies> =
   return { attempts, probe, resolver, dependencies: { attempts, probe, completion: { mode: "attempt_only" }, ...overrides } as AuthenticatedSessionCoordinatorDependencies };
 }
 function coordinate(dependencies: AuthenticatedSessionCoordinatorDependencies, input = {}) { return coordinateAuthenticatedSessionState({ identity, ownerToken: "caller-owner", leaseDurationMs: 1_000, ...input }, dependencies); }
+function expectNoDurableMutation(attempts: ReturnType<typeof setup>["attempts"], resolver: ReturnType<typeof setup>["resolver"]) {
+  expect(attempts.getOrCreate).not.toHaveBeenCalled(); expect(attempts.acquireLease).not.toHaveBeenCalled(); expect(attempts.reconcileExpiredLease).not.toHaveBeenCalled(); expect(attempts.completeAuthenticated).not.toHaveBeenCalled(); expect(resolver.resolveObservedRestoration).not.toHaveBeenCalled();
+}
 
 describe("coordinateAuthenticatedSessionState", () => {
   it.each([{ identity: { ...identity, bankCode: " " } }, { ownerToken: " " }, { leaseDurationMs: 0 }, { leaseDurationMs: 1.5 }])("rejects invalid durable input without dependencies: %#", async (input) => {
@@ -41,11 +44,11 @@ describe("coordinateAuthenticatedSessionState", () => {
     await expect(coordinate(dependencies, { signal: controller.signal })).resolves.toEqual({ status: "cancelled" }); expect(attempts.getOrCreate).not.toHaveBeenCalled();
   });
   it("maps terminal records without probing", async () => {
-    const { attempts, probe, dependencies } = setup(); attempts.getOrCreate.mockResolvedValueOnce({ status: "found", record: authenticated() });
+    const { attempts, probe, dependencies } = setup(); attempts.findExact.mockResolvedValueOnce({ status: "found", record: authenticated() });
     await expect(coordinate(dependencies)).resolves.toEqual({ status: "authenticated", source: "existing" }); expect(probe.observe).not.toHaveBeenCalled();
   });
   it.each(["temporary_authentication_problem", "protected_authentication_step_detected", "bank_login_configuration_requires_review", "authentication_attempt_requires_review"] as const)("maps durable failure %s safely", async (reason) => {
-    const { attempts, dependencies } = setup(); attempts.getOrCreate.mockResolvedValueOnce({ status: "found", record: failed(reason) });
+    const { attempts, dependencies } = setup(); attempts.findExact.mockResolvedValueOnce({ status: "found", record: failed(reason) });
     await expect(coordinate(dependencies)).resolves.toEqual({ status: "needs_operator_action", reason });
   });
   it("hides identity-conflict attempt IDs", async () => {
@@ -53,24 +56,39 @@ describe("coordinateAuthenticatedSessionState", () => {
     const result = await coordinate(dependencies); expect(result).toEqual({ status: "needs_operator_action", reason: "identity_conflict" }); expect(JSON.stringify(result)).not.toContain("conflicting-attempt-id");
   });
   it("requires authentication without leasing or retrying when unowned probe is unauthenticated", async () => {
-    const { attempts, probe, dependencies } = setup(); probe.observe.mockResolvedValueOnce({ status: "unauthenticated" });
-    await expect(coordinate(dependencies)).resolves.toEqual({ status: "authentication_required" }); expect(attempts.acquireLease).not.toHaveBeenCalled(); expect("claimRetry" in attempts).toBe(false);
+    const { attempts, probe, resolver, dependencies } = setup(); probe.observe.mockResolvedValueOnce({ status: "unauthenticated" });
+    await expect(coordinate(dependencies)).resolves.toEqual({ status: "authentication_required" }); expectNoDurableMutation(attempts, resolver); expect("claimRetry" in attempts).toBe(false);
   });
   it.each(["unavailable", "throws"] as const)("maps probe %s to a safe retry", async (outcome) => {
-    const { probe, dependencies } = setup();
+    const { attempts, probe, resolver, dependencies } = setup();
     if (outcome === "throws") probe.observe.mockRejectedValueOnce(new Error("internal")); else probe.observe.mockResolvedValueOnce({ status: "unavailable" });
-    await expect(coordinate(dependencies)).resolves.toEqual({ status: "retry_later", reason: "session_probe_unavailable" });
+    await expect(coordinate(dependencies)).resolves.toEqual({ status: "retry_later", reason: "session_probe_unavailable" }); expectNoDurableMutation(attempts, resolver);
   });
   it("cancels when the caller aborts during probing", async () => {
-    const controller = new AbortController(); const { probe, attempts, dependencies } = setup(); probe.observe.mockImplementationOnce(async () => { controller.abort(); return { status: "authenticated", observedAt: new Date() }; });
-    await expect(coordinate(dependencies, { signal: controller.signal })).resolves.toEqual({ status: "cancelled" }); expect(attempts.acquireLease).not.toHaveBeenCalled();
+    const controller = new AbortController(); const { probe, attempts, resolver, dependencies } = setup(); probe.observe.mockImplementationOnce(async () => { controller.abort(); return { status: "authenticated", observedAt: new Date() }; });
+    await expect(coordinate(dependencies, { signal: controller.signal })).resolves.toEqual({ status: "cancelled" }); expectNoDurableMutation(attempts, resolver);
+  });
+  it.each([
+    { label: "created active", created: { status: "created", record: active() }, expected: { status: "authenticated", source: "observed" } },
+    { label: "concurrently active", created: { status: "found", record: active() }, expected: { status: "authenticated", source: "observed" } },
+    { label: "concurrently authenticated", created: { status: "found", record: authenticated() }, expected: { status: "authenticated", source: "existing" } },
+    { label: "concurrently failed", created: { status: "found", record: failed("temporary_authentication_problem") }, expected: { status: "needs_operator_action", reason: "temporary_authentication_problem" } },
+    { label: "identity conflict", created: { status: "identity_conflict", existingAttemptId: "other" }, expected: { status: "needs_operator_action", reason: "identity_conflict" } },
+  ])("probes before getOrCreate and safely maps missing $label races", async ({ created, expected }) => {
+    const { attempts, probe, dependencies } = setup(); attempts.getOrCreate.mockResolvedValueOnce(created);
+    await expect(coordinate(dependencies)).resolves.toEqual(expected); expect(probe.observe.mock.invocationCallOrder[0]).toBeLessThan(attempts.getOrCreate.mock.invocationCallOrder[0]);
+  });
+  it("classifies a concurrently owned getOrCreate result without a second probe", async () => {
+    const { attempts, probe, dependencies } = setup(); attempts.getOrCreate.mockResolvedValueOnce({ status: "found", record: owned() }); attempts.acquireLease.mockResolvedValueOnce({ status: "lease_held", record: owned() });
+    await expect(coordinate(dependencies)).resolves.toEqual({ status: "in_progress", reason: "lease_held" }); expect(probe.observe).toHaveBeenCalledTimes(1);
   });
   it("classifies an owned active attempt from the lease path without probing", async () => {
-    const { attempts, probe, dependencies } = setup(); attempts.getOrCreate.mockResolvedValueOnce({ status: "found", record: owned() }); attempts.acquireLease.mockResolvedValueOnce({ status: "lease_held", record: owned() });
+    const { attempts, probe, dependencies } = setup(); attempts.findExact.mockResolvedValueOnce({ status: "found", record: owned() }); attempts.acquireLease.mockResolvedValueOnce({ status: "lease_held", record: owned() });
     await expect(coordinate(dependencies)).resolves.toEqual({ status: "in_progress", reason: "lease_held" }); expect(probe.observe).not.toHaveBeenCalled();
   });
   it("closes observed authentication in attempt-only mode", async () => {
-    const { attempts, dependencies } = setup(); await expect(coordinate(dependencies)).resolves.toEqual({ status: "authenticated", source: "observed" }); expect(attempts.completeAuthenticated).toHaveBeenCalledWith({ owner });
+    const { attempts, dependencies } = setup(); attempts.findExact.mockResolvedValueOnce({ status: "found", record: active() });
+    await expect(coordinate(dependencies)).resolves.toEqual({ status: "authenticated", source: "observed" }); expect(attempts.getOrCreate).not.toHaveBeenCalled(); expect(attempts.completeAuthenticated).toHaveBeenCalledWith({ owner });
   });
   it("allows only the lease owner to complete concurrent observations", async () => {
     const { attempts, dependencies } = setup(); attempts.acquireLease.mockResolvedValueOnce({ status: "lease_acquired", owner, record: owned() }).mockResolvedValueOnce({ status: "lease_held", record: owned() });

--- a/src/modules/bank-sessions/ensure-authenticated-session.ts
+++ b/src/modules/bank-sessions/ensure-authenticated-session.ts
@@ -1,0 +1,98 @@
+import type {
+  ObservedRestorationResolver,
+  SessionAuthenticationAttemptRecord,
+  SessionAuthenticationAttemptRepository,
+} from "./session-authentication-attempt-repository";
+import type { SessionAuthenticationAttemptIdentity, SessionAuthenticationOperatorReason } from "./session-authentication-attempt";
+
+export interface AuthenticatedSessionProbe {
+  observe(input: Readonly<{ bankCode: string; signal?: AbortSignal }>): Promise<
+    | Readonly<{ status: "authenticated"; observedAt: Date }>
+    | Readonly<{ status: "unauthenticated" }>
+    | Readonly<{ status: "unavailable" }>
+  >;
+}
+
+type Attempts = Pick<SessionAuthenticationAttemptRepository, "getOrCreate" | "findExact" | "acquireLease" | "reconcileExpiredLease" | "completeAuthenticated">;
+export type AuthenticatedSessionCompletion =
+  | Readonly<{ mode: "attempt_only" }>
+  | Readonly<{ mode: "expiry_restoration"; resolver: ObservedRestorationResolver }>;
+export type AuthenticatedSessionCoordinatorDependencies = Readonly<{ attempts: Attempts; probe: AuthenticatedSessionProbe; completion: AuthenticatedSessionCompletion }>;
+export type CoordinateAuthenticatedSessionStateInput = Readonly<{ identity: SessionAuthenticationAttemptIdentity; ownerToken: string; leaseDurationMs: number; signal?: AbortSignal }>;
+export type AuthenticatedSessionState =
+  | Readonly<{ status: "authenticated"; source: "existing" | "observed" }>
+  | Readonly<{ status: "authentication_required" }>
+  | Readonly<{ status: "in_progress"; reason: "lease_held" | "active_mutation_owner" }>
+  | Readonly<{ status: "retry_later"; reason: "session_probe_unavailable" | "ownership_changed" | "state_changed" }>
+  | Readonly<{ status: "needs_operator_action"; reason: SessionAuthenticationOperatorReason | "identity_conflict" | "restoration_state_conflict" }>
+  | Readonly<{ status: "cancelled" }>
+  | Readonly<{ status: "invalid_request" }>;
+
+const isNonblank = (value: unknown): value is string => typeof value === "string" && /\S/.test(value);
+const retryState = (): AuthenticatedSessionState => ({ status: "retry_later", reason: "state_changed" });
+const ownershipChanged = (): AuthenticatedSessionState => ({ status: "retry_later", reason: "ownership_changed" });
+
+function terminal(record: SessionAuthenticationAttemptRecord): AuthenticatedSessionState | null {
+  if (record.status === "authenticated") return { status: "authenticated", source: "existing" };
+  if (record.status === "failed") return { status: "needs_operator_action", reason: record.operatorReason };
+  return null;
+}
+
+async function findTerminalOrRetry(attempts: Attempts, identity: SessionAuthenticationAttemptIdentity): Promise<AuthenticatedSessionState> {
+  const exact = await attempts.findExact({ identity });
+  return exact.status === "found" ? terminal(exact.record) ?? retryState() : retryState();
+}
+
+export async function coordinateAuthenticatedSessionState(
+  input: CoordinateAuthenticatedSessionStateInput,
+  { attempts, probe, completion }: AuthenticatedSessionCoordinatorDependencies,
+): Promise<AuthenticatedSessionState> {
+  const { identity, ownerToken, leaseDurationMs, signal } = input;
+  if (![identity?.bankCode, identity?.runId, identity?.attemptId, ownerToken].every(isNonblank) || !Number.isSafeInteger(leaseDurationMs) || leaseDurationMs <= 0) return { status: "invalid_request" };
+  if (signal?.aborted) return { status: "cancelled" };
+
+  const created = await attempts.getOrCreate({ identity });
+  if (created.status === "identity_conflict") return { status: "needs_operator_action", reason: "identity_conflict" };
+  const existing = terminal(created.record);
+  if (existing) return existing;
+
+  let shouldProbe = created.record.ownerToken === null;
+  let reconciled = false;
+  while (true) {
+    if (shouldProbe) {
+      let observation: Awaited<ReturnType<AuthenticatedSessionProbe["observe"]>>;
+      try { observation = await probe.observe({ bankCode: identity.bankCode, signal }); }
+      catch { return { status: "retry_later", reason: "session_probe_unavailable" }; }
+      if (signal?.aborted) return { status: "cancelled" };
+      if (observation.status === "unauthenticated") return { status: "authentication_required" };
+      if (observation.status === "unavailable") return { status: "retry_later", reason: "session_probe_unavailable" };
+    }
+
+    const leased = await attempts.acquireLease({ identity, ownerToken, leaseDurationMs });
+    if (leased.status === "lease_held") return { status: "in_progress", reason: "lease_held" };
+    if (leased.status === "terminal") return terminal(leased.record) ?? retryState();
+    if (leased.status === "missing" || leased.status === "not_applied") return findTerminalOrRetry(attempts, identity);
+    if (leased.status === "reconciliation_required") {
+      if (reconciled) return retryState();
+      reconciled = true;
+      const reconciliation = await attempts.reconcileExpiredLease({ identity });
+      if (reconciliation.status === "terminal") return terminal(reconciliation.record) ?? retryState();
+      if (reconciliation.status === "lease_still_active") return { status: "in_progress", reason: "lease_held" };
+      if (reconciliation.status === "missing" || reconciliation.status === "not_applied") return findTerminalOrRetry(attempts, identity);
+      const reconciledTerminal = terminal(reconciliation.record);
+      if (reconciledTerminal) return reconciledTerminal;
+      shouldProbe = true;
+      continue;
+    }
+
+    if (completion.mode === "attempt_only") {
+      const result = await attempts.completeAuthenticated({ owner: leased.owner });
+      return result.status === "authenticated" ? { status: "authenticated", source: "observed" } : ownershipChanged();
+    }
+    const restored = await completion.resolver.resolveObservedRestoration(leased.owner);
+    if (restored.status === "resolved" || restored.status === "already_resolved") return { status: "authenticated", source: "observed" };
+    if (restored.status === "active_mutation_owner") return { status: "in_progress", reason: "active_mutation_owner" };
+    if (restored.status === "stale_owner" || restored.status === "lease_expired" || restored.status === "not_applied") return ownershipChanged();
+    return { status: "needs_operator_action", reason: "restoration_state_conflict" };
+  }
+}

--- a/src/modules/bank-sessions/ensure-authenticated-session.ts
+++ b/src/modules/bank-sessions/ensure-authenticated-session.ts
@@ -51,12 +51,25 @@ export async function coordinateAuthenticatedSessionState(
   if (![identity?.bankCode, identity?.runId, identity?.attemptId, ownerToken].every(isNonblank) || !Number.isSafeInteger(leaseDurationMs) || leaseDurationMs <= 0) return { status: "invalid_request" };
   if (signal?.aborted) return { status: "cancelled" };
 
-  const created = await attempts.getOrCreate({ identity });
-  if (created.status === "identity_conflict") return { status: "needs_operator_action", reason: "identity_conflict" };
-  const existing = terminal(created.record);
-  if (existing) return existing;
-
-  let shouldProbe = created.record.ownerToken === null;
+  const exact = await attempts.findExact({ identity });
+  let shouldProbe: boolean;
+  if (exact.status === "found") {
+    const existing = terminal(exact.record);
+    if (existing) return existing;
+    shouldProbe = exact.record.ownerToken === null;
+  } else {
+    let observation: Awaited<ReturnType<AuthenticatedSessionProbe["observe"]>>;
+    try { observation = await probe.observe({ bankCode: identity.bankCode, signal }); }
+    catch { return { status: "retry_later", reason: "session_probe_unavailable" }; }
+    if (signal?.aborted) return { status: "cancelled" };
+    if (observation.status === "unauthenticated") return { status: "authentication_required" };
+    if (observation.status === "unavailable") return { status: "retry_later", reason: "session_probe_unavailable" };
+    const created = await attempts.getOrCreate({ identity });
+    if (created.status === "identity_conflict") return { status: "needs_operator_action", reason: "identity_conflict" };
+    const existing = terminal(created.record);
+    if (existing) return existing;
+    shouldProbe = false;
+  }
   let reconciled = false;
   while (true) {
     if (shouldProbe) {


### PR DESCRIPTION
## Summary

Closes #82

This inert Slice 4 coordinator observes and coordinates authenticated session state. It does NOT authenticate or mutate credentials; authentication_required is a normal result.

Related: #67, #69

## Scope and Ordering

- Validate input, then findExact.
- For a missing or unowned authentication attempt, probe before any getOrCreate or lease acquisition.
- Unauthenticated, unavailable, and cancelled probe outcomes perform zero durable mutation.
- An authenticated observation is revalidated through getOrCreate and acquire.
- Existing owned and terminal sessions are classified using DB-authoritative repository outcomes.
- attempt_only and expiry_restoration are explicit modes; resolver failure never falls back to the other mode.
- The retry budget is untouched: no claimRetry, renew, begin, or barrier operations.
- Once ownership is acquired, caller cancellation does not abandon the durable lease; the coordinator completes or conclusively classifies the closure before returning.
- Results use the safe result vocabulary and expose no diagnostics.

## Commit Story

- 08be54e feat(bank-sessions): coordinate authenticated session state contains the original implementation.
- 88f0c59 fix(bank-sessions): probe before creating authentication attempt corrects an ordering defect independently caught by verification: a pre-probe insertion could occur for an unauthenticated missing session. The correction probes first.

## Inertness and Follow-up Slices

This slice is production-inert and reached only through test imports. It has no barrel, runtime, worker, queue, browser, CDP, credential, or environment access.

- Slice 5 will add durable pre-click runner integration.
- Slice 6 will activate this path and remove the legacy recover/recollect behavior.

## Review Path

1. Review the result and ordering contract in the coordinator.
2. Verify reconciliation and completion mappings.
3. Review the focused tests, especially zero-mutation probe outcomes and cancellation after lease acquisition.

## Changes

| File | Change |
| --- | --- |
| src/modules/bank-sessions/ensure-authenticated-session.ts | Adds the inert authenticated-session state coordinator and ports. |
| src/modules/bank-sessions/ensure-authenticated-session.test.ts | Covers ordering, result vocabulary, reconciliation, completion, modes, and cancellation. |

Two files changed: 240 additions, 0 deletions. This is within the project's ~400-line review budget; no size exception is required.

## Local Verification

- Focused suite: 40/40 passed.
- Full suite: 1,434 passed, 2 skipped.
- pnpm lint passed.
- pnpm typecheck passed.
- Prisma validation passed.
- git diff --check passed.
- The repository has no CI workflows; this PR has local verification evidence only.

## Rollback

Revert the two commits above. The rollback boundary is these two files only; no schema or runtime state is introduced.

## Checklist

- [x] Linked approved issue #82.
- [x] Added exactly one type label.
- [x] Conventional commits used.
- [x] No Co-Authored-By trailers.