### PR TITLE
feat(auto-login): add typed trigger lock identity

### DIFF
--- a/src/modules/bank-auto-login-lock/index.ts
+++ b/src/modules/bank-auto-login-lock/index.ts
@@ -1,5 +1,7 @@
 import { randomBytes } from "node:crypto";
 
+import { parseAutoLoginTriggerIdentity, type AutoLoginTriggerIdentity } from "../bank-auto-login-trigger";
+
 export interface AcquiredLock {
   leaseToken: string;
   fencingToken: number;
@@ -7,9 +9,9 @@ export interface AcquiredLock {
 }
 
 export interface AutoLoginLock {
-  acquire(bankCode: string, expiredEventId: string, ttlMs?: number): Promise<AcquiredLock | null>;
-  release(bankCode: string, expiredEventId: string, leaseToken: string): Promise<boolean>;
-  renew(bankCode: string, expiredEventId: string, leaseToken: string, ttlMs?: number): Promise<boolean>;
+  acquire(bankCode: string, trigger: string | AutoLoginTriggerIdentity, ttlMs?: number): Promise<AcquiredLock | null>;
+  release(bankCode: string, trigger: string | AutoLoginTriggerIdentity, leaseToken: string): Promise<boolean>;
+  renew(bankCode: string, trigger: string | AutoLoginTriggerIdentity, leaseToken: string, ttlMs?: number): Promise<boolean>;
 }
 
 export interface AcquireSlotParams {
@@ -77,8 +79,24 @@ function validateTtlMs(ttlMs: number, maxTtlMs?: number): void {
   ]);
 }
 
