### PR TITLE
feat(bank-sessions): enrich restoration evidence

### DIFF
--- a/src/modules/bank-sessions/session-authentication-attempt-repository.test.ts
+++ b/src/modules/bank-sessions/session-authentication-attempt-repository.test.ts
@@ -125,8 +125,8 @@ const reconcileExpiredLeaseResults: readonly ReconcileExpiredLeaseResult[] = [
 ];
 const notApplied: SessionAuthenticationAttemptNotAppliedResult = { status: "not_applied" };
 const observedRestorationResults: readonly ResolveObservedRestorationResult[] = [
-  { status: "resolved", evidence: { authenticatedAt: new Date("2026-08-13T01:00:00.000Z") } },
-  { status: "already_resolved" }, { status: "missing", missing: "authentication_attempt" },
+  { status: "resolved", evidence: { identity: owner.identity, interactionPhase: "no_credential_interaction", terminalGeneration: 2n, authenticatedAt: new Date("2026-08-13T01:00:00.000Z") } },
+  { status: "already_resolved", evidence: { identity: owner.identity, interactionPhase: "no_credential_interaction", terminalGeneration: 2n, authenticatedAt: new Date("2026-08-13T01:00:00.000Z") } }, { status: "missing", missing: "authentication_attempt" },
   { status: "missing", missing: "expiry_episode" }, { status: "identity_mismatch" },
   { status: "stale_owner" }, { status: "lease_expired" }, { status: "active_mutation_owner" },
   { status: "episode_not_resolvable" }, { status: "terminal_conflict" }, { status: "not_applied" },

--- a/src/modules/bank-sessions/session-authentication-attempt-repository.ts
+++ b/src/modules/bank-sessions/session-authentication-attempt-repository.ts
@@ -52,10 +52,15 @@ export type ClaimRetryInput = Readonly<{ owner: SessionAuthenticationLeaseOwner 
 export type CompleteAuthenticatedInput = Readonly<{ owner: SessionAuthenticationLeaseOwner }>;
 export type CompleteFailedInput = Readonly<{ owner: SessionAuthenticationLeaseOwner } & SessionAuthenticationFailurePair>;
 export type ReconcileExpiredLeaseInput = Readonly<{ identity: SessionAuthenticationAttemptIdentity }>;
-export type ObservedRestorationEvidence = Readonly<{ authenticatedAt: Date }>;
+export type ObservedRestorationEvidence = Readonly<{
+  identity: SessionAuthenticationAttemptIdentity;
+  interactionPhase: CredentialInteractionPhase;
+  terminalGeneration: bigint;
+  authenticatedAt: Date;
+}>;
 export type ResolveObservedRestorationResult =
   | Readonly<{ status: "resolved"; evidence: ObservedRestorationEvidence }>
-  | Readonly<{ status: "already_resolved" }>
+  | Readonly<{ status: "already_resolved"; evidence: ObservedRestorationEvidence }>
   | Readonly<{ status: "missing"; missing: "authentication_attempt" | "expiry_episode" }>
   | Readonly<{ status: "identity_mismatch" | "stale_owner" | "lease_expired" | "active_mutation_owner" | "episode_not_resolvable" | "terminal_conflict" }>
   | SessionAuthenticationAttemptNotAppliedResult;

--- a/src/modules/persistence/prisma-bank-session-authentication-attempt-repository.ts
+++ b/src/modules/persistence/prisma-bank-session-authentication-attempt-repository.ts
@@ -24,6 +24,7 @@ import {
   type SessionAuthenticationAttemptRecord,
   type SessionAuthenticationAttemptRepository,
   type ObservedRestorationResolver,
+  type ObservedRestorationEvidence,
   type ResolveObservedRestorationResult,
   type SessionAuthenticationLeaseOwner,
 } from "../bank-sessions/session-authentication-attempt-repository";
@@ -38,6 +39,10 @@ function record(row: Row): SessionAuthenticationAttemptRecord {
   const parsed = parseSessionAuthenticationAttemptRecord(row);
   if (!parsed) throw new Error("Invalid durable session authentication attempt record");
   return parsed;
+}
+function observedRestorationEvidence(attempt: SessionAuthenticationAttemptRecord): ObservedRestorationEvidence {
+  if (attempt.status !== "authenticated") throw new Error("Observed restoration evidence requires an authenticated terminal attempt");
+  return { identity: attempt.identity, interactionPhase: attempt.interactionPhase, terminalGeneration: attempt.generation, authenticatedAt: attempt.terminalAt };
 }
 
 function assertLease(ownerToken: string, duration: number): void {
@@ -186,15 +191,17 @@ export class PrismaBankSessionAuthenticationAttemptRepository implements Session
         const attempts = await tx.$queryRaw<Array<Row & { leaseActive: boolean }>>`SELECT "bankCode", "runId", "attemptId", "status", "interactionPhase", "failureClass", "operatorReason", "retryCount", "ownerToken", "generation", "leaseExpiresAt", "terminalAt", "createdAt", "updatedAt", COALESCE("leaseExpiresAt" > NOW(), FALSE) AS "leaseActive" FROM "BankSessionAuthenticationAttempt" WHERE "bankCode" = ${owner.identity.bankCode} AND "runId" = ${owner.identity.runId} FOR UPDATE`;
         const attempt = attempts[0];
         if (!attempt) return { status: "missing", missing: "authentication_attempt" };
-        if (attempt.attemptId !== owner.identity.attemptId) return { status: "identity_mismatch" };
-        if (attempt.status !== "active") {
-          if (attempt.status !== "authenticated") return { status: "terminal_conflict" };
+        const current = record(attempt);
+        if (current.identity.attemptId !== owner.identity.attemptId) return { status: "identity_mismatch" };
+        if (current.status !== "active") {
+          if (current.status !== "authenticated") return { status: "terminal_conflict" };
+          const evidence = observedRestorationEvidence(current);
           const episode = (await tx.$queryRaw<Array<{ runId: string; consumerAttemptState: string | null }>>`SELECT "runId", "consumerAttemptState" FROM "BankSessionExpiryEpisode" WHERE "bankCode" = ${owner.identity.bankCode} FOR UPDATE`)[0];
-          if (!episode) return { status: "already_resolved" };
+          if (!episode) return { status: "already_resolved", evidence };
           if (episode.runId !== owner.identity.runId) return { status: "identity_mismatch" };
-          return episode.consumerAttemptState === "resolved" ? { status: "already_resolved" } : { status: "terminal_conflict" };
+          return episode.consumerAttemptState === "resolved" ? { status: "already_resolved", evidence } : { status: "terminal_conflict" };
         }
-        if (attempt.ownerToken !== owner.ownerToken || attempt.generation !== owner.generation) return { status: "stale_owner" };
+        if (current.ownerToken !== owner.ownerToken || current.generation !== owner.generation) return { status: "stale_owner" };
         if (!attempt.leaseActive) return { status: "lease_expired" };
         const episode = (await tx.$queryRaw<Array<{ runId: string; consumerAttemptState: string | null; consumerClaimToken: string | null; consumerLeaseExpiresAt: Date | null; leaseActive: boolean }>>`SELECT "runId", "consumerAttemptState", "consumerClaimToken", "consumerLeaseExpiresAt", COALESCE("consumerLeaseExpiresAt" > NOW(), FALSE) AS "leaseActive" FROM "BankSessionExpiryEpisode" WHERE "bankCode" = ${owner.identity.bankCode} FOR UPDATE`)[0];
         if (!episode) return { status: "missing", missing: "expiry_episode" };
@@ -202,11 +209,11 @@ export class PrismaBankSessionAuthenticationAttemptRepository implements Session
         const mutation = episode.consumerAttemptState === "mutation_started";
         if (mutation && (!episode.consumerClaimToken || !episode.consumerLeaseExpiresAt || episode.leaseActive)) return { status: "active_mutation_owner" };
         if (episode.consumerAttemptState !== "manual_recovery_required" && !mutation) return { status: "episode_not_resolvable" };
-        const authenticated = await tx.$queryRaw<Array<{ terminalAt: Date }>>`UPDATE "BankSessionAuthenticationAttempt" SET "status" = 'authenticated', "ownerToken" = NULL, "leaseExpiresAt" = NULL, "terminalAt" = NOW(), "generation" = "generation" + 1, "updatedAt" = NOW() WHERE "bankCode" = ${owner.identity.bankCode} AND "runId" = ${owner.identity.runId} AND "attemptId" = ${owner.identity.attemptId} AND "status" = 'active' AND "ownerToken" = ${owner.ownerToken} AND "generation" = ${owner.generation} AND "leaseExpiresAt" > NOW() RETURNING "terminalAt"`;
+        const authenticated = await tx.$queryRaw<Row[]>`UPDATE "BankSessionAuthenticationAttempt" SET "status" = 'authenticated', "ownerToken" = NULL, "leaseExpiresAt" = NULL, "terminalAt" = NOW(), "generation" = "generation" + 1, "updatedAt" = NOW() WHERE "bankCode" = ${owner.identity.bankCode} AND "runId" = ${owner.identity.runId} AND "attemptId" = ${owner.identity.attemptId} AND "status" = 'active' AND "ownerToken" = ${owner.ownerToken} AND "generation" = ${owner.generation} AND "leaseExpiresAt" > NOW() RETURNING "bankCode", "runId", "attemptId", "status", "interactionPhase", "failureClass", "operatorReason", "retryCount", "ownerToken", "generation", "leaseExpiresAt", "terminalAt", "createdAt", "updatedAt"`;
         if (authenticated.length !== 1) throw new Error("Observed restoration authentication CAS lost");
         const resolved = await tx.$executeRaw`UPDATE "BankSessionExpiryEpisode" SET "consumerAttemptState" = 'resolved', "consumerLeaseExpiresAt" = NULL, "updatedAt" = NOW() WHERE "bankCode" = ${owner.identity.bankCode} AND "runId" = ${owner.identity.runId} AND "consumerAttemptState" IN ('manual_recovery_required', 'mutation_started')`;
         if (resolved !== 1) throw new Error("Observed restoration expiry CAS lost");
-        return { status: "resolved", evidence: { authenticatedAt: authenticated[0].terminalAt } };
+        return { status: "resolved", evidence: observedRestorationEvidence(record(authenticated[0])) };
       }, { isolationLevel: "Serializable" });
     } catch (error) {
       const code = isRecord(error) && typeof error.code === "string" ? error.code : undefined;

--- a/src/modules/persistence/session-authentication-attempt.postgres.test.ts
+++ b/src/modules/persistence/session-authentication-attempt.postgres.test.ts
@@ -197,12 +197,16 @@ describe.skipIf(!url)("Session authentication attempt PostgreSQL contract", () =
     }
   });
 
