### PR TITLE
feat(bank-sessions): orchestrate authenticated session precondition

### DIFF
--- a/src/modules/bank-sessions/authenticated-session-precondition.test.ts
+++ b/src/modules/bank-sessions/authenticated-session-precondition.test.ts
@@ -1,0 +1,119 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it, vi } from "vitest";
+import {
+  coordinateAuthenticatedSessionPrecondition,
+  type AuthenticatedSessionMutationRunner,
+  type AuthenticatedSessionStateCoordinator,
+} from "./authenticated-session-precondition";
+import type { AuthenticationMutationAuthority } from "./authentication-mutation-authority";
+import type { CoordinateAuthenticatedSessionStateInput } from "./ensure-authenticated-session";
+
+const input: CoordinateAuthenticatedSessionStateInput = {
+  identity: { bankCode: "popular", runId: "run-1", attemptId: "attempt-1" },
+  ownerToken: "caller-owner",
+  leaseDurationMs: 1_000,
+};
+const authority = {} as AuthenticationMutationAuthority;
+const operatorReasons = [
+  "temporary_authentication_problem",
+  "protected_authentication_step_detected",
+  "bank_login_configuration_requires_review",
+  "authentication_attempt_requires_review",
+] as const;
+
+function setup(coordinatorResult: unknown, runnerResult: unknown) {
+  const coordinator = { coordinate: vi.fn().mockResolvedValue(coordinatorResult) };
+  const runner = { run: vi.fn().mockResolvedValue(runnerResult) };
+  return { coordinator, runner };
+}
+
+function precondition(coordinatorResult: unknown, ...runnerResults: [unknown] | []) {
+  const runnerResult = runnerResults.length === 0 ? { status: "authenticated" } : runnerResults[0];
+  const { coordinator, runner } = setup(coordinatorResult, runnerResult);
+  return { coordinator, runner, result: coordinateAuthenticatedSessionPrecondition(input, { coordinator: coordinator as AuthenticatedSessionStateCoordinator, runner: runner as AuthenticatedSessionMutationRunner }) };
+}
+
+describe("coordinateAuthenticatedSessionPrecondition", () => {
+  it.each(["existing", "observed"] as const)("returns authenticated from coordinator %s without running a mutation", async (source) => {
+    const { runner, result } = precondition({ status: "authenticated", source });
+    await expect(result).resolves.toEqual({ status: "authenticated" });
+    expect(runner.run).not.toHaveBeenCalled();
+  });
+
+  it.each(["session_probe_unavailable", "ownership_changed", "state_changed"] as const)("maps coordinator retry %s to delivery retry", async (reason) => {
+    const { runner, result } = precondition({ status: "retry_later", reason });
+    await expect(result).resolves.toEqual({ status: "retry_delivery" });
+    expect(runner.run).not.toHaveBeenCalled();
+  });
+
+  it.each(["lease_held", "active_mutation_owner"] as const)("preserves coordinator in-progress %s", async (reason) => {
+    await expect(precondition({ status: "in_progress", reason }).result).resolves.toEqual({ status: "in_progress" });
+  });
+
+  it.each([...operatorReasons, "identity_conflict", "restoration_state_conflict"] as const)("preserves safe coordinator operator reason %s", async (reason) => {
+    await expect(precondition({ status: "needs_operator_action", reason }).result).resolves.toEqual({ status: "needs_operator_action", reason });
+  });
+
+  it.each(["cancelled", "invalid_request"] as const)("preserves coordinator %s", async (status) => {
+    await expect(precondition({ status }).result).resolves.toEqual({ status });
+  });
+
+  it("coordinates before handing the exact authority to the runner once", async () => {
+    const { coordinator, runner, result } = precondition({ status: "authentication_required", authority });
+    await expect(result).resolves.toEqual({ status: "authenticated" });
+    expect(runner.run).toHaveBeenCalledExactlyOnceWith(authority);
+    expect(coordinator.coordinate).toHaveBeenCalledExactlyOnceWith(input);
+    expect(coordinator.coordinate.mock.invocationCallOrder[0]).toBeLessThan(runner.run.mock.invocationCallOrder[0]);
+  });
+
+  it("runs after authority minting even if cancellation occurs before the runner", async () => {
+    const controller = new AbortController();
+    const coordinator = { coordinate: vi.fn().mockImplementation(async () => { controller.abort(); return { status: "authentication_required", authority }; }) };
+    const runner = { run: vi.fn().mockResolvedValue({ status: "authenticated" }) };
+    await expect(coordinateAuthenticatedSessionPrecondition({ ...input, signal: controller.signal }, { coordinator: coordinator as AuthenticatedSessionStateCoordinator, runner: runner as AuthenticatedSessionMutationRunner })).resolves.toEqual({ status: "authenticated" });
+    expect(runner.run).toHaveBeenCalledExactlyOnceWith(authority);
+  });
+
+  it.each([
+    [{ status: "authenticated" }, { status: "authenticated" }],
+    [{ status: "retry_claimed" }, { status: "retry_delivery" }],
+    [{ status: "retry_exhausted" }, { status: "needs_operator_action", reason: "temporary_authentication_problem" }],
+    [{ status: "unresolved" }, { status: "needs_operator_action", reason: "authentication_attempt_requires_review" }],
+  ])("maps runner result %# safely", async (runnerResult, expected) => {
+    await expect(precondition({ status: "authentication_required", authority }, runnerResult).result).resolves.toEqual(expected);
+  });
+
+  it.each(operatorReasons)("preserves safe runner failure reason %s", async (reason) => {
+    await expect(precondition({ status: "authentication_required", authority }, { status: "failed", reason }).result).resolves.toEqual({ status: "needs_operator_action", reason });
+  });
+
+  it.each([
+    null, undefined, true, 1, "authenticated", [], {}, { status: "unknown" }, { status: "failed" },
+    { status: "failed", reason: "wrong" }, { status: "authenticated", token: "leak" },
+    { status: "authenticated", authority }, { status: "authenticated", owner: "leak" }, { status: "authenticated", generation: 1 },
+  ])("fails closed for malformed runner output %#", async (runnerResult) => {
+    const state = await precondition({ status: "authentication_required", authority }, runnerResult).result;
+    expect(state).toEqual({ status: "needs_operator_action", reason: "authentication_attempt_requires_review" });
+    expect(JSON.stringify(state)).not.toMatch(/authority|token|owner|generation|error|leak/i);
+  });
+
+  it("fails closed when the runner throws", async () => {
+    const { coordinator, runner } = setup({ status: "authentication_required", authority }, { status: "authenticated" });
+    runner.run.mockRejectedValueOnce(new Error("raw private diagnostic"));
+    await expect(coordinateAuthenticatedSessionPrecondition(input, { coordinator: coordinator as AuthenticatedSessionStateCoordinator, runner: runner as AuthenticatedSessionMutationRunner })).resolves.toEqual({ status: "needs_operator_action", reason: "authentication_attempt_requires_review" });
+  });
+
+  it("calls each injected dependency at most once without retrying", async () => {
+    const { coordinator, runner } = setup({ status: "authentication_required", authority }, { status: "unresolved" });
+    await coordinateAuthenticatedSessionPrecondition(input, { coordinator, runner });
+    expect(coordinator.coordinate).toHaveBeenCalledTimes(1);
+    expect(runner.run).toHaveBeenCalledTimes(1);
+  });
+
+  it("exposes no authority-bearing result or forbidden capability surface", () => {
+    const source = readFileSync(fileURLToPath(new URL("./authenticated-session-precondition.ts", import.meta.url)), "utf8");
+    expect(source).not.toMatch(/claimAuthenticationMutationAuthority|ClaimedAuthenticationMutationAuthority/i);
+    expect(source).not.toMatch(/collection|audit|queue|browser|credential|repository/i);
+  });
+});

