### PR TITLE
feat(auto-login): add durable mutation boundary

### DIFF
--- a/src/worker/scraper/durable-auto-login-mutation.test.ts
+++ b/src/worker/scraper/durable-auto-login-mutation.test.ts
@@ -125,6 +125,41 @@ describe("executeDurablyFencedAutoLogin", () => {
     expect(result).toMatchObject({ status: "blocked", reason: "durable_state_changed" });
   });
 
+  it("keeps a begin ownership denial sticky when a strategy catches it and later fills", async () => {
+    const events: string[] = [];
+    const result = await execute(events, async (p) => { try { await p.fill("user", "alice"); } catch {} await p.fill("later", "alice"); }, { begin: "stale_owner" });
+    expect(events).toEqual(["begin"]);
+    expect(result).toMatchObject({ status: "blocked", reason: "ownership_lost", interactionPhase: "no_credential_interaction" });
+  });
+
+  it("keeps denial sticky across empty cleanup before a later non-empty fill", async () => {
+    const events: string[] = [];
+    const result = await execute(events, async (p) => { try { await p.fill("user", "alice"); } catch { await p.fill("user", ""); } await p.fill("later", "alice"); }, { begin: "stale_owner" });
+    expect(events).toEqual(["begin", "fill:user:"]);
+    expect(result).toMatchObject({ status: "blocked", reason: "ownership_lost", interactionPhase: "no_credential_interaction" });
+  });
+
+  it("keeps a fill denial sticky before a later click", async () => {
+    const events: string[] = [];
+    const result = await execute(events, async (p) => { try { await p.fill("user", "alice"); } catch {} await p.click("submit"); }, { begin: "stale_owner" });
+    expect(events).toEqual(["begin"]);
+    expect(result).toMatchObject({ status: "blocked", reason: "ownership_lost" });
+  });
+
+  it("keeps a barrier denial sticky when a strategy catches it and clicks again", async () => {
+    const events: string[] = [];
+    const result = await execute(events, async (p) => { try { await p.click("first"); } catch {} await p.click("second"); }, { barrier: "already_recorded" });
+    expect(events).toEqual(["barrier"]);
+    expect(result).toMatchObject({ status: "blocked", reason: "durable_state_changed" });
+  });
+
+  it("keeps a repository failure denial sticky when a strategy later fills", async () => {
+    const events: string[] = [];
+    const result = await executeDurablyFencedAutoLogin({ strategy: strategy(async (p) => { try { await p.fill("user", "alice"); } catch {} await p.fill("later", "alice"); }), credential, page: page(events), attempts: { ...attempts(events), beginCredentialInteraction: async () => { events.push("begin"); throw new Error("unavailable"); } }, owner, leaseDurationMs: 1 });
+    expect(events).toEqual(["begin"]);
+    expect(result).toMatchObject({ status: "blocked", reason: "persistence_unavailable" });
+  });
+
   it("allows empty cleanup best-effort without durable calls and preserves a primary denial", async () => {
     const events: string[] = [];
     const result = await execute(events, async (p) => { try { await p.fill("user", "alice"); } catch { await p.fill("user", ""); } }, { begin: "stale_owner" });

--- a/src/worker/scraper/durable-auto-login-mutation.test.ts
+++ b/src/worker/scraper/durable-auto-login-mutation.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+import { createBankAutoLoginStrategy, type BankAutoLoginPage, type BankAutoLoginStrategy } from "./auto-login";
+import { executeDurablyFencedAutoLogin } from "./durable-auto-login-mutation";
+import type {
+  BeginCredentialInteractionResult,
+  RecordSessionAuthenticationSubmitBarrierResult,
+  RenewSessionAuthenticationLeaseResult,
+  SessionAuthenticationAttemptRepository,
+  SessionAuthenticationLeaseOwner,
+} from "../../modules/bank-sessions/session-authentication-attempt-repository";
+
+const owner: SessionAuthenticationLeaseOwner = { identity: { bankCode: "popular", runId: "run", attemptId: "attempt" }, ownerToken: "owner", generation: 1n };
+const credential = { bankCode: "popular", username: "alice", password: "secret" };
+const record = {} as never;
+type Status = "interaction_started" | "already_started" | "lease_renewed" | "recorded" | "already_recorded" | "invalid_transition" | "stale_owner" | "lease_expired" | "terminal" | "missing" | "not_applied";
+type DurableInput = Parameters<typeof executeDurablyFencedAutoLogin>[0];
+type DurableOutput = Awaited<ReturnType<typeof executeDurablyFencedAutoLogin>>;
+const attemptsSurfaceIsNarrow: Exclude<keyof DurableInput["attempts"], "beginCredentialInteraction" | "renewLease" | "recordSubmitBarrier"> extends never ? true : false = true;
+const outputDoesNotExposeRawPage: "page" extends keyof DurableOutput ? false : true = true;
+void attemptsSurfaceIsNarrow;
+void outputDoesNotExposeRawPage;
+
+function page(events: string[], overrides: Partial<BankAutoLoginPage> = {}): BankAutoLoginPage {
+  return {
+    currentUrl: async () => "https://bank.example/login",
+    hasVisibleSelector: async () => false,
+    protectedStateDetectionWindowMs: 321,
+    fill: async (selector, value) => { events.push(`fill:${selector}:${value}`); },
+    click: async (selector) => { events.push(`click:${selector}`); },
+    ...overrides,
+  };
+}
+
+function attempts(events: string[], statuses: Partial<Record<"begin" | "renew" | "barrier", Status>> = {}) {
+  return {
+    beginCredentialInteraction: async () => { events.push("begin"); return { status: statuses.begin ?? "interaction_started", record } as unknown as BeginCredentialInteractionResult; },
+    renewLease: async () => { events.push("renew"); return { status: statuses.renew ?? "lease_renewed", record } as unknown as RenewSessionAuthenticationLeaseResult; },
+    recordSubmitBarrier: async () => { events.push("barrier"); return { status: statuses.barrier ?? "recorded", record } as unknown as RecordSessionAuthenticationSubmitBarrierResult; },
+  } satisfies Pick<SessionAuthenticationAttemptRepository, "beginCredentialInteraction" | "renewLease" | "recordSubmitBarrier">;
+}
+
+function strategy(run: (page: BankAutoLoginPage) => Promise<void>, outcome: ReturnType<BankAutoLoginStrategy["autoLogin"]> extends Promise<infer Result> ? Result : never = { status: "succeeded" }): BankAutoLoginStrategy {
+  return { bankCode: "popular", autoLogin: async ({ page }) => { try { await run(page); return outcome; } catch { return { status: "needs_admin_action", reason: "portal_state_unavailable", safeSummary: "safe" }; } } };
+}
+
+function execute(events: string[], run: (page: BankAutoLoginPage) => Promise<void>, statuses = {}, raw = page(events)) {
+  return executeDurablyFencedAutoLogin({ strategy: strategy(run), credential, page: raw, attempts: attempts(events, statuses), owner, leaseDurationMs: 1_000 });
+}
+
+describe("executeDurablyFencedAutoLogin", () => {
+  it("begins before the first raw fill and records the credential phase", async () => {
+    const events: string[] = [];
+    const result = await execute(events, async (p) => { await p.fill("user", "alice"); });
+    expect(events).toEqual(["begin", "fill:user:alice"]);
+    expect(result).toMatchObject({ status: "completed", interactionPhase: "credentials_may_have_reached_portal" });
+  });
+
+  it.each(["already_started", "stale_owner", "lease_expired", "terminal", "missing", "not_applied"] as const)("blocks a non-authorizing begin result: %s", async (begin) => {
+    const events: string[] = [];
+    const result = await execute(events, async (p) => { await p.fill("user", "alice"); }, { begin });
+    expect(events).toEqual(["begin"]);
+    expect(result).toMatchObject({ status: "blocked", interactionPhase: "no_credential_interaction" });
+  });
+
+  it("blocks a begin failure without serializing its error", async () => {
+    const events: string[] = [];
+    const result = await executeDurablyFencedAutoLogin({ strategy: strategy(async (p) => { await p.fill("user", "alice"); }), credential, page: page(events), attempts: { ...attempts(events), beginCredentialInteraction: async () => { throw new Error("token=raw-secret"); } }, owner, leaseDurationMs: 1 });
+    expect(JSON.stringify(result)).not.toContain("raw-secret");
+    expect(result).toMatchObject({ status: "blocked", reason: "persistence_unavailable" });
+  });
+
+  it("renews immediately before every later non-empty fill", async () => {
+    const events: string[] = [];
+    await execute(events, async (p) => { await p.fill("user", "alice"); await p.fill("password", "secret"); });
+    expect(events).toEqual(["begin", "fill:user:alice", "renew", "fill:password:secret"]);
+  });
+
+  it.each(["stale_owner", "lease_expired", "terminal", "missing", "not_applied"] as const)("blocks a non-authorizing renewal: %s", async (renew) => {
+    const events: string[] = [];
+    const result = await execute(events, async (p) => { await p.fill("user", "alice"); await p.fill("password", "secret"); }, { renew });
+    expect(events).toEqual(["begin", "fill:user:alice", "renew"]);
+    expect(result).toMatchObject({ status: "blocked", interactionPhase: "credentials_may_have_reached_portal" });
+  });
+
+  it("blocks renewal persistence failure", async () => {
+    const events: string[] = [];
+    const result = await executeDurablyFencedAutoLogin({ strategy: strategy(async (p) => { await p.fill("user", "alice"); await p.fill("password", "secret"); }), credential, page: page(events), attempts: { ...attempts(events), renewLease: async () => { events.push("renew"); throw new Error("database-url"); } }, owner, leaseDurationMs: 1 });
+    expect(events).toEqual(["begin", "fill:user:alice", "renew"]);
+    expect(result).toMatchObject({ status: "blocked", reason: "persistence_unavailable" });
+  });
+
+  it("places the submit barrier immediately before the raw click", async () => {
+    const events: string[] = [];
+    await execute(events, async (p) => { await p.click("submit"); });
+    expect(events).toEqual(["barrier", "click:submit"]);
+  });
+
+  it.each(["already_recorded", "invalid_transition", "stale_owner", "lease_expired", "terminal", "missing", "not_applied"] as const)("blocks every non-authorizing barrier: %s", async (barrier) => {
+    const events: string[] = [];
+    const result = await execute(events, async (p) => { await p.click("submit"); }, { barrier });
+    expect(events).toEqual(["barrier"]);
+    expect(result).toMatchObject({ status: "blocked", interactionPhase: "no_credential_interaction" });
+  });
+
+  it("blocks barrier failure and a click error with safe submit-phase uncertainty", async () => {
+    const barrierEvents: string[] = [];
+    const barrierResult = await executeDurablyFencedAutoLogin({ strategy: strategy(async (p) => { await p.click("submit"); }), credential, page: page(barrierEvents), attempts: { ...attempts(barrierEvents), recordSubmitBarrier: async () => { throw new Error("token"); } }, owner, leaseDurationMs: 1 });
+    expect(barrierEvents).toEqual([]);
+    expect(barrierResult).toMatchObject({ status: "blocked", reason: "persistence_unavailable" });
+    const clickEvents: string[] = [];
+    const clickResult = await execute(clickEvents, async (p) => { await p.click("submit"); }, {}, page(clickEvents, { click: async () => { clickEvents.push("click"); throw new Error("https://private"); } }));
+    expect(clickResult).toMatchObject({ status: "blocked", interactionPhase: "submit_may_have_been_dispatched" });
+    expect(JSON.stringify(clickResult)).not.toContain("private");
+  });
+
+  it("retains submit uncertainty for an unknown post-submit strategy outcome", async () => {
+    const events: string[] = [];
+    const result = await executeDurablyFencedAutoLogin({ strategy: strategy(async (p) => { await p.click("submit"); }, { status: "needs_admin_action", reason: "unknown_post_submit_state", safeSummary: "safe" }), credential, page: page(events), attempts: attempts(events), owner, leaseDurationMs: 1 });
+    expect(result).toMatchObject({ status: "completed", interactionPhase: "submit_may_have_been_dispatched" });
+  });
+
+  it("does not let a strategy catch swallow a durable denial", async () => {
+    const events: string[] = [];
+    const result = await execute(events, async (p) => { await p.fill("user", "alice"); }, { begin: "already_started" });
+    expect(result).toMatchObject({ status: "blocked", reason: "durable_state_changed" });
+  });
+
+  it("allows empty cleanup best-effort without durable calls and preserves a primary denial", async () => {
+    const events: string[] = [];
+    const result = await execute(events, async (p) => { try { await p.fill("user", "alice"); } catch { await p.fill("user", ""); } }, { begin: "stale_owner" });
+    expect(events).toEqual(["begin", "fill:user:"]);
+    expect(result).toMatchObject({ status: "blocked", reason: "ownership_lost" });
+  });
+
+  it("forwards read methods and the exact detection window", async () => {
+    const events: string[] = [];
+    const raw = page(events, { currentUrl: async () => { events.push("url"); return "url"; }, hasVisibleSelector: async (s, timeout) => { events.push(`${s}:${timeout}`); return true; } });
+    let received: BankAutoLoginPage | undefined;
+    const result = await executeDurablyFencedAutoLogin({ strategy: { bankCode: "popular", autoLogin: async ({ page: strategyPage }) => { received = strategyPage; return { status: "succeeded" }; } }, credential, page: raw, attempts: attempts(events), owner, leaseDurationMs: 1 });
+    expect(result.status).toBe("completed");
+    expect(received?.protectedStateDetectionWindowMs).toBe(raw.protectedStateDetectionWindowMs);
+    await received?.currentUrl();
+    await received?.hasVisibleSelector("mfa", 77);
+    expect(events).toEqual(["url", "mfa:77"]);
+  });
+
+  it("fences the real strategy in begin, username, renew, password, barrier, click order", async () => {
+    const events: string[] = [];
+    const raw = page(events, { currentUrl: async () => events.some((event) => event === "click:submit") ? "https://bank.example/dashboard" : "https://bank.example/login", hasVisibleSelector: async (selector) => !["mfa", "incompatible"].includes(selector) });
+    const real = createBankAutoLoginStrategy({ bankCode: "popular", baseUrl: "https://bank.example", loginPathAllowlist: ["/login"], usernameSelector: "user", passwordSelector: "password", submitSelector: "submit", mfaIndicatorSelector: "mfa", incompatibleFlowSelector: "incompatible", dashboardPathIndicator: "/dashboard" });
+    await executeDurablyFencedAutoLogin({ strategy: real, credential, page: raw, attempts: attempts(events), owner, leaseDurationMs: 1 });
+    expect(events).toEqual(["begin", "fill:user:alice", "renew", "fill:password:secret", "barrier", "click:submit"]);
+  });
+
+  it("does no durable mutation when the real guard rejects before the first fill or sees protected state before submit", async () => {
+    const config = { bankCode: "popular", baseUrl: "https://bank.example", loginPathAllowlist: ["/login"], usernameSelector: "user", passwordSelector: "password", submitSelector: "submit", mfaIndicatorSelector: "mfa", incompatibleFlowSelector: "incompatible", dashboardPathIndicator: "/dashboard" };
+    const guardEvents: string[] = [];
+    await executeDurablyFencedAutoLogin({ strategy: createBankAutoLoginStrategy(config), credential, page: page(guardEvents, { currentUrl: async () => "https://evil.example" }), attempts: attempts(guardEvents), owner, leaseDurationMs: 1 });
+    expect(guardEvents).toEqual([]);
+    const protectedEvents: string[] = [];
+    let protectedChecks = 0;
+    await executeDurablyFencedAutoLogin({ strategy: createBankAutoLoginStrategy(config), credential, page: page(protectedEvents, { currentUrl: async () => "https://bank.example/login", hasVisibleSelector: async (selector) => selector === "mfa" ? ++protectedChecks === 3 : selector !== "incompatible" }), attempts: attempts(protectedEvents), owner, leaseDurationMs: 1 });
+    expect(protectedEvents).toEqual(["begin", "fill:user:alice", "renew", "fill:password:secret", "fill:password:", "fill:user:"]);
+  });
+
+  it("requires a fresh barrier for a second click", async () => {
+    const events: string[] = [];
+    let barrierCalls = 0;
+    const result = await executeDurablyFencedAutoLogin({ strategy: strategy(async (p) => { await p.click("one"); await p.click("two"); }), credential, page: page(events), attempts: { ...attempts(events), recordSubmitBarrier: async () => { events.push("barrier"); return { status: ++barrierCalls === 1 ? "recorded" : "already_recorded", record }; } }, owner, leaseDurationMs: 1 });
+    expect(events).toEqual(["barrier", "click:one", "barrier"]);
+    expect(result).toMatchObject({ status: "blocked" });
+  });
+});

--- a/src/worker/scraper/durable-auto-login-mutation.ts
+++ b/src/worker/scraper/durable-auto-login-mutation.ts
@@ -1,0 +1,84 @@
+import type { CredentialInteractionPhase } from "../../modules/bank-sessions/session-authentication-attempt";
+import type {
+  SessionAuthenticationAttemptRepository,
+  SessionAuthenticationLeaseOwner,
+} from "../../modules/bank-sessions/session-authentication-attempt-repository";
+import type {
+  BankAutoLoginCredential,
+  BankAutoLoginOutcome,
+  BankAutoLoginPage,
+  BankAutoLoginStrategy,
+} from "./auto-login";
+
+type DurableAttempts = Pick<SessionAuthenticationAttemptRepository, "beginCredentialInteraction" | "renewLease" | "recordSubmitBarrier">;
+type DurableBlockReason = "ownership_lost" | "durable_state_changed" | "persistence_unavailable";
+
+export type DurableAutoLoginMutationResult =
+  | Readonly<{ status: "completed"; outcome: BankAutoLoginOutcome; interactionPhase: CredentialInteractionPhase }>
+  | Readonly<{ status: "blocked"; reason: DurableBlockReason; interactionPhase: CredentialInteractionPhase }>;
+
+export async function executeDurablyFencedAutoLogin(input: Readonly<{
+  strategy: BankAutoLoginStrategy;
+  credential: BankAutoLoginCredential;
+  page: BankAutoLoginPage;
+  attempts: DurableAttempts;
+  owner: SessionAuthenticationLeaseOwner;
+  leaseDurationMs: number;
+}>): Promise<DurableAutoLoginMutationResult> {
+  if (!Number.isSafeInteger(input.leaseDurationMs) || input.leaseDurationMs <= 0) {
+    throw new Error("Lease duration must be a positive safe integer");
+  }
+
+  let phase: CredentialInteractionPhase = "no_credential_interaction";
+  let denial: DurableBlockReason | undefined;
+  let clickFailed = false;
+
+  const blockFor = (status: string): DurableBlockReason =>
+    status === "stale_owner" || status === "lease_expired" ? "ownership_lost" : "durable_state_changed";
+  const deny = (reason: DurableBlockReason): never => {
+    denial ??= reason;
+    throw new Error("Durable auto-login mutation denied");
+  };
+
+  const page: BankAutoLoginPage = {
+    currentUrl: () => input.page.currentUrl(),
+    hasVisibleSelector: (selector, timeoutMs) => input.page.hasVisibleSelector(selector, timeoutMs),
+    protectedStateDetectionWindowMs: input.page.protectedStateDetectionWindowMs,
+    async fill(selector, value) {
+      if (!value) return input.page.fill(selector, value);
+      try {
+        const result = phase === "no_credential_interaction"
+          ? await input.attempts.beginCredentialInteraction({ owner: input.owner })
+          : await input.attempts.renewLease({ owner: input.owner, leaseDurationMs: input.leaseDurationMs });
+        const authorized = phase === "no_credential_interaction" ? result.status === "interaction_started" : result.status === "lease_renewed";
+        if (!authorized) deny(blockFor(result.status));
+        if (phase === "no_credential_interaction") phase = "credentials_may_have_reached_portal";
+      } catch {
+        if (denial) throw new Error("Durable auto-login mutation denied");
+        deny("persistence_unavailable");
+      }
+      return input.page.fill(selector, value);
+    },
+    async click(selector) {
+      try {
+        const result = await input.attempts.recordSubmitBarrier({ owner: input.owner });
+        if (result.status !== "recorded") deny(blockFor(result.status));
+        phase = "submit_may_have_been_dispatched";
+      } catch {
+        if (denial) throw new Error("Durable auto-login mutation denied");
+        deny("persistence_unavailable");
+      }
+      try {
+        return await input.page.click(selector);
+      } catch (error) {
+        clickFailed = true;
+        throw error;
+      }
+    },
+  };
+
+  const outcome = await input.strategy.autoLogin({ credential: input.credential, page });
+  if (denial) return { status: "blocked", reason: denial, interactionPhase: phase };
+  if (clickFailed) return { status: "blocked", reason: "durable_state_changed", interactionPhase: phase };
+  return { status: "completed", outcome, interactionPhase: phase };
+}

--- a/src/worker/scraper/durable-auto-login-mutation.ts
+++ b/src/worker/scraper/durable-auto-login-mutation.ts
@@ -46,6 +46,7 @@ export async function executeDurablyFencedAutoLogin(input: Readonly<{
     protectedStateDetectionWindowMs: input.page.protectedStateDetectionWindowMs,
     async fill(selector, value) {
       if (!value) return input.page.fill(selector, value);
+      if (denial) throw new Error("Durable auto-login mutation denied");
       try {
         const result = phase === "no_credential_interaction"
           ? await input.attempts.beginCredentialInteraction({ owner: input.owner })
@@ -60,6 +61,7 @@ export async function executeDurablyFencedAutoLogin(input: Readonly<{
       return input.page.fill(selector, value);
     },
     async click(selector) {
+      if (denial) throw new Error("Durable auto-login mutation denied");
       try {
         const result = await input.attempts.recordSubmitBarrier({ owner: input.owner });
         if (result.status !== "recorded") deny(blockFor(result.status));


### PR DESCRIPTION
Closes #84

## Summary
- Adds a production-inert receiving boundary for durable auto-login mutations; the raw page remains closure-private.
- Enforces durable authorization immediately at non-empty credential fills and clicks without activating any production consumer.
- Includes the sticky-denial correction identified by independent verification.

## Mutation Protocol
- The first non-empty fill is authorized only when `beginCredentialInteraction` returns exactly `interaction_started`; each later non-empty fill only when `renewLease` returns exactly `lease_renewed`; each click only when `recordSubmitBarrier` returns exactly `recorded`, immediately before the raw click.
- All other statuses and errors are non-authorizing. `already_*` and `not_applied` are explicitly blocked.
- Phase advances happen conservatively before each raw action. A raw click throw is submit uncertainty.
- The first denial is sticky: strategy catch-and-continue cannot bypass it, and empty cleanup cannot clear or replace it.

## Scope
- No optional hook, cached boolean, heartbeat, retry change, completion, queue/runtime/coordinator activation.
- Existing production code is byte-for-byte unchanged. This is a receiving boundary for future Slice 6 composition only.
- Zero production consumers; no production activation is included.
- Related: #67, #69.

## Review Path
1. Verify executor privacy and result handling.
2. Verify exact durable-boundary ordering around raw page operations.
3. Verify sticky-denial and empty-cleanup tests.
4. Follow the real strategy sequence.

## Changes
| File | Change |
| --- | --- |
| `src/worker/scraper/durable-auto-login-mutation.ts` | Adds the closure-private, fail-closed mutation executor. |
| `src/worker/scraper/durable-auto-login-mutation.test.ts` | Covers boundary ordering, denial stickiness, cleanup, and strategy sequences. |

Exactly two new files, 294 additions, and under the ~400-line review budget; no exception is needed.

## Verification
- Focused tests: 36/36 passed.
- Full suite: 1,470 passed, 2 skipped.
- Lint, typecheck, Prisma, and `git diff --check` passed.
- The repository has no CI workflows, so zero GitHub checks are expected; all merge evidence is local and this PR does not claim CI green.
- Receipt-driven review state is `disabled/unmanaged`.

## Rollback
Revert the two commits (`3743b79`, `a4a757e`) to remove these two files. No schema or runtime state is introduced.