-  it.each(["no_credential_interaction", "credentials_may_have_reached_portal", "submit_may_have_been_dispatched"])("resolves manual recovery while preserving %s", async (phase) => {
+  it.each(["no_credential_interaction", "credentials_may_have_reached_portal", "submit_may_have_been_dispatched"] as const)("resolves manual recovery with exact durable evidence for %s", async (phase) => {
     const { id, owner } = await lease(`observed-${phase}`); await episode(id);
     if (phase !== "no_credential_interaction") await repo().beginCredentialInteraction({ owner });
     if (phase === "submit_may_have_been_dispatched") await repo().recordSubmitBarrier({ owner });
-    await expect(repo().resolveObservedRestoration(owner)).resolves.toMatchObject({ status: "resolved" });
-    await expect(repo().findExact({ identity: id })).resolves.toMatchObject({ status: "found", record: { status: "authenticated", interactionPhase: phase, ownerToken: null, leaseExpiresAt: null, generation: owner.generation + 1n } });
+    const result = await repo().resolveObservedRestoration(owner);
+    if (result.status !== "resolved") throw new Error("Expected observed restoration");
+    expect(result.evidence).toMatchObject({ identity: id, interactionPhase: phase, terminalGeneration: owner.generation + 1n });
+    const durable = await repo().findExact({ identity: id });
+    if (durable.status !== "found" || durable.record.status !== "authenticated") throw new Error("Expected authenticated terminal attempt");
+    expect(result.evidence).toEqual({ identity: durable.record.identity, interactionPhase: durable.record.interactionPhase, terminalGeneration: durable.record.generation, authenticatedAt: durable.record.terminalAt });
     await expect(pool!.query('SELECT "consumerAttemptState", "consumerLeaseExpiresAt" FROM "BankSessionExpiryEpisode" WHERE "bankCode" = $1', [id.bankCode])).resolves.toMatchObject({ rows: [{ consumerAttemptState: "resolved", consumerLeaseExpiresAt: null }] });
   });
 
@@ -239,10 +243,11 @@ describe.skipIf(!url)("Session authentication attempt PostgreSQL contract", () =
     const failed = await lease("observed-failed"); await episode(failed.id); await repo().completeFailed({ owner: failed.owner, failureClass: "transient_pre_interaction", operatorReason: "temporary_authentication_problem" });
     await expect(repo().resolveObservedRestoration(failed.owner)).resolves.toEqual({ status: "terminal_conflict" });
     await pool!.query('DELETE FROM "BankSessionExpiryEpisode" WHERE "bankCode" = $1', [failed.id.bankCode]);
-    const resolved = await lease("observed-resolved"); await episode(resolved.id); await repo().resolveObservedRestoration(resolved.owner);
-    await expect(repo().resolveObservedRestoration(resolved.owner)).resolves.toEqual({ status: "already_resolved" });
+    const resolved = await lease("observed-resolved"); await episode(resolved.id); const first = await repo().resolveObservedRestoration(resolved.owner);
+    if (first.status !== "resolved") throw new Error("Expected observed restoration");
+    await expect(repo().resolveObservedRestoration(resolved.owner)).resolves.toEqual({ status: "already_resolved", evidence: first.evidence });
     await pool!.query('DELETE FROM "BankSessionExpiryEpisode" WHERE "bankCode" = $1', [resolved.id.bankCode]);
-    await expect(repo().resolveObservedRestoration(resolved.owner)).resolves.toEqual({ status: "already_resolved" });
+    await expect(repo().resolveObservedRestoration(resolved.owner)).resolves.toEqual({ status: "already_resolved", evidence: first.evidence });
     const conflict = await lease("observed-terminal-conflict"); await episode(conflict.id); await repo().completeAuthenticated({ owner: conflict.owner });
     await expect(repo().resolveObservedRestoration(conflict.owner)).resolves.toEqual({ status: "terminal_conflict" });
   });


### PR DESCRIPTION
## Why
Fail-closed consumers need stronger durable restoration evidence to make authorization decisions without inferring state from caller input.

## What changed
- Resolved and already_resolved outcomes now include exact identity, phase, terminal generation, and authenticatedAt.
- Each value is derived from the parsed durable authenticated record, including the deleted-episode idempotency path, never from caller input.

## Review path
Review the four files from the repository contract through the Prisma transaction implementation, then the pure and PostgreSQL tests.

| File | Change |
| --- | --- |
| src/modules/bank-sessions/session-authentication-attempt-repository.ts | Extends restoration outcome evidence. |
| src/modules/persistence/prisma-bank-session-authentication-attempt-repository.ts | Derives evidence from parsed durable authenticated records. |
| src/modules/bank-sessions/session-authentication-attempt-repository.test.ts | Covers the expanded contract. |
| src/modules/persistence/session-authentication-attempt.postgres.test.ts | Verifies phases and resolved/deleted idempotent paths. |

## Inertia and non-goals
- No production callers exist for this repository contract.
- No runtime, schema, or generated changes are included.
- #80 and #86 are related context only; this PR closes only #87.

## Scope
+35/-18 across four files, within the 400-line review budget.

## Verification
- Pure focused suite: 28 passed.
- PostgreSQL focused suite: 36 passed after applying 16 migrations.
- Clean full rerun: 1470 passed, 2 skipped.
- pnpm lint, pnpm typecheck, pnpm exec prisma validate, and git diff --check passed.
- The repository has no CI workflows, so zero GitHub check contexts are expected and merge evidence is local.
- Receipt-driven review is disabled/unmanaged.

## Reliability note
One earlier full-suite execution had an unrelated defaults.test failure caused by shared globalThis state. The isolated test passed, followed by one clean full-suite rerun. This is documented rather than hidden; residual test order-dependence risk remains outside this change.

## Rollback
Revert commit 02becb2 to remove this behavior. The rollback boundary is the four files listed above.

Closes #87