--- a/src/modules/bank-sessions/authenticated-session-precondition.test.ts
+++ b/src/modules/bank-sessions/authenticated-session-precondition.test.ts
@@ -14,7 +14,7 @@ const input: CoordinateAuthenticatedSessionStateInput = {
   ownerToken: "caller-owner",
   leaseDurationMs: 1_000,
 };
-const authority = {} as AuthenticationMutationAuthority;
+const authority = Object.freeze(Object.create(null)) as AuthenticationMutationAuthority;
 const operatorReasons = [
   "temporary_authentication_problem",
   "protected_authentication_step_detected",
@@ -57,6 +57,24 @@ describe("coordinateAuthenticatedSessionPrecondition", () => {
 
   it.each(["cancelled", "invalid_request"] as const)("preserves coordinator %s", async (status) => {
     await expect(precondition({ status }).result).resolves.toEqual({ status });
+  });
+
+  it.each([
+    null, undefined, true, 1, "authenticated", {}, { status: "unknown" }, { status: "authenticated" },
+    { status: "authenticated", source: "wrong" }, { status: "retry_later" }, { status: "retry_later", reason: "wrong" },
+    { status: "in_progress" }, { status: "in_progress", reason: "wrong" }, { status: "needs_operator_action" },
+    { status: "needs_operator_action", reason: "wrong" }, { status: "authentication_required" },
+    { status: "authentication_required", authority: {} }, { status: "authentication_required", authority: Object.create(null) },
+    { status: "authentication_required", authority: Object.freeze({}) },
+    { status: "authentication_required", authority: Object.freeze(Object.assign(Object.create(null), { token: "leak" })) },
+    { status: "authenticated", source: "existing", authority }, { status: "retry_later", reason: "state_changed", owner: "leak" },
+    { status: "cancelled", generation: 1 }, { status: "invalid_request", raw: "leak" },
+  ])("fails closed for malformed coordinator output %# without running a mutation", async (coordinatorResult) => {
+    const { runner, result } = precondition(coordinatorResult);
+    const state = await result;
+    expect(state).toEqual({ status: "needs_operator_action", reason: "authentication_attempt_requires_review" });
+    expect(JSON.stringify(state)).not.toMatch(/authority|token|owner|generation|raw|leak/i);
+    expect(runner.run).not.toHaveBeenCalled();
   });
 
   it("coordinates before handing the exact authority to the runner once", async () => {

--- a/src/modules/bank-sessions/authenticated-session-precondition.ts
+++ b/src/modules/bank-sessions/authenticated-session-precondition.ts
@@ -1,0 +1,74 @@
+import type { AuthenticationMutationAuthority } from "./authentication-mutation-authority";
+import type {
+  AuthenticatedSessionState,
+  CoordinateAuthenticatedSessionStateInput,
+} from "./ensure-authenticated-session";
+import type { SessionAuthenticationOperatorReason } from "./session-authentication-attempt";
+
+export interface AuthenticatedSessionStateCoordinator {
+  coordinate(input: CoordinateAuthenticatedSessionStateInput): Promise<AuthenticatedSessionState>;
+}
+
+export type AuthenticatedSessionMutationRunnerResult =
+  | Readonly<{ status: "authenticated" }>
+  | Readonly<{ status: "retry_claimed" }>
+  | Readonly<{ status: "retry_exhausted" }>
+  | Readonly<{ status: "failed"; reason: SessionAuthenticationOperatorReason }>
+  | Readonly<{ status: "unresolved" }>;
+
+export interface AuthenticatedSessionMutationRunner {
+  run(authority: AuthenticationMutationAuthority): Promise<AuthenticatedSessionMutationRunnerResult>;
+}
+
+export type AuthenticatedSessionPreconditionResult =
+  | Readonly<{ status: "authenticated" }>
+  | Readonly<{ status: "retry_delivery" }>
+  | Readonly<{ status: "needs_operator_action"; reason: SessionAuthenticationOperatorReason | "identity_conflict" | "restoration_state_conflict" }>
+  | Readonly<{ status: "in_progress" }>
+  | Readonly<{ status: "cancelled" }>
+  | Readonly<{ status: "invalid_request" }>;
+
+export type AuthenticatedSessionPreconditionDependencies = Readonly<{
+  coordinator: AuthenticatedSessionStateCoordinator;
+  runner: AuthenticatedSessionMutationRunner;
+}>;
+
+const review = (): AuthenticatedSessionPreconditionResult => ({ status: "needs_operator_action", reason: "authentication_attempt_requires_review" });
+const isRecord = (value: unknown): value is Record<PropertyKey, unknown> => typeof value === "object" && value !== null;
+const hasOnlyKeys = (value: Record<PropertyKey, unknown>, expected: string[]) => {
+  const keys = Reflect.ownKeys(value);
+  return keys.length === expected.length && keys.every((key) => typeof key === "string" && expected.includes(key));
+};
+const isOperatorReason = (value: unknown): value is SessionAuthenticationOperatorReason =>
+  value === "temporary_authentication_problem"
+  || value === "protected_authentication_step_detected"
+  || value === "bank_login_configuration_requires_review"
+  || value === "authentication_attempt_requires_review";
+
+function mapRunnerResult(value: unknown): AuthenticatedSessionPreconditionResult {
+  if (!isRecord(value)) return review();
+  if (hasOnlyKeys(value, ["status"]) && value.status === "authenticated") return { status: "authenticated" };
+  if (hasOnlyKeys(value, ["status"]) && value.status === "retry_claimed") return { status: "retry_delivery" };
+  if (hasOnlyKeys(value, ["status"]) && value.status === "retry_exhausted") return { status: "needs_operator_action", reason: "temporary_authentication_problem" };
+  if (hasOnlyKeys(value, ["status"]) && value.status === "unresolved") return review();
+  if (hasOnlyKeys(value, ["status", "reason"]) && value.status === "failed" && isOperatorReason(value.reason)) return { status: "needs_operator_action", reason: value.reason };
+  return review();
+}
+
+export async function coordinateAuthenticatedSessionPrecondition(
+  input: CoordinateAuthenticatedSessionStateInput,
+  { coordinator, runner }: AuthenticatedSessionPreconditionDependencies,
+): Promise<AuthenticatedSessionPreconditionResult> {
+  const state = await coordinator.coordinate(input);
+  if (state.status === "authenticated") return { status: "authenticated" };
+  if (state.status === "retry_later") return { status: "retry_delivery" };
+  if (state.status === "in_progress") return { status: "in_progress" };
+  if (state.status === "needs_operator_action") return { status: "needs_operator_action", reason: state.reason };
+  if (state.status === "cancelled" || state.status === "invalid_request") return state;
+
+  try {
+    return mapRunnerResult(await runner.run(state.authority));
+  } catch {
+    return review();
+  }
+}

--- a/src/modules/bank-sessions/authenticated-session-precondition.ts
+++ b/src/modules/bank-sessions/authenticated-session-precondition.ts
@@ -44,6 +44,20 @@ const isOperatorReason = (value: unknown): value is SessionAuthenticationOperato
   || value === "protected_authentication_step_detected"
   || value === "bank_login_configuration_requires_review"
   || value === "authentication_attempt_requires_review";
+const isAuthority = (value: unknown): value is AuthenticationMutationAuthority =>
+  isRecord(value) && Object.getPrototypeOf(value) === null && Object.isFrozen(value) && Reflect.ownKeys(value).length === 0;
+
+function parseCoordinatorState(value: unknown): AuthenticatedSessionState | null {
+  if (!isRecord(value)) return null;
+  if (hasOnlyKeys(value, ["status", "source"]) && value.status === "authenticated" && (value.source === "existing" || value.source === "observed")) return { status: "authenticated", source: value.source };
+  if (hasOnlyKeys(value, ["status", "authority"]) && value.status === "authentication_required" && isAuthority(value.authority)) return { status: "authentication_required", authority: value.authority };
+  if (hasOnlyKeys(value, ["status", "reason"]) && value.status === "retry_later" && (value.reason === "session_probe_unavailable" || value.reason === "ownership_changed" || value.reason === "state_changed")) return { status: "retry_later", reason: value.reason };
+  if (hasOnlyKeys(value, ["status", "reason"]) && value.status === "in_progress" && (value.reason === "lease_held" || value.reason === "active_mutation_owner")) return { status: "in_progress", reason: value.reason };
+  if (hasOnlyKeys(value, ["status", "reason"]) && value.status === "needs_operator_action" && (isOperatorReason(value.reason) || value.reason === "identity_conflict" || value.reason === "restoration_state_conflict")) return { status: "needs_operator_action", reason: value.reason };
+  if (hasOnlyKeys(value, ["status"]) && value.status === "cancelled") return { status: "cancelled" };
+  if (hasOnlyKeys(value, ["status"]) && value.status === "invalid_request") return { status: "invalid_request" };
+  return null;
+}
 
 function mapRunnerResult(value: unknown): AuthenticatedSessionPreconditionResult {
   if (!isRecord(value)) return review();
@@ -59,7 +73,13 @@ export async function coordinateAuthenticatedSessionPrecondition(
   input: CoordinateAuthenticatedSessionStateInput,
   { coordinator, runner }: AuthenticatedSessionPreconditionDependencies,
 ): Promise<AuthenticatedSessionPreconditionResult> {
-  const state = await coordinator.coordinate(input);
+  let state: AuthenticatedSessionState | null;
+  try {
+    state = parseCoordinatorState(await coordinator.coordinate(input));
+  } catch {
+    return review();
+  }
+  if (!state) return review();
   if (state.status === "authenticated") return { status: "authenticated" };
   if (state.status === "retry_later") return { status: "retry_delivery" };
   if (state.status === "in_progress") return { status: "in_progress" };
@@ -67,6 +87,7 @@ export async function coordinateAuthenticatedSessionPrecondition(
   if (state.status === "cancelled" || state.status === "invalid_request") return state;
 
   try {
+    // The runner's claim remains the final proof that this opaque handle is genuine.
     return mapRunnerResult(await runner.run(state.authority));
   } catch {
     return review();


### PR DESCRIPTION
Closes #92

## Summary
- Adds a pure authenticated-session precondition orchestrator whose injected runner is the sole lifecycle authority.
- Maps coordinator state to runner inputs; only an authenticated result permits a future collection step, while this work deliberately adds no collection capability.
- Preserves a single opaque-authority handoff, imports no claims, and never loops or issues a second abort after minting.

## Authority and Safety
| Topic | Decision |
|---|---|
| Coordinator and runner | Coordinator state maps to runner input; the injected runner owns session lifecycle decisions. |
| Authority handoff | The opaque authority is handed off exactly once; this unit neither imports claims nor exposes it. |
| Runtime parsing | Malformed coordinator and runner values are parsed strictly and fail closed with safe operator-facing outputs that leak no internals. |
| Delivery failures | `retry_delivery` preserves retry semantics; exhausted retries return explicit operator reasons. |

## Scope and Inertia
- This is intentionally inert in production: no caller, barrel export, runtime wiring, or capabilities are introduced.
- No collection occurs here; authenticated status is only the precondition for a future collection work unit.
- WU4 will implement the authority-consuming authenticated-session mutation runner while remaining inert; WU6 will gate production collection on this precondition and activate it.

## Review Path
1. Review `src/modules/bank-sessions/authenticated-session-precondition.ts` for coordinator-to-runner mapping, authority ownership, strict parsing, and failure handling.
2. Review `src/modules/bank-sessions/authenticated-session-precondition.test.ts` for lifecycle, malformed-value, retry-exhaustion, and safe-output contracts.

| File | Change |
|---|---|
| `src/modules/bank-sessions/authenticated-session-precondition.ts` | Adds the pure precondition orchestrator and strict runtime boundaries. |
| `src/modules/bank-sessions/authenticated-session-precondition.test.ts` | Adds behavior-focused contract coverage. |

The two-file change is 232 additions, 0 deletions, within the 400-line review budget.

## Commit Story and Rollback
- `0857789 feat(bank-sessions): orchestrate authenticated session precondition` introduces the independent work unit.
- An independent verifier found malformed coordinator values could reach the runner; `86400b6 fix(bank-sessions): reject malformed precondition state` closes that fail-closed gap.
- Rollback is limited to these two commits and the two listed files.

## Verification
- [x] Focused tests: 66 passed.
- [x] Full local verbose suite: 1,584 passed, 11 skipped, 0 failed.
- [x] Implementer run in a richer environment: 1,593 passed, 2 skipped.
- [x] Lint, typecheck, Prisma validation, and `git diff --check` passed.
- [x] Skips are environment-gated: one Redis ingestion integration lacks `RD_SYNC_TEST_REDIS_URL`; one expiry integration lacks a database or Redis URL; nine `launch-bank-browser` tests are locally allowed to skip because `bash` is absent from `PATH` outside CI.
- [x] The repository has no CI workflows; receipt-driven review is disabled/unmanaged, so verification evidence is local only.

## PR Type
- [x] New feature
- [ ] Bug fix
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Related Work
- Prerequisites: #90, #86
- Context: #67, #69

These items are related context and prerequisites only; this PR closes only #92.