-export const buildLockKey = (bankCode: string, expiredEventId: string): string =>
-  `${LOCK_KEY_PREFIX}:${bankCode}:${expiredEventId}`;
+export const buildLockKey = (bankCode: string, trigger: string | AutoLoginTriggerIdentity): string => {
+  if (typeof trigger === "string") return `${LOCK_KEY_PREFIX}:${bankCode}:${trigger}`;
+  return trigger.kind === "session_expiry"
+    ? `${LOCK_KEY_PREFIX}:${bankCode}:${trigger.id}`
+    : `${LOCK_KEY_PREFIX}:v2:${bankCode}:authentication_attempt:${trigger.id}`;
+};
+
+function validateTrigger(trigger: string | AutoLoginTriggerIdentity): string | AutoLoginTriggerIdentity {
+  if (typeof trigger === "string") {
+    validateEventId(trigger);
+    return trigger;
+  }
+  try {
+    return parseAutoLoginTriggerIdentity(trigger);
+  } catch {
+    throw new LockValidationError("trigger", "must be a valid auto-login trigger identity");
+  }
+}
 
 const defaultGenerateLeaseToken = (): string => randomBytes(16).toString("hex");
 export function createAutoLoginLock(options: {
@@ -93,31 +111,31 @@ export function createAutoLoginLock(options: {
   if (!store) throw new Error("LockStore is required");
 
   return {
-    async acquire(bankCode, expiredEventId, ttlMs?) {
+    async acquire(bankCode, trigger, ttlMs?) {
       validateBankCode(bankCode);
-      validateEventId(expiredEventId);
+      const validatedTrigger = validateTrigger(trigger);
       const effectiveTtlMs = ttlMs ?? defaultTtlMs;
       validateTtlMs(effectiveTtlMs, maxTtlMs);
-      const key = buildLockKey(bankCode, expiredEventId);
+      const key = buildLockKey(bankCode, validatedTrigger);
       const leaseToken = generateLeaseToken();
       const currentTime = now();
       const fencingToken = await store.acquireSlot({ key, leaseToken, ttlMs: effectiveTtlMs, nowMs: currentTime });
       if (fencingToken === null) return null;
       return { leaseToken, fencingToken, expiresAt: currentTime + effectiveTtlMs };
     },
-    async release(bankCode, expiredEventId, leaseToken) {
+    async release(bankCode, trigger, leaseToken) {
       validateBankCode(bankCode);
-      validateEventId(expiredEventId);
+      const validatedTrigger = validateTrigger(trigger);
       validateLeaseToken(leaseToken);
-      return store.releaseIfOwner(buildLockKey(bankCode, expiredEventId), leaseToken);
+      return store.releaseIfOwner(buildLockKey(bankCode, validatedTrigger), leaseToken);
     },
-    async renew(bankCode, expiredEventId, leaseToken, ttlMs?) {
+    async renew(bankCode, trigger, leaseToken, ttlMs?) {
       validateBankCode(bankCode);
-      validateEventId(expiredEventId);
+      const validatedTrigger = validateTrigger(trigger);
       validateLeaseToken(leaseToken);
       const effectiveTtlMs = ttlMs ?? defaultTtlMs;
       validateTtlMs(effectiveTtlMs, maxTtlMs);
-      return store.renewIfOwner({ key: buildLockKey(bankCode, expiredEventId), expectedLeaseToken: leaseToken, newTtlMs: effectiveTtlMs, nowMs: now() });
+      return store.renewIfOwner({ key: buildLockKey(bankCode, validatedTrigger), expectedLeaseToken: leaseToken, newTtlMs: effectiveTtlMs, nowMs: now() });
     },
   };
 }

--- a/src/modules/bank-auto-login-lock/lock.test.ts
+++ b/src/modules/bank-auto-login-lock/lock.test.ts
@@ -12,8 +12,10 @@ import { createAuthenticationAttemptTrigger } from "../bank-auto-login-trigger";
 class InMemoryLockStore {
   private store = new Map<string, string>();
   private counters = new Map<string, number>();
+  readonly calls = { acquire: [] as string[], release: [] as string[], renew: [] as string[] };
   constructor(private readonly now?: () => number) {}
   async acquireSlot({ key, leaseToken, ttlMs, nowMs }: { key: string; leaseToken: string; ttlMs: number; nowMs: number }): Promise<number | null> {
+    this.calls.acquire.push(key);
     const raw = this.store.get(key);
     if (raw) {
       const d = JSON.parse(raw) as { expiresAt: number; fencingToken: number };
@@ -27,6 +29,7 @@ class InMemoryLockStore {
     return ft;
   }
   async releaseIfOwner(key: string, expected: string): Promise<boolean> {
+    this.calls.release.push(key);
     const raw = this.store.get(key);
     if (!raw) return false;
     const d = JSON.parse(raw) as { leaseToken: string; expiresAt: number };
@@ -36,6 +39,7 @@ class InMemoryLockStore {
     return true;
   }
   async renewIfOwner({ key, expectedLeaseToken: expected, newTtlMs, nowMs }: { key: string; expectedLeaseToken: string; newTtlMs: number; nowMs: number }): Promise<boolean> {
+    this.calls.renew.push(key);
     const raw = this.store.get(key);
     if (!raw) return false;
     const d = JSON.parse(raw) as { leaseToken: string; fencingToken: number; expiresAt: number };
@@ -324,6 +328,23 @@ describe("AutoLoginLock", () => {
       await expect(lock.release("Popular", expiry, "lease")).rejects.toThrow(LockValidationError);
       await expect(lock.renew("popular", { kind: "session_expiry", id: "secret", owner: "x" } as never, "lease")).rejects.toThrow(LockValidationError);
       expect(calls).toEqual([]);
+    });
+
+    it("passes exact legacy and v2 keys to every store operation", async () => {
+      const { lock, store } = setup();
+      const legacyKey = "autologin:lock:popular:evt-001";
+      const legacy = await lock.acquire("popular", "evt-001");
+      await lock.renew("popular", { kind: "session_expiry", id: "evt-001" }, legacy!.leaseToken);
+      await lock.release("popular", { kind: "session_expiry", id: "evt-001" }, legacy!.leaseToken);
+      const v2Key = `autologin:lock:v2:popular:authentication_attempt:${authenticationAttempt.id}`;
+      const authentication = await lock.acquire("popular", authenticationAttempt);
+      await lock.renew("popular", authenticationAttempt, authentication!.leaseToken);
+      await lock.release("popular", authenticationAttempt, authentication!.leaseToken);
+
+      expect(store.calls.acquire).toEqual([legacyKey, v2Key]);
+      expect(store.calls.renew).toEqual([legacyKey, v2Key]);
+      expect(store.calls.release).toEqual([legacyKey, v2Key]);
+      expect(v2Key).toContain("ff9d00d3b688af1a16ee47e5a774614f23cd33224d6c4278d5ccfcb530e9c5bd");
     });
   });
 });

--- a/src/modules/bank-auto-login-lock/lock.test.ts
+++ b/src/modules/bank-auto-login-lock/lock.test.ts
@@ -7,6 +7,7 @@ import {
   MAX_LOCK_TTL_MS,
   LOCK_KEY_PREFIX,
 } from "./index";
+import { createAuthenticationAttemptTrigger } from "../bank-auto-login-trigger";
 
 class InMemoryLockStore {
   private store = new Map<string, string>();
@@ -267,6 +268,62 @@ describe("AutoLoginLock", () => {
     it("throws when store is missing (fail-fast)", () => {
       // Force an undefined store to exercise the runtime guard (TS would catch this normally).
       expect(() => createAutoLoginLock({ store: undefined as unknown as import("./index").LockStore })).toThrow("LockStore is required");
+    });
+  });
+
+  describe("typed trigger compatibility", () => {
+    const expiry = { kind: "session_expiry", id: "evt-001" } as const;
+    const authenticationAttempt = createAuthenticationAttemptTrigger({ bankCode: "popular", runId: "run-1", attemptId: "attempt-1" });
+
+    it("maps a session-expiry object to the exact legacy key and contends with legacy callers", async () => {
+      const { lock } = setup();
+      expect(buildLockKey("popular", expiry)).toBe("autologin:lock:popular:evt-001");
+      const legacy = await lock.acquire("popular", "evt-001");
+      expect(await lock.acquire("popular", expiry)).toBeNull();
+      expect(await lock.release("popular", expiry, legacy!.leaseToken)).toBe(true);
+      const typed = await lock.acquire("popular", expiry);
+      expect(await lock.renew("popular", "evt-001", typed!.leaseToken)).toBe(true);
+    });
+
+    it("uses a stable, separated v2 key for authentication attempts", async () => {
+      const { lock } = setup();
+      const expected = `autologin:lock:v2:popular:authentication_attempt:${authenticationAttempt.id}`;
+      expect(buildLockKey("popular", authenticationAttempt)).toBe(expected);
+      expect(buildLockKey("popular", { kind: "session_expiry", id: authenticationAttempt.id })).not.toBe(expected);
+      expect(await lock.acquire("popular", authenticationAttempt)).not.toBeNull();
+      expect(await lock.acquire("popular", authenticationAttempt)).toBeNull();
+      expect(await lock.acquire("banreservas", authenticationAttempt)).not.toBeNull();
+      const other = createAuthenticationAttemptTrigger({ bankCode: "popular", runId: "run-1", attemptId: "attempt-2" });
+      expect(await lock.acquire("popular", other)).not.toBeNull();
+    });
+
+    it("preserves owner, expiry, renew, and fencing semantics for authentication attempts", async () => {
+      let timeMs = 1_000_000;
+      const now = () => timeMs;
+      const lock = createAutoLoginLock({ store: new InMemoryLockStore(now), defaultTtlMs: 1_000, now });
+      const first = await lock.acquire("popular", authenticationAttempt);
+      expect(await lock.release("popular", authenticationAttempt, "wrong-token")).toBe(false);
+      expect(await lock.renew("popular", authenticationAttempt, first!.leaseToken)).toBe(true);
+      timeMs += 2_000;
+      const second = await lock.acquire("popular", authenticationAttempt);
+      expect(second!.fencingToken).toBe(2);
+      expect(await lock.release("popular", authenticationAttempt, first!.leaseToken)).toBe(false);
+      expect(await lock.release("popular", authenticationAttempt, second!.leaseToken)).toBe(true);
+    });
+
+    it("rejects malformed triggers before calling the store", async () => {
+      const calls: string[] = [];
+      const lock = createAutoLoginLock({
+        store: {
+          acquireSlot: async () => { calls.push("acquire"); return 1; },
+          releaseIfOwner: async () => { calls.push("release"); return true; },
+          renewIfOwner: async () => { calls.push("renew"); return true; },
+        },
+      });
+      await expect(lock.acquire("popular", { kind: "authentication_attempt", id: "raw-id" } as never)).rejects.toThrow(LockValidationError);
+      await expect(lock.release("Popular", expiry, "lease")).rejects.toThrow(LockValidationError);
+      await expect(lock.renew("popular", { kind: "session_expiry", id: "secret", owner: "x" } as never, "lease")).rejects.toThrow(LockValidationError);
+      expect(calls).toEqual([]);
     });
   });
 });

--- a/src/modules/bank-auto-login-trigger/index.test.ts
+++ b/src/modules/bank-auto-login-trigger/index.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+  AutoLoginTriggerValidationError,
+  createAuthenticationAttemptTrigger,
+  parseAutoLoginTriggerIdentity,
+} from "./index";
+
+describe("auto-login trigger identity", () => {
+  it("parses exact session-expiry and authentication-attempt variants", () => {
+    expect(parseAutoLoginTriggerIdentity({ kind: "session_expiry", id: "evt-001" }))
+      .toEqual({ kind: "session_expiry", id: "evt-001" });
+    expect(parseAutoLoginTriggerIdentity({ kind: "authentication_attempt", id: "a".repeat(64) }))
+      .toEqual({ kind: "authentication_attempt", id: "a".repeat(64) });
+    const nullPrototype = Object.assign(Object.create(null), { kind: "session_expiry", id: "evt-001" });
+    expect(parseAutoLoginTriggerIdentity(nullPrototype)).toEqual({ kind: "session_expiry", id: "evt-001" });
+  });
+
+  it.each([
+    null, [], new Date(), "evt-001", 1, undefined,
+    {}, { kind: "session_expiry" }, { id: "evt-001" },
+    { kind: "unknown", id: "evt-001" }, { kind: "session_expiry", id: "evt-001", owner: "secret" },
+    { kind: "session_expiry", id: "" }, { kind: "session_expiry", id: "   " },
+    { kind: "session_expiry", id: "a".repeat(257) },
+  ])("rejects malformed trigger %#", (input) => {
+    expect(() => parseAutoLoginTriggerIdentity(input)).toThrow(AutoLoginTriggerValidationError);
+  });
+
+  it.each(["with spaces", "evt_001", "evt!", "a".repeat(65)])("rejects invalid session-expiry ids", (id) => {
+    expect(() => parseAutoLoginTriggerIdentity({ kind: "session_expiry", id })).toThrow(AutoLoginTriggerValidationError);
+  });
+
+  it.each(["A".repeat(64), "a".repeat(63), "g".repeat(64), " ".repeat(64)])("rejects non-canonical authentication ids", (id) => {
+    expect(() => parseAutoLoginTriggerIdentity({ kind: "authentication_attempt", id })).toThrow(AutoLoginTriggerValidationError);
+  });
+
+  it("creates a stable opaque digest from run and attempt without embedding the bank", () => {
+    const first = createAuthenticationAttemptTrigger({ bankCode: "popular", runId: "run-1", attemptId: "attempt-1" });
+    expect(first).toEqual(createAuthenticationAttemptTrigger({ bankCode: "popular", runId: "run-1", attemptId: "attempt-1" }));
+    expect(first).not.toEqual(createAuthenticationAttemptTrigger({ bankCode: "popular", runId: "run-2", attemptId: "attempt-1" }));
+    expect(first).not.toEqual(createAuthenticationAttemptTrigger({ bankCode: "popular", runId: "run-1", attemptId: "attempt-2" }));
+    expect(first).toEqual({ kind: "authentication_attempt", id: expect.stringMatching(/^[a-f0-9]{64}$/) });
+    expect(JSON.stringify(first)).not.toContain("popular");
+    expect(JSON.stringify(first)).not.toContain("run-1");
+    expect(JSON.stringify(first)).not.toContain("attempt-1");
+  });
+
+  it.each([
+    {}, { bankCode: "popular", runId: "run-1" },
+    { bankCode: " ", runId: "run-1", attemptId: "attempt-1" },
+    { bankCode: "popular", runId: "", attemptId: "attempt-1" },
+    { bankCode: "popular", runId: "run-1", attemptId: "", generation: 1 },
+  ])("rejects malformed authentication attempt identities %#", (identity) => {
+    expect(() => createAuthenticationAttemptTrigger(identity as never)).toThrow(AutoLoginTriggerValidationError);
+  });
+});

--- a/src/modules/bank-auto-login-trigger/index.test.ts
+++ b/src/modules/bank-auto-login-trigger/index.test.ts
@@ -33,12 +33,28 @@ describe("auto-login trigger identity", () => {
     expect(() => parseAutoLoginTriggerIdentity({ kind: "authentication_attempt", id })).toThrow(AutoLoginTriggerValidationError);
   });
 
+  it("rejects hidden, symbolic, and accessor trigger fields without invoking accessors", () => {
+    const hidden = { kind: "session_expiry", id: "evt-001" };
+    Object.defineProperty(hidden, "owner", { value: "secret" });
+    const symbolic = { kind: "session_expiry", id: "evt-001", [Symbol("owner")]: "secret" };
+    let getterInvoked = false;
+    const accessor = { kind: "session_expiry", get id() { getterInvoked = true; return "evt-001"; } };
+    const nonEnumerableRequired = { kind: "session_expiry" };
+    Object.defineProperty(nonEnumerableRequired, "id", { value: "evt-001" });
+
+    for (const input of [hidden, symbolic, accessor, nonEnumerableRequired]) {
+      expect(() => parseAutoLoginTriggerIdentity(input)).toThrow(AutoLoginTriggerValidationError);
+    }
+    expect(getterInvoked).toBe(false);
+  });
+
   it("creates a stable opaque digest from run and attempt without embedding the bank", () => {
     const first = createAuthenticationAttemptTrigger({ bankCode: "popular", runId: "run-1", attemptId: "attempt-1" });
     expect(first).toEqual(createAuthenticationAttemptTrigger({ bankCode: "popular", runId: "run-1", attemptId: "attempt-1" }));
     expect(first).not.toEqual(createAuthenticationAttemptTrigger({ bankCode: "popular", runId: "run-2", attemptId: "attempt-1" }));
     expect(first).not.toEqual(createAuthenticationAttemptTrigger({ bankCode: "popular", runId: "run-1", attemptId: "attempt-2" }));
     expect(first).toEqual({ kind: "authentication_attempt", id: expect.stringMatching(/^[a-f0-9]{64}$/) });
+    expect(first.id).toBe("ff9d00d3b688af1a16ee47e5a774614f23cd33224d6c4278d5ccfcb530e9c5bd");
     expect(JSON.stringify(first)).not.toContain("popular");
     expect(JSON.stringify(first)).not.toContain("run-1");
     expect(JSON.stringify(first)).not.toContain("attempt-1");
@@ -51,5 +67,20 @@ describe("auto-login trigger identity", () => {
     { bankCode: "popular", runId: "run-1", attemptId: "", generation: 1 },
   ])("rejects malformed authentication attempt identities %#", (identity) => {
     expect(() => createAuthenticationAttemptTrigger(identity as never)).toThrow(AutoLoginTriggerValidationError);
+  });
+
+  it("rejects hidden, symbolic, and accessor authentication identity fields without invoking accessors", () => {
+    const hidden = { bankCode: "popular", runId: "run-1", attemptId: "attempt-1" };
+    Object.defineProperty(hidden, "generation", { value: 1 });
+    const symbolic = { bankCode: "popular", runId: "run-1", attemptId: "attempt-1", [Symbol("owner")]: "secret" };
+    let getterInvoked = false;
+    const accessor = { bankCode: "popular", runId: "run-1", get attemptId() { getterInvoked = true; return "attempt-1"; } };
+    const nonEnumerableRequired = { bankCode: "popular", runId: "run-1" };
+    Object.defineProperty(nonEnumerableRequired, "attemptId", { value: "attempt-1" });
+
+    for (const identity of [hidden, symbolic, accessor, nonEnumerableRequired]) {
+      expect(() => createAuthenticationAttemptTrigger(identity as never)).toThrow(AutoLoginTriggerValidationError);
+    }
+    expect(getterInvoked).toBe(false);
   });
 });

--- a/src/modules/bank-auto-login-trigger/index.ts
+++ b/src/modules/bank-auto-login-trigger/index.ts
@@ -18,17 +18,25 @@ const SESSION_EXPIRY_ID_RE = /^[a-zA-Z0-9-]{1,64}$/;
 const AUTHENTICATION_ATTEMPT_ID_RE = /^[a-f0-9]{64}$/;
 const MAX_ID_LENGTH = 256;
 
-function hasExactKeys(value: object, keys: readonly string[]): boolean {
-  const ownKeys = Object.keys(value).sort();
-  return ownKeys.length === keys.length
-    && ownKeys.every((key, index) => key === keys[index])
-    && !Object.getOwnPropertySymbols(value).some((symbol) => Object.prototype.propertyIsEnumerable.call(value, symbol));
-}
-
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
   if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
   const prototype = Object.getPrototypeOf(value);
   return prototype === null || prototype === Object.prototype;
+}
+
+function readExactDataProperties(value: unknown, keys: readonly string[]): Record<string, unknown> | null {
+  if (!isPlainRecord(value)) return null;
+  const ownKeys = Reflect.ownKeys(value);
+  if (ownKeys.length !== keys.length || ownKeys.some((key) => typeof key !== "string" || !keys.includes(key))) return null;
+
+  const descriptors = Object.getOwnPropertyDescriptors(value);
+  const result: Record<string, unknown> = {};
+  for (const key of keys) {
+    const descriptor = descriptors[key];
+    if (!descriptor || !descriptor.enumerable || !("value" in descriptor)) return null;
+    result[key] = descriptor.value;
+  }
+  return result;
 }
 
 function validateNonblankId(field: string, value: unknown): asserts value is string {
@@ -38,24 +46,26 @@ function validateNonblankId(field: string, value: unknown): asserts value is str
 }
 
 export function parseAutoLoginTriggerIdentity(value: unknown): AutoLoginTriggerIdentity {
-  if (!isPlainRecord(value) || !hasExactKeys(value, ["id", "kind"])) {
+  const trigger = readExactDataProperties(value, ["id", "kind"]);
+  if (!trigger) {
     throw new AutoLoginTriggerValidationError("must be a plain object with exactly kind and id");
   }
-  validateNonblankId("id", value.id);
-  if (value.kind === "session_expiry" && SESSION_EXPIRY_ID_RE.test(value.id)) return { kind: value.kind, id: value.id };
-  if (value.kind === "authentication_attempt" && AUTHENTICATION_ATTEMPT_ID_RE.test(value.id)) return { kind: value.kind, id: value.id };
+  validateNonblankId("id", trigger.id);
+  if (trigger.kind === "session_expiry" && SESSION_EXPIRY_ID_RE.test(trigger.id)) return { kind: trigger.kind, id: trigger.id };
+  if (trigger.kind === "authentication_attempt" && AUTHENTICATION_ATTEMPT_ID_RE.test(trigger.id)) return { kind: trigger.kind, id: trigger.id };
   throw new AutoLoginTriggerValidationError("kind or id is not recognized");
 }
 
 export function createAuthenticationAttemptTrigger(identity: SessionAuthenticationAttemptIdentity): AutoLoginTriggerIdentity {
-  if (!isPlainRecord(identity) || !hasExactKeys(identity, ["attemptId", "bankCode", "runId"])) {
+  const attemptIdentity = readExactDataProperties(identity, ["attemptId", "bankCode", "runId"]);
+  if (!attemptIdentity) {
     throw new AutoLoginTriggerValidationError("authentication attempt must have exactly bankCode, runId, and attemptId");
   }
-  validateNonblankId("bankCode", identity.bankCode);
-  validateNonblankId("runId", identity.runId);
-  validateNonblankId("attemptId", identity.attemptId);
+  validateNonblankId("bankCode", attemptIdentity.bankCode);
+  validateNonblankId("runId", attemptIdentity.runId);
+  validateNonblankId("attemptId", attemptIdentity.attemptId);
   return {
     kind: "authentication_attempt",
-    id: createHash("sha256").update(JSON.stringify([identity.runId, identity.attemptId])).digest("hex"),
+    id: createHash("sha256").update(JSON.stringify([attemptIdentity.runId, attemptIdentity.attemptId])).digest("hex"),
   };
 }

--- a/src/modules/bank-auto-login-trigger/index.ts
+++ b/src/modules/bank-auto-login-trigger/index.ts
@@ -1,0 +1,61 @@
+import { createHash } from "node:crypto";
+
+import type { SessionAuthenticationAttemptIdentity } from "../bank-sessions/session-authentication-attempt";
+
+export type AutoLoginTriggerIdentity = Readonly<
+  | { kind: "session_expiry"; id: string }
+  | { kind: "authentication_attempt"; id: string }
+>;
+
+export class AutoLoginTriggerValidationError extends Error {
+  constructor(message: string) {
+    super(`Invalid auto-login trigger: ${message}`);
+    this.name = "AutoLoginTriggerValidationError";
+  }
+}
+
+const SESSION_EXPIRY_ID_RE = /^[a-zA-Z0-9-]{1,64}$/;
+const AUTHENTICATION_ATTEMPT_ID_RE = /^[a-f0-9]{64}$/;
+const MAX_ID_LENGTH = 256;
+
+function hasExactKeys(value: object, keys: readonly string[]): boolean {
+  const ownKeys = Object.keys(value).sort();
+  return ownKeys.length === keys.length
+    && ownKeys.every((key, index) => key === keys[index])
+    && !Object.getOwnPropertySymbols(value).some((symbol) => Object.prototype.propertyIsEnumerable.call(value, symbol));
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === null || prototype === Object.prototype;
+}
+
+function validateNonblankId(field: string, value: unknown): asserts value is string {
+  if (typeof value !== "string" || value.trim().length === 0 || value.length > MAX_ID_LENGTH) {
+    throw new AutoLoginTriggerValidationError(`${field} must be a nonblank string up to ${MAX_ID_LENGTH} characters`);
+  }
+}
+
+export function parseAutoLoginTriggerIdentity(value: unknown): AutoLoginTriggerIdentity {
+  if (!isPlainRecord(value) || !hasExactKeys(value, ["id", "kind"])) {
+    throw new AutoLoginTriggerValidationError("must be a plain object with exactly kind and id");
+  }
+  validateNonblankId("id", value.id);
+  if (value.kind === "session_expiry" && SESSION_EXPIRY_ID_RE.test(value.id)) return { kind: value.kind, id: value.id };
+  if (value.kind === "authentication_attempt" && AUTHENTICATION_ATTEMPT_ID_RE.test(value.id)) return { kind: value.kind, id: value.id };
+  throw new AutoLoginTriggerValidationError("kind or id is not recognized");
+}
+
+export function createAuthenticationAttemptTrigger(identity: SessionAuthenticationAttemptIdentity): AutoLoginTriggerIdentity {
+  if (!isPlainRecord(identity) || !hasExactKeys(identity, ["attemptId", "bankCode", "runId"])) {
+    throw new AutoLoginTriggerValidationError("authentication attempt must have exactly bankCode, runId, and attemptId");
+  }
+  validateNonblankId("bankCode", identity.bankCode);
+  validateNonblankId("runId", identity.runId);
+  validateNonblankId("attemptId", identity.attemptId);
+  return {
+    kind: "authentication_attempt",
+    id: createHash("sha256").update(JSON.stringify([identity.runId, identity.attemptId])).digest("hex"),
+  };
+}


### PR DESCRIPTION
Closes #100

## Summary
- Adds a typed trigger union with strict descriptors and a stable authentication digest.
- Preserves exact legacy-key bytes for mixed workers while v2 keys use kind, bank, and digest without double hashing.
- Adds acquire, renew, release, and fence lock semantics with validation before any store interaction.

## Review Path
Review src/modules/bank-auto-login-trigger/index.ts first, then the lock integration and focused tests.

## Scope
- Merged prerequisite work and context only: #98 and #96; this PR does not close them.
- This PR intentionally has no runner, queue, or production caller; WU4c1b is the next slice.
- The second commit independently fixes hidden-property, digest, and store-key test gaps.
- Exactly 4 files changed, 267 additions and 14 deletions (281 total), under the 400-line budget; no exception is needed.

## Verification
- Focused tests: PASS (71 tests).
- Full tests: 1,635 passed, 2 skipped.
- Lint, typecheck, pnpm exec prisma validate, and git diff --check: PASS.
- The repository has no CI workflows, so zero checks are expected; evidence is local. Receipt-driven review is disabled/unmanaged.

## Rollback
Revert commits 4ea0a3c and d237cff; the rollback is limited to these 4 files and requires no migration of existing keys.

## Checklist
- [x] Linked approved issue #100.
- [x] Added exactly one type:feature label.
- [x] Conventional commits; no Co-Authored-By trailers.