### PR TITLE
feat(bank-sessions): renew leases at mutation boundaries

### DIFF
--- a/src/modules/bank-sessions/authentication-mutation-authority.ts
+++ b/src/modules/bank-sessions/authentication-mutation-authority.ts
@@ -129,7 +129,7 @@ export function claimAuthenticationMutationAuthority(authority: AuthenticationMu
     const record = parseAttempt(value.record);
     return record?.status === "active" && record.identity.bankCode === state.owner.identity.bankCode && record.identity.runId === state.owner.identity.runId && record.identity.attemptId === state.owner.identity.attemptId && record.ownerToken === null && record.leaseExpiresAt === null && record.failureClass === null && record.operatorReason === null && record.terminalAt === null && record.generation === state.owner.generation + 1n && record.retryCount === value.retryCount;
   };
-  const run = async (allowed: Phase, call: () => Promise<unknown>, next: Phase): Promise<MutationAuthorityResult> => {
+  const run = async (allowed: Phase, call: () => Promise<unknown>, next: Phase, expectedStatus: string): Promise<MutationAuthorityResult> => {
     if (phase !== allowed || pending) return invalidSequence();
     pending = true;
     try {
@@ -137,7 +137,7 @@ export function claimAuthenticationMutationAuthority(authority: AuthenticationMu
       if (!isRecord(result) || typeof result.status !== "string") { poison(); return unavailable(); }
       if (result.status === "stale_owner" || result.status === "lease_expired") { poison(); return lost(); }
       const expected = next === "interaction_started" ? "credentials_may_have_reached_portal" : "submit_may_have_been_dispatched";
-      if (!(["interaction_started", "lease_renewed", "recorded"] as string[]).includes(result.status) || !active(result.record, expected)) { poison(); return unavailable(); }
+      if (result.status !== expectedStatus || !active(result.record, expected)) { poison(); return unavailable(); }
       phase = next; return { status: "authorized" };
     } catch { poison(); return unavailable(); }
   };
@@ -164,10 +164,10 @@ export function claimAuthenticationMutationAuthority(authority: AuthenticationMu
     } catch { pending = false; return unavailable(); }
   };
   return { status: "claimed", authority: Object.freeze({
-    beginCredentialInteraction: () => run("leased", () => state.repository.beginCredentialInteraction({ owner: state.owner }), "interaction_started"),
+    beginCredentialInteraction: () => run("leased", () => state.repository.beginCredentialInteraction({ owner: state.owner, leaseDurationMs: state.leaseDurationMs }), "interaction_started", "interaction_started"),
     // A blocked overlap never changes phase; a later serial renewal remains valid.
-    renewLease: () => run("interaction_started", () => state.repository.renewLease({ owner: state.owner, leaseDurationMs: state.leaseDurationMs }), "interaction_started"),
-    recordSubmitBarrier: () => run("interaction_started", () => state.repository.recordSubmitBarrier({ owner: state.owner }), "submit_barrier_recorded"),
+    renewLease: () => run("interaction_started", () => state.repository.renewLease({ owner: state.owner, leaseDurationMs: state.leaseDurationMs }), "interaction_started", "lease_renewed"),
+    recordSubmitBarrier: () => run("interaction_started", () => state.repository.recordSubmitBarrier({ owner: state.owner, leaseDurationMs: state.leaseDurationMs }), "submit_barrier_recorded", "recorded"),
     claimRetry,
     completeAuthenticated: () => complete(() => state.repository.completeAuthenticated({ owner: state.owner })),
     completeFailed: (failure) => complete(() => state.repository.completeFailed({ owner: state.owner, ...failure }), failure),

--- a/src/modules/bank-sessions/ensure-authenticated-session.test.ts
+++ b/src/modules/bank-sessions/ensure-authenticated-session.test.ts
@@ -184,6 +184,48 @@ describe("coordinateAuthenticatedSessionState", () => {
     expect(attempts.completeAuthenticated).toHaveBeenCalledTimes(1);
   });
 
+  it("vaults the lease duration for begin and submit-boundary transitions", async () => {
+    const { attempts, dependencies, probe } = setup(); probe.observe.mockResolvedValue({ status: "unauthenticated" });
+    const acquired = await coordinate(dependencies); if (acquired.status !== "authentication_required") throw new Error("expected authority");
+    const claimed = claimAuthenticationMutationAuthority(acquired.authority); if (claimed.status !== "claimed") throw new Error("expected claim");
+    await claimed.authority.beginCredentialInteraction(); await claimed.authority.recordSubmitBarrier();
+    expect(attempts.beginCredentialInteraction).toHaveBeenCalledWith({ owner, leaseDurationMs: 1_000 });
+    expect(attempts.recordSubmitBarrier).toHaveBeenCalledWith({ owner, leaseDurationMs: 1_000 });
+  });
+
+  it.each([
+    ["begin", "lease_renewed", interacting()],
+    ["renew", "interaction_started", interacting()],
+    ["barrier", "interaction_started", submitted()],
+  ] as const)("poisons cross-operation %s success statuses", async (operation, status, record) => {
+    const { attempts, dependencies, probe } = setup(); probe.observe.mockResolvedValue({ status: "unauthenticated" });
+    const acquired = await coordinate(dependencies); if (acquired.status !== "authentication_required") throw new Error("expected authority");
+    const claimed = claimAuthenticationMutationAuthority(acquired.authority); if (claimed.status !== "claimed") throw new Error("expected claim");
+    if (operation !== "begin") await claimed.authority.beginCredentialInteraction();
+    if (operation === "begin") attempts.beginCredentialInteraction.mockResolvedValueOnce({ status, record } as never);
+    if (operation === "renew") attempts.renewLease.mockResolvedValueOnce({ status, record } as never);
+    if (operation === "barrier") attempts.recordSubmitBarrier.mockResolvedValueOnce({ status, record } as never);
+    const result = operation === "begin" ? await claimed.authority.beginCredentialInteraction() : operation === "renew" ? await claimed.authority.renewLease() : await claimed.authority.recordSubmitBarrier();
+    expect(result).toEqual({ status: "unavailable" });
+    await expect(claimed.authority.completeAuthenticated()).resolves.toEqual({ status: "invalid_sequence" });
+  });
+
+  it.each([
+    { label: "status only", result: { status: "interaction_started" } },
+    { label: "wrong phase", result: { status: "interaction_started", record: owned() } },
+    { label: "wrong identity", result: { status: "interaction_started", record: { ...interacting(), identity: { ...identity, attemptId: "other" } } } },
+    { label: "wrong owner", result: { status: "interaction_started", record: { ...interacting(), ownerToken: "other" } } },
+    { label: "wrong generation", result: { status: "interaction_started", record: { ...interacting(), generation: 1n } } },
+    { label: "invalid lease", result: { status: "interaction_started", record: { ...interacting(), leaseExpiresAt: new Date("invalid") } } },
+  ])("poisons malformed begin authorization with $label", async ({ result }) => {
+    const { attempts, dependencies, probe } = setup(); probe.observe.mockResolvedValue({ status: "unauthenticated" });
+    const acquired = await coordinate(dependencies); if (acquired.status !== "authentication_required") throw new Error("expected authority");
+    const claimed = claimAuthenticationMutationAuthority(acquired.authority); if (claimed.status !== "claimed") throw new Error("expected claim");
+    attempts.beginCredentialInteraction.mockResolvedValueOnce(result as never);
+    await expect(claimed.authority.beginCredentialInteraction()).resolves.toEqual({ status: "unavailable" });
+    await expect(claimed.authority.recordSubmitBarrier()).resolves.toEqual({ status: "invalid_sequence" });
+  });
+
   it("poisons the lifecycle after a repository throw or non-authorizing result", async () => {
     const { attempts, dependencies, probe } = setup(); probe.observe.mockResolvedValue({ status: "unauthenticated" });
     const result = await coordinate(dependencies); if (result.status !== "authentication_required") throw new Error("expected authority");

--- a/src/modules/bank-sessions/session-authentication-attempt-repository.test.ts
+++ b/src/modules/bank-sessions/session-authentication-attempt-repository.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   parseSessionAuthenticationAttemptRecord,
   type AcquireSessionAuthenticationLeaseResult,
@@ -82,6 +82,28 @@ describe("ObservedRestorationResolver", () => {
   });
 });
 
+describe("PrismaBankSessionAuthenticationAttemptRepository lease duration validation", () => {
+  it.each([0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, Number.MAX_SAFE_INTEGER + 1])("rejects invalid duration %p before issuing SQL", async (leaseDurationMs) => {
+    const query = vi.fn();
+    const repository = new PrismaBankSessionAuthenticationAttemptRepository({ $queryRaw: query } as never);
+    await expect(repository.acquireLease({ identity: owner.identity, ownerToken: owner.ownerToken, leaseDurationMs })).rejects.toThrow();
+    await expect(repository.renewLease({ owner, leaseDurationMs })).rejects.toThrow();
+    await expect(repository.beginCredentialInteraction({ owner, leaseDurationMs })).rejects.toThrow();
+    await expect(repository.recordSubmitBarrier({ owner, leaseDurationMs })).rejects.toThrow();
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it("accepts a positive safe-integer duration for every lease boundary", async () => {
+    const query = vi.fn().mockResolvedValue([]);
+    const repository = new PrismaBankSessionAuthenticationAttemptRepository({ $queryRaw: query } as never);
+    await repository.acquireLease({ identity: owner.identity, ownerToken: owner.ownerToken, leaseDurationMs: 1 });
+    await repository.renewLease({ owner, leaseDurationMs: 1 });
+    await repository.beginCredentialInteraction({ owner, leaseDurationMs: 1 });
+    await repository.recordSubmitBarrier({ owner, leaseDurationMs: 1 });
+    expect(query).toHaveBeenCalled();
+  });
+});
+
 type RepositoryMethods = Pick<SessionAuthenticationAttemptRepository,
   "getOrCreate" | "findExact" | "acquireLease" | "renewLease" | "beginCredentialInteraction" |
   "recordSubmitBarrier" | "claimRetry" | "completeAuthenticated" | "completeFailed" | "reconcileExpiredLease">;
@@ -92,6 +114,10 @@ declare const repository: SessionAuthenticationAttemptRepository;
 if (false) {
   // @ts-expect-error The generic repository operation is intentionally unavailable.
   void repository.execute;
+  // @ts-expect-error Mutation boundaries require an explicit lease renewal duration.
+  void repository.beginCredentialInteraction({ owner });
+  // @ts-expect-error Mutation boundaries require an explicit lease renewal duration.
+  void repository.recordSubmitBarrier({ owner });
 }
 
 const submitBarrierResults: readonly RecordSessionAuthenticationSubmitBarrierResult[] = [

--- a/src/modules/bank-sessions/session-authentication-attempt-repository.ts
+++ b/src/modules/bank-sessions/session-authentication-attempt-repository.ts
@@ -45,8 +45,8 @@ export type GetOrCreateSessionAuthenticationAttemptInput = Readonly<{ identity: 
 export type FindExactSessionAuthenticationAttemptInput = Readonly<{ identity: SessionAuthenticationAttemptIdentity }>;
 export type AcquireSessionAuthenticationLeaseInput = Readonly<{ identity: SessionAuthenticationAttemptIdentity; ownerToken: string; leaseDurationMs: number }>;
 export type RenewSessionAuthenticationLeaseInput = Readonly<{ owner: SessionAuthenticationLeaseOwner; leaseDurationMs: number }>;
-export type BeginCredentialInteractionInput = Readonly<{ owner: SessionAuthenticationLeaseOwner }>;
-export type RecordSubmitBarrierInput = Readonly<{ owner: SessionAuthenticationLeaseOwner }>;
+export type BeginCredentialInteractionInput = Readonly<{ owner: SessionAuthenticationLeaseOwner; leaseDurationMs: number }>;
+export type RecordSubmitBarrierInput = Readonly<{ owner: SessionAuthenticationLeaseOwner; leaseDurationMs: number }>;
 export type ClaimRetryInput = Readonly<{ owner: SessionAuthenticationLeaseOwner }>;
 // PostgreSQL is the authoritative clock for terminal and lease timestamps.
 export type CompleteAuthenticatedInput = Readonly<{ owner: SessionAuthenticationLeaseOwner }>;

--- a/src/modules/persistence/prisma-bank-session-authentication-attempt-repository.ts
+++ b/src/modules/persistence/prisma-bank-session-authentication-attempt-repository.ts
@@ -47,7 +47,7 @@ function observedRestorationEvidence(attempt: SessionAuthenticationAttemptRecord
 
 function assertLease(ownerToken: string, duration: number): void {
   if (!ownerToken.trim()) throw new Error("Session authentication owner token must be nonblank");
-  if (!Number.isFinite(duration) || duration <= 0) throw new Error("Session authentication lease duration must be positive and finite");
+  if (!Number.isSafeInteger(duration) || duration <= 0) throw new Error("Session authentication lease duration must be a positive safe integer");
 }
 function assertObservedOwner(owner: SessionAuthenticationLeaseOwner): void {
   if (![owner.identity.bankCode, owner.identity.runId, owner.identity.attemptId, owner.ownerToken].every((value) => value.trim())) throw new Error("Observed restoration identity and owner must be nonblank");
@@ -138,14 +138,16 @@ export class PrismaBankSessionAuthenticationAttemptRepository implements Session
     const state = await this.ownerState(owner); return state.status === "current" ? { status: "not_applied" } : state;
   }
 
-  async beginCredentialInteraction({ owner }: BeginCredentialInteractionInput): Promise<BeginCredentialInteractionResult> {
-    const rows = await this.prisma.$queryRaw<Row[]>`UPDATE "BankSessionAuthenticationAttempt" SET "interactionPhase" = 'credentials_may_have_reached_portal', "updatedAt" = NOW() WHERE "bankCode" = ${owner.identity.bankCode} AND "runId" = ${owner.identity.runId} AND "attemptId" = ${owner.identity.attemptId} AND "status" = 'active' AND "ownerToken" = ${owner.ownerToken} AND "generation" = ${owner.generation} AND "leaseExpiresAt" > NOW() AND "interactionPhase" = 'no_credential_interaction' RETURNING "bankCode", "runId", "attemptId", "status", "interactionPhase", "failureClass", "operatorReason", "retryCount", "ownerToken", "generation", "leaseExpiresAt", "terminalAt", "createdAt", "updatedAt"`;
+  async beginCredentialInteraction({ owner, leaseDurationMs }: BeginCredentialInteractionInput): Promise<BeginCredentialInteractionResult> {
+    assertLease(owner.ownerToken, leaseDurationMs);
+    const rows = await this.prisma.$queryRaw<Row[]>`UPDATE "BankSessionAuthenticationAttempt" SET "interactionPhase" = 'credentials_may_have_reached_portal', "leaseExpiresAt" = NOW() + (${leaseDurationMs} * INTERVAL '1 millisecond'), "updatedAt" = NOW() WHERE "bankCode" = ${owner.identity.bankCode} AND "runId" = ${owner.identity.runId} AND "attemptId" = ${owner.identity.attemptId} AND "status" = 'active' AND "ownerToken" = ${owner.ownerToken} AND "generation" = ${owner.generation} AND "leaseExpiresAt" > NOW() AND "interactionPhase" = 'no_credential_interaction' RETURNING "bankCode", "runId", "attemptId", "status", "interactionPhase", "failureClass", "operatorReason", "retryCount", "ownerToken", "generation", "leaseExpiresAt", "terminalAt", "createdAt", "updatedAt"`;
     if (rows[0]) return { status: "interaction_started", record: record(rows[0]) };
     const state = await this.ownerState(owner); return state.status === "current" ? { status: "already_started", record: state.record } : state;
   }
 
-  async recordSubmitBarrier({ owner }: RecordSubmitBarrierInput): Promise<RecordSessionAuthenticationSubmitBarrierResult> {
-    const rows = await this.prisma.$queryRaw<Row[]>`UPDATE "BankSessionAuthenticationAttempt" SET "interactionPhase" = 'submit_may_have_been_dispatched', "updatedAt" = NOW() WHERE "bankCode" = ${owner.identity.bankCode} AND "runId" = ${owner.identity.runId} AND "attemptId" = ${owner.identity.attemptId} AND "status" = 'active' AND "ownerToken" = ${owner.ownerToken} AND "generation" = ${owner.generation} AND "leaseExpiresAt" > NOW() AND "interactionPhase" = 'credentials_may_have_reached_portal' RETURNING "bankCode", "runId", "attemptId", "status", "interactionPhase", "failureClass", "operatorReason", "retryCount", "ownerToken", "generation", "leaseExpiresAt", "terminalAt", "createdAt", "updatedAt"`;
+  async recordSubmitBarrier({ owner, leaseDurationMs }: RecordSubmitBarrierInput): Promise<RecordSessionAuthenticationSubmitBarrierResult> {
+    assertLease(owner.ownerToken, leaseDurationMs);
+    const rows = await this.prisma.$queryRaw<Row[]>`UPDATE "BankSessionAuthenticationAttempt" SET "interactionPhase" = 'submit_may_have_been_dispatched', "leaseExpiresAt" = NOW() + (${leaseDurationMs} * INTERVAL '1 millisecond'), "updatedAt" = NOW() WHERE "bankCode" = ${owner.identity.bankCode} AND "runId" = ${owner.identity.runId} AND "attemptId" = ${owner.identity.attemptId} AND "status" = 'active' AND "ownerToken" = ${owner.ownerToken} AND "generation" = ${owner.generation} AND "leaseExpiresAt" > NOW() AND "interactionPhase" = 'credentials_may_have_reached_portal' RETURNING "bankCode", "runId", "attemptId", "status", "interactionPhase", "failureClass", "operatorReason", "retryCount", "ownerToken", "generation", "leaseExpiresAt", "terminalAt", "createdAt", "updatedAt"`;
     if (rows[0]) return { status: "recorded", record: record(rows[0]) };
     const state = await this.ownerState(owner);
     if (state.status !== "current") return state;

--- a/src/modules/persistence/session-authentication-attempt.postgres.test.ts
+++ b/src/modules/persistence/session-authentication-attempt.postgres.test.ts
@@ -124,7 +124,7 @@ describe.skipIf(!url)("Session authentication attempt PostgreSQL contract", () =
     const replacement = await repo().acquireLease({ identity: id, ownerToken: "replacement", leaseDurationMs: 10_000 });
     if (replacement.status !== "lease_acquired") throw new Error("Expected replacement owner after reconciliation");
     expect(replacement.owner.generation).toBeGreaterThan(old.generation);
-    await expect(repo().beginCredentialInteraction({ owner: old })).resolves.toEqual({ status: "stale_owner" });
+    await expect(repo().beginCredentialInteraction({ owner: old, leaseDurationMs: 10_000 })).resolves.toEqual({ status: "stale_owner" });
   });
 
   it("does not label a failed renew CAS as expired when its diagnostic still sees an active current owner", async () => {
@@ -138,21 +138,68 @@ describe.skipIf(!url)("Session authentication attempt PostgreSQL contract", () =
 
   it("preserves monotonic interaction and requires one recorded submit barrier", async () => {
     const { id, owner: current } = await lease("barrier");
-    await expect(repo().recordSubmitBarrier({ owner: current })).resolves.toEqual({ status: "invalid_transition" });
-    await expect(repo().beginCredentialInteraction({ owner: current })).resolves.toMatchObject({ status: "interaction_started" });
-    await expect(repo().beginCredentialInteraction({ owner: current })).resolves.toMatchObject({ status: "already_started" });
-    await expect(repo().recordSubmitBarrier({ owner: current })).resolves.toMatchObject({ status: "recorded" });
-    await expect(repo().recordSubmitBarrier({ owner: current })).resolves.toMatchObject({ status: "already_recorded" });
+    await expect(repo().recordSubmitBarrier({ owner: current, leaseDurationMs: 10_000 })).resolves.toEqual({ status: "invalid_transition" });
+    await expect(repo().beginCredentialInteraction({ owner: current, leaseDurationMs: 10_000 })).resolves.toMatchObject({ status: "interaction_started" });
+    await expect(repo().beginCredentialInteraction({ owner: current, leaseDurationMs: 10_000 })).resolves.toMatchObject({ status: "already_started" });
+    await expect(repo().recordSubmitBarrier({ owner: current, leaseDurationMs: 10_000 })).resolves.toMatchObject({ status: "recorded" });
+    await expect(repo().recordSubmitBarrier({ owner: current, leaseDurationMs: 10_000 })).resolves.toMatchObject({ status: "already_recorded" });
     expect((await repo().findExact({ identity: id }))).toMatchObject({ status: "found", record: { interactionPhase: "submit_may_have_been_dispatched" } });
   });
 
   it("does not authorize a second submit barrier", async () => {
     const { owner } = await lease("second-submit");
-    await repo().beginCredentialInteraction({ owner });
-    await expect(repo().recordSubmitBarrier({ owner })).resolves.toMatchObject({ status: "recorded" });
-    const second = await repo().recordSubmitBarrier({ owner });
+    await repo().beginCredentialInteraction({ owner, leaseDurationMs: 10_000 });
+    await expect(repo().recordSubmitBarrier({ owner, leaseDurationMs: 10_000 })).resolves.toMatchObject({ status: "recorded" });
+    const second = await repo().recordSubmitBarrier({ owner, leaseDurationMs: 10_000 });
     expect(second.status).toBe("already_recorded");
     expect(second.status === "recorded").toBe(false);
+  });
+
+  it("renews near-expiry mutation boundaries from PostgreSQL NOW()", async () => {
+    const verify = async (name: string, barrier: boolean) => {
+      const { id, owner } = await lease(name);
+      if (barrier) await repo().beginCredentialInteraction({ owner, leaseDurationMs: 10_000 });
+      await pool!.query('UPDATE "BankSessionAuthenticationAttempt" SET "leaseExpiresAt" = NOW() + INTERVAL \'100 milliseconds\' WHERE "bankCode" = $1 AND "runId" = $2 AND "attemptId" = $3', [id.bankCode, id.runId, id.attemptId]);
+      const clock = await pool!.connect();
+      try {
+        const lower = (await clock.query<{ now: Date }>('SELECT NOW() AS "now"')).rows[0].now;
+        const result = barrier ? await repo().recordSubmitBarrier({ owner, leaseDurationMs: 10_000 }) : await repo().beginCredentialInteraction({ owner, leaseDurationMs: 10_000 });
+        const upper = (await clock.query<{ now: Date }>('SELECT NOW() AS "now"')).rows[0].now;
+        if (!(result.status === "recorded" || result.status === "interaction_started")) throw new Error("Expected mutation boundary transition");
+        expect(result.record.leaseExpiresAt!.getTime()).toBeGreaterThanOrEqual(lower.getTime() + 10_000);
+        expect(result.record.leaseExpiresAt!.getTime()).toBeLessThanOrEqual(upper.getTime() + 10_000);
+      } finally { clock.release(); }
+    };
+    await verify("near-expiry-begin", false);
+    await verify("near-expiry-barrier", true);
+  });
+
+  it("does not renew failed mutation boundaries and rolls back a forced SQL failure", async () => {
+    const { id, owner } = await lease("boundary-no-renew");
+    const before = await repo().findExact({ identity: id });
+    if (before.status !== "found") throw new Error("Expected attempt");
+    await expect(repo().recordSubmitBarrier({ owner, leaseDurationMs: 10_000 })).resolves.toEqual({ status: "invalid_transition" });
+    await expect(repo().findExact({ identity: id })).resolves.toEqual(before);
+    await pool!.query('CREATE FUNCTION fail_auth_boundary() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION \'forced\'; END $$; CREATE TRIGGER fail_auth_boundary BEFORE UPDATE ON "BankSessionAuthenticationAttempt" FOR EACH ROW EXECUTE FUNCTION fail_auth_boundary()');
+    await expect(repo().beginCredentialInteraction({ owner, leaseDurationMs: 10_000 })).rejects.toThrow("forced");
+    await pool!.query('DROP TRIGGER fail_auth_boundary ON "BankSessionAuthenticationAttempt"; DROP FUNCTION fail_auth_boundary()');
+    await expect(repo().findExact({ identity: id })).resolves.toEqual(before);
+  });
+
+  it("leaves phase and expiry unchanged for stale, expired, invalid, and replayed boundaries", async () => {
+    const unchanged = async (name: string, action: (owner: Awaited<ReturnType<typeof lease>>["owner"], id: ReturnType<typeof attemptIdentity>) => Promise<unknown>) => {
+      const { id, owner } = await lease(name); const before = await repo().findExact({ identity: id });
+      await action(owner, id); await expect(repo().findExact({ identity: id })).resolves.toEqual(before);
+    };
+    await unchanged("stale-token", (owner) => repo().beginCredentialInteraction({ owner: { ...owner, ownerToken: "wrong" }, leaseDurationMs: 10_000 }));
+    await unchanged("stale-generation", (owner) => repo().beginCredentialInteraction({ owner: { ...owner, generation: owner.generation + 1n }, leaseDurationMs: 10_000 }));
+    const expired = await lease("expired"); await expire(expired.id); const beforeExpired = await repo().findExact({ identity: expired.id });
+    await repo().beginCredentialInteraction({ owner: expired.owner, leaseDurationMs: 10_000 });
+    await expect(repo().findExact({ identity: expired.id })).resolves.toEqual(beforeExpired);
+    await unchanged("invalid-transition", (owner) => repo().recordSubmitBarrier({ owner, leaseDurationMs: 10_000 }));
+    const { id, owner } = await lease("replayed"); await repo().beginCredentialInteraction({ owner, leaseDurationMs: 10_000 });
+    const beforeReplay = await repo().findExact({ identity: id }); await repo().beginCredentialInteraction({ owner, leaseDurationMs: 10_000 });
+    await expect(repo().findExact({ identity: id })).resolves.toEqual(beforeReplay);
   });
 
   it("returns not_applied for ambiguous retry and completion diagnostics", async () => {
@@ -172,8 +219,8 @@ describe.skipIf(!url)("Session authentication attempt PostgreSQL contract", () =
     const next = await repo().acquireLease({ identity: id, ownerToken: "next", leaseDurationMs: 10_000 });
     if (next.status !== "lease_acquired") throw new Error("Expected replacement owner");
     expect(next.owner.generation).toBeGreaterThan(old.generation);
-    await expect(repo().beginCredentialInteraction({ owner: old })).resolves.toEqual({ status: "stale_owner" });
-    await expect(repo().recordSubmitBarrier({ owner: old })).resolves.toEqual({ status: "stale_owner" });
+    await expect(repo().beginCredentialInteraction({ owner: old, leaseDurationMs: 10_000 })).resolves.toEqual({ status: "stale_owner" });
+    await expect(repo().recordSubmitBarrier({ owner: old, leaseDurationMs: 10_000 })).resolves.toEqual({ status: "stale_owner" });
     await expect(repo().completeAuthenticated({ owner: old })).resolves.toEqual({ status: "stale_owner" });
     await expect(repo().completeAuthenticated({ owner: next.owner })).resolves.toMatchObject({ status: "authenticated", record: { retryCount: 1 } });
     await expect(repo().completeFailed({ owner: next.owner, failureClass: "transient_pre_interaction", operatorReason: "temporary_authentication_problem" })).resolves.toEqual({ status: "terminal" });
@@ -189,8 +236,8 @@ describe.skipIf(!url)("Session authentication attempt PostgreSQL contract", () =
     await expect(repo().findExact({ identity: retry.id })).resolves.toMatchObject({ status: "found", record: { status: "failed", retryCount: 2, generation: 6n, failureClass: "transient_pre_interaction", operatorReason: "temporary_authentication_problem" } });
     for (const phase of ["no", "credentials", "submit"] as const) {
       const current = await lease(`expired-${phase}`);
-      if (phase !== "no") await repo().beginCredentialInteraction({ owner: current.owner });
-      if (phase === "submit") await repo().recordSubmitBarrier({ owner: current.owner });
+       if (phase !== "no") await repo().beginCredentialInteraction({ owner: current.owner, leaseDurationMs: 10_000 });
+       if (phase === "submit") await repo().recordSubmitBarrier({ owner: current.owner, leaseDurationMs: 10_000 });
       await expire(current.id); const reconciled = await repo().reconcileExpiredLease({ identity: current.id });
       expect(reconciled).toMatchObject(phase === "no" ? { status: "lease_reconciled", record: { retryCount: 1, status: "active" } } : { status: "lease_reconciled", record: { status: "failed", failureClass: "interaction_outcome_uncertain" } });
       await expect(repo().completeAuthenticated({ owner: current.owner })).resolves.toMatchObject({ status: phase === "no" ? "stale_owner" : "terminal" });
@@ -199,8 +246,8 @@ describe.skipIf(!url)("Session authentication attempt PostgreSQL contract", () =
 
   it.each(["no_credential_interaction", "credentials_may_have_reached_portal", "submit_may_have_been_dispatched"] as const)("resolves manual recovery with exact durable evidence for %s", async (phase) => {
     const { id, owner } = await lease(`observed-${phase}`); await episode(id);
-    if (phase !== "no_credential_interaction") await repo().beginCredentialInteraction({ owner });
-    if (phase === "submit_may_have_been_dispatched") await repo().recordSubmitBarrier({ owner });
+    if (phase !== "no_credential_interaction") await repo().beginCredentialInteraction({ owner, leaseDurationMs: 10_000 });
+    if (phase === "submit_may_have_been_dispatched") await repo().recordSubmitBarrier({ owner, leaseDurationMs: 10_000 });
     const result = await repo().resolveObservedRestoration(owner);
     if (result.status !== "resolved") throw new Error("Expected observed restoration");
     expect(result.evidence).toMatchObject({ identity: id, interactionPhase: phase, terminalGeneration: owner.generation + 1n });

--- a/src/worker/scraper/durable-auto-login-mutation.test.ts
+++ b/src/worker/scraper/durable-auto-login-mutation.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createBankAutoLoginStrategy, type BankAutoLoginPage, type BankAutoLoginStrategy } from "./auto-login";
 import { executeDurablyFencedAutoLogin } from "./durable-auto-login-mutation";
 import type {
@@ -93,6 +93,15 @@ describe("executeDurablyFencedAutoLogin", () => {
     const events: string[] = [];
     await execute(events, async (p) => { await p.click("submit"); });
     expect(events).toEqual(["barrier", "click:submit"]);
+  });
+
+  it("passes the executor lease duration to both mutation boundaries", async () => {
+    const events: string[] = [];
+    const beginCredentialInteraction = vi.fn().mockResolvedValue({ status: "interaction_started", record });
+    const recordSubmitBarrier = vi.fn().mockResolvedValue({ status: "recorded", record });
+    await executeDurablyFencedAutoLogin({ strategy: strategy(async (p) => { await p.fill("user", "alice"); await p.click("submit"); }), credential, page: page(events), attempts: { beginCredentialInteraction, renewLease: attempts(events).renewLease, recordSubmitBarrier }, owner, leaseDurationMs: 321 });
+    expect(beginCredentialInteraction).toHaveBeenCalledWith({ owner, leaseDurationMs: 321 });
+    expect(recordSubmitBarrier).toHaveBeenCalledWith({ owner, leaseDurationMs: 321 });
   });
 
   it.each(["already_recorded", "invalid_transition", "stale_owner", "lease_expired", "terminal", "missing", "not_applied"] as const)("blocks every non-authorizing barrier: %s", async (barrier) => {

--- a/src/worker/scraper/durable-auto-login-mutation.ts
+++ b/src/worker/scraper/durable-auto-login-mutation.ts
@@ -49,7 +49,7 @@ export async function executeDurablyFencedAutoLogin(input: Readonly<{
       if (denial) throw new Error("Durable auto-login mutation denied");
       try {
         const result = phase === "no_credential_interaction"
-          ? await input.attempts.beginCredentialInteraction({ owner: input.owner })
+          ? await input.attempts.beginCredentialInteraction({ owner: input.owner, leaseDurationMs: input.leaseDurationMs })
           : await input.attempts.renewLease({ owner: input.owner, leaseDurationMs: input.leaseDurationMs });
         const authorized = phase === "no_credential_interaction" ? result.status === "interaction_started" : result.status === "lease_renewed";
         if (!authorized) deny(blockFor(result.status));
@@ -63,7 +63,7 @@ export async function executeDurablyFencedAutoLogin(input: Readonly<{
     async click(selector) {
       if (denial) throw new Error("Durable auto-login mutation denied");
       try {
-        const result = await input.attempts.recordSubmitBarrier({ owner: input.owner });
+        const result = await input.attempts.recordSubmitBarrier({ owner: input.owner, leaseDurationMs: input.leaseDurationMs });
         if (result.status !== "recorded") deny(blockFor(result.status));
         phase = "submit_may_have_been_dispatched";
       } catch {


### PR DESCRIPTION
Closes #90

Related: #86 and #84 are prerequisites only; this PR does not close them.

## Summary
- Renews the lease atomically with the begin-interaction and submit-barrier phase transitions, using database `NOW()` in the same `UPDATE`.
- Requires a positive safe lease duration and forwards the vaulted value through the mutation authority.
- Enforces exact operation, status, and phase guards; replay paths do not renew a lease.
- Preserves executor compatibility by forwarding the existing `leaseDurationMs` to the begin-interaction and submit-barrier calls while retaining the already-established immediate pre-click barrier placement.

## Review Path

| File | Change |
| --- | --- |
| `src/modules/bank-sessions/authentication-mutation-authority.ts` | Validates and forwards the vaulted renewal duration at mutation boundaries. |
| `src/modules/bank-sessions/ensure-authenticated-session.test.ts` | Covers authority forwarding and boundary behavior. |
| `src/modules/bank-sessions/session-authentication-attempt-repository.test.ts` | Covers repository contract guards. |
| `src/modules/bank-sessions/session-authentication-attempt-repository.ts` | Extends transition inputs with the renewal duration. |
| `src/modules/persistence/prisma-bank-session-authentication-attempt-repository.ts` | Performs guarded phase change and lease renewal atomically. |
| `src/modules/persistence/session-authentication-attempt.postgres.test.ts` | Verifies PostgreSQL behavior and replay nonrenewal. |
| `src/worker/scraper/durable-auto-login-mutation.test.ts` | Covers executor compatibility and click-adjacent barrier placement. |
| `src/worker/scraper/durable-auto-login-mutation.ts` | Forwards the existing `leaseDurationMs` to the existing begin/barrier operations while preserving the already-established immediate pre-click barrier placement. |

## Scope

- No heartbeat, timers, or activation behavior: production remains inert. Heartbeat work is future WU4.
- No Prisma schema or migration changes.

## Verification

- Full suite: 1,527 passed, 2 skipped.
- Focused authority/executor suite: 161 passed.
- Fresh PostgreSQL 16 run: all 16 migrations applied; 163 PostgreSQL tests passed.
- `pnpm lint`, `pnpm typecheck`, `pnpm prisma validate`, and `git diff --check` passed.
- Migration diff is N/A because schema and migrations are untouched; Prisma validation passed.
- The repository has no CI workflows, so zero GitHub checks are expected. The evidence above is local; this PR does not claim CI is green.

## Review Budget And Rollback

- Eight-file review path; 157 additions and 31 deletions (188 total), under the 400-line budget without an exception.
- Roll back by reverting commit `2f8f01a`; only these eight files are removed and no data migration is involved.