### PR TITLE
feat(auto-login): translate typed runner triggers

### DIFF
--- a/src/worker/scraper/auto-login.test.ts
+++ b/src/worker/scraper/auto-login.test.ts
@@ -842,6 +842,153 @@ describe("createScrapeTimeAutoLoginRunner", () => {
     };
   }
 
+  function createDependencyProbe() {
+    const adapterRegistry = { get: vi.fn() };
+    const autoLoginConfigs = { getByBankCode: vi.fn() };
+    const credentials = { findByBankCode: vi.fn() };
+    const lock = { acquire: vi.fn(), release: vi.fn() };
+    const cdpUrlForBankCode = vi.fn();
+    const ensureBrowser = vi.fn();
+    const recordCredentialDecryptUse = vi.fn();
+    const recordFailure = vi.fn();
+    const beforeAutoLoginMutation = vi.fn();
+    const afterAutoLoginOutcome = vi.fn();
+    const resolvingKey = vi.fn(() => key);
+    return {
+      run: createScrapeTimeAutoLoginRunner({
+        adapterRegistry,
+        autoLoginConfigs,
+        credentials,
+        keyResolver: resolvingKey,
+        lock,
+        cdpUrlForBankCode,
+        ensureBrowser,
+        recordCredentialDecryptUse,
+        recordFailure,
+        beforeAutoLoginMutation,
+        afterAutoLoginOutcome,
+      }),
+      dependencyMocks: [
+        adapterRegistry.get, autoLoginConfigs.getByBankCode, credentials.findByBankCode,
+        lock.acquire, lock.release, cdpUrlForBankCode, ensureBrowser,
+        recordCredentialDecryptUse, recordFailure, beforeAutoLoginMutation,
+        afterAutoLoginOutcome, resolvingKey,
+      ],
+    };
+  }
+
+  function expectNoDependencyCalls(dependencyMocks: ReturnType<typeof createDependencyProbe>["dependencyMocks"]) {
+    for (const dependency of dependencyMocks) expect(dependency).not.toHaveBeenCalled();
+  }
+
+  it("preserves the legacy expiry path and page identity when no options are provided", async () => {
+    const page = makePage();
+    const autoLogin = vi.fn().mockResolvedValue({ status: "succeeded" as const });
+    const acquire = vi.fn().mockResolvedValue({ leaseToken: "lease-1", fencingToken: 1, expiresAt: 123 });
+    const release = vi.fn().mockResolvedValue(true);
+    const afterAutoLoginOutcome = vi.fn();
+    const run = createScrapeTimeAutoLoginRunner({
+      adapterRegistry: { get: vi.fn().mockReturnValue({ bankCode: "popular", createAutoLoginStrategy: () => ({ bankCode: "popular", autoLogin }) }) },
+      autoLoginConfigs: { getByBankCode: vi.fn().mockResolvedValue({ autoLoginEnabled: true, breakerState: "closed" }) },
+      credentials: { findByBankCode: vi.fn().mockResolvedValue(encryptedCredentialRecord()) },
+      keyResolver,
+      lock: { acquire, release },
+      cdpUrlForBankCode: vi.fn().mockReturnValue("http://127.0.0.1:9222"),
+      ensureBrowser: vi.fn().mockResolvedValue(readyBrowser(page)),
+      afterAutoLoginOutcome,
+    });
+
+    await expect(run({ data: { bankId: "popular", expiredEventId: "E1", runId: "run-1" } })).resolves.toEqual({ status: "succeeded" });
+
+    expect(autoLogin).toHaveBeenCalledWith({ credential, page });
+    expect(acquire).toHaveBeenCalledWith("popular", "E1");
+    expect(release).toHaveBeenCalledWith("popular", "E1", "lease-1");
+    expect(afterAutoLoginOutcome).toHaveBeenCalledWith({ bankCode: "popular", expiredEventId: "E1", runId: "run-1", outcome: { status: "succeeded" } });
+  });
+
+  it("executes an explicit session-expiry trigger through the exact legacy path", async () => {
+    const page = makePage();
+    const autoLogin = vi.fn().mockResolvedValue({ status: "succeeded" as const });
+    const acquire = vi.fn().mockResolvedValue({ leaseToken: "lease-1", fencingToken: 1, expiresAt: 123 });
+    const release = vi.fn().mockResolvedValue(true);
+    const afterAutoLoginOutcome = vi.fn();
+    const run = createScrapeTimeAutoLoginRunner({
+      adapterRegistry: { get: vi.fn().mockReturnValue({ bankCode: "popular", createAutoLoginStrategy: () => ({ bankCode: "popular", autoLogin }) }) },
+      autoLoginConfigs: { getByBankCode: vi.fn().mockResolvedValue({ autoLoginEnabled: true, breakerState: "closed" }) },
+      credentials: { findByBankCode: vi.fn().mockResolvedValue(encryptedCredentialRecord()) },
+      keyResolver,
+      lock: { acquire, release },
+      cdpUrlForBankCode: vi.fn().mockReturnValue("http://127.0.0.1:9222"),
+      ensureBrowser: vi.fn().mockResolvedValue(readyBrowser(page)),
+      afterAutoLoginOutcome,
+    });
+
+    await expect(run({ data: { bankId: "popular", runId: "run-1" } }, { trigger: { kind: "session_expiry", id: "E1" } })).resolves.toEqual({ status: "succeeded" });
+
+    expect(autoLogin).toHaveBeenCalledWith({ credential, page });
+    expect(acquire).toHaveBeenCalledWith("popular", "E1");
+    expect(release).toHaveBeenCalledWith("popular", "E1", "lease-1");
+    expect(afterAutoLoginOutcome).toHaveBeenCalledWith({ bankCode: "popular", expiredEventId: "E1", runId: "run-1", outcome: { status: "succeeded" } });
+  });
+
+  it("rejects conflicting identities before every dependency", async () => {
+    const { run, dependencyMocks } = createDependencyProbe();
+
+    await expect(run({ data: { bankId: "popular", expiredEventId: "E1" } }, { trigger: { kind: "session_expiry", id: "E1" } })).resolves.toEqual({
+      status: "needs_admin_action", reason: "invalid_trigger", safeSummary: "Bank auto-login requires admin action",
+    });
+
+    expectNoDependencyCalls(dependencyMocks);
+  });
+
+  it("rejects malformed options and triggers without invoking accessors or dependencies", async () => {
+    let getterReads = 0;
+    const getterOptions = {};
+    Object.defineProperty(getterOptions, "trigger", { enumerable: true, get: () => { getterReads += 1; return { kind: "session_expiry", id: "E1" }; } });
+    const hiddenTrigger = { kind: "session_expiry", id: "E1" };
+    Object.defineProperty(hiddenTrigger, "extra", { value: "hidden" });
+    const symbolTrigger = { kind: "session_expiry", id: "E1", [Symbol("extra")]: true };
+    const getterTrigger = { kind: "session_expiry" };
+    Object.defineProperty(getterTrigger, "id", { enumerable: true, get: () => { getterReads += 1; return "E1"; } });
+    const malformedTriggers = [null, 1, [], new Date(), {}, { kind: "unknown", id: "E1" }, { kind: "session_expiry", id: " " }, { kind: "session_expiry", id: "a".repeat(65) }, { kind: "session_expiry", id: "E1", extra: true }, hiddenTrigger, symbolTrigger, getterTrigger];
+    const executeStrategy = vi.fn();
+    const malformedOptions = [null, 1, [], new Date(), { extra: true }, getterOptions, { trigger: undefined }, { trigger: { kind: "session_expiry", id: "E1" }, executeStrategy }];
+
+    for (const options of malformedOptions) {
+      const { run, dependencyMocks } = createDependencyProbe();
+      await expect(run({ data: { bankId: "popular" } }, options as never)).resolves.toMatchObject({ status: "needs_admin_action", reason: "invalid_trigger" });
+      expectNoDependencyCalls(dependencyMocks);
+    }
+    for (const trigger of malformedTriggers) {
+      const { run, dependencyMocks } = createDependencyProbe();
+      await expect(run({ data: { bankId: "popular" } }, { trigger })).resolves.toMatchObject({ status: "needs_admin_action", reason: "invalid_trigger" });
+      expectNoDependencyCalls(dependencyMocks);
+    }
+
+    expect(getterReads).toBe(0);
+    expect(executeStrategy).not.toHaveBeenCalled();
+  });
+
+  it("returns a fixed fail-closed outcome for authentication attempts without metadata or dependencies", async () => {
+    const rawTrigger = "a".repeat(64);
+    const { run, dependencyMocks } = createDependencyProbe();
+
+    const result = await run({ data: { bankId: "popular", runId: "run-1" } }, { trigger: { kind: "authentication_attempt", id: rawTrigger } });
+
+    expect(result).toEqual({ status: "needs_admin_action", reason: "authentication_trigger_not_ready", safeSummary: "Bank auto-login requires admin action" });
+    expect(JSON.stringify(result)).not.toContain(rawTrigger);
+    expect(JSON.stringify(result)).not.toContain("run-1");
+    expectNoDependencyCalls(dependencyMocks);
+  });
+
+  it("returns null without dependencies when neither a legacy expiry nor explicit trigger exists", async () => {
+    const { run, dependencyMocks } = createDependencyProbe();
+
+    await expect(run({ data: { bankId: "popular" } }, {})).resolves.toBeNull();
+
+    expectNoDependencyCalls(dependencyMocks);
+  });
+
   it("does not call the mutation hook when config is off or credentials are absent", async () => {
     const beforeAutoLoginMutation = vi.fn();
     for (const [config, storedCredential] of [

--- a/src/worker/scraper/auto-login.test.ts
+++ b/src/worker/scraper/auto-login.test.ts
@@ -849,6 +849,7 @@ describe("createScrapeTimeAutoLoginRunner", () => {
     const lock = { acquire: vi.fn(), release: vi.fn() };
     const cdpUrlForBankCode = vi.fn();
     const ensureBrowser = vi.fn();
+    const recordLockReleaseFailure = vi.fn();
     const recordCredentialDecryptUse = vi.fn();
     const recordFailure = vi.fn();
     const beforeAutoLoginMutation = vi.fn();
@@ -863,6 +864,7 @@ describe("createScrapeTimeAutoLoginRunner", () => {
         lock,
         cdpUrlForBankCode,
         ensureBrowser,
+        recordLockReleaseFailure,
         recordCredentialDecryptUse,
         recordFailure,
         beforeAutoLoginMutation,
@@ -871,7 +873,7 @@ describe("createScrapeTimeAutoLoginRunner", () => {
       dependencyMocks: [
         adapterRegistry.get, autoLoginConfigs.getByBankCode, credentials.findByBankCode,
         lock.acquire, lock.release, cdpUrlForBankCode, ensureBrowser,
-        recordCredentialDecryptUse, recordFailure, beforeAutoLoginMutation,
+        recordLockReleaseFailure, recordCredentialDecryptUse, recordFailure, beforeAutoLoginMutation,
         afterAutoLoginOutcome, resolvingKey,
       ],
     };
@@ -945,6 +947,11 @@ describe("createScrapeTimeAutoLoginRunner", () => {
     let getterReads = 0;
     const getterOptions = {};
     Object.defineProperty(getterOptions, "trigger", { enumerable: true, get: () => { getterReads += 1; return { kind: "session_expiry", id: "E1" }; } });
+    const hiddenOptionExtra = { trigger: { kind: "session_expiry", id: "E1" } };
+    Object.defineProperty(hiddenOptionExtra, "extra", { value: true });
+    const symbolOptionExtra = { trigger: { kind: "session_expiry", id: "E1" }, [Symbol("extra")]: true };
+    const hiddenOptionTrigger = {};
+    Object.defineProperty(hiddenOptionTrigger, "trigger", { value: { kind: "session_expiry", id: "E1" } });
     const hiddenTrigger = { kind: "session_expiry", id: "E1" };
     Object.defineProperty(hiddenTrigger, "extra", { value: "hidden" });
     const symbolTrigger = { kind: "session_expiry", id: "E1", [Symbol("extra")]: true };
@@ -952,7 +959,7 @@ describe("createScrapeTimeAutoLoginRunner", () => {
     Object.defineProperty(getterTrigger, "id", { enumerable: true, get: () => { getterReads += 1; return "E1"; } });
     const malformedTriggers = [null, 1, [], new Date(), {}, { kind: "unknown", id: "E1" }, { kind: "session_expiry", id: " " }, { kind: "session_expiry", id: "a".repeat(65) }, { kind: "session_expiry", id: "E1", extra: true }, hiddenTrigger, symbolTrigger, getterTrigger];
     const executeStrategy = vi.fn();
-    const malformedOptions = [null, 1, [], new Date(), { extra: true }, getterOptions, { trigger: undefined }, { trigger: { kind: "session_expiry", id: "E1" }, executeStrategy }];
+    const malformedOptions = [null, 1, [], new Date(), { extra: true }, getterOptions, hiddenOptionExtra, symbolOptionExtra, hiddenOptionTrigger, { trigger: undefined }, { trigger: { kind: "session_expiry", id: "E1" }, executeStrategy }];
 
     for (const options of malformedOptions) {
       const { run, dependencyMocks } = createDependencyProbe();
@@ -987,6 +994,55 @@ describe("createScrapeTimeAutoLoginRunner", () => {
     await expect(run({ data: { bankId: "popular" } }, {})).resolves.toBeNull();
 
     expectNoDependencyCalls(dependencyMocks);
+  });
+
+  it("distinguishes omitted or empty options from an explicit null trigger", async () => {
+    const omitted = createDependencyProbe();
+    const empty = createDependencyProbe();
+    const explicitNull = createDependencyProbe();
+
+    await expect(omitted.run({ data: { bankId: "popular" } })).resolves.toBeNull();
+    await expect(empty.run({ data: { bankId: "popular" } }, {})).resolves.toBeNull();
+    await expect(explicitNull.run({ data: { bankId: "popular" } }, { trigger: null })).resolves.toMatchObject({ status: "needs_admin_action", reason: "invalid_trigger" });
+
+    expectNoDependencyCalls(omitted.dependencyMocks);
+    expectNoDependencyCalls(empty.dependencyMocks);
+    expectNoDependencyCalls(explicitNull.dependencyMocks);
+  });
+
+  it("preserves the existing local and runner outcome ordering for legacy and explicit expiry triggers", async () => {
+    const directEvents: string[] = [];
+    await executeScrapeTimeAutoLoginTrigger({
+      bankCode: "popular", expiredEventId: "E1", credential, cdpUrl: "http://127.0.0.1:9222",
+      adapter: { bankCode: "popular", createAutoLoginStrategy: () => ({ bankCode: "popular", autoLogin: async () => { directEvents.push("strategy"); return { status: "succeeded" }; } }) },
+      lock: { acquire: async () => ({ leaseToken: "lease-1", fencingToken: 1, expiresAt: 1 }), release: async () => { directEvents.push("lock.release"); return true; } },
+      ensureBrowser: async () => ({ status: "ready", page: makePage(), close: async () => { directEvents.push("browser.close"); } }),
+      afterAutoLoginOutcome: async () => { directEvents.push("direct.outcome"); },
+    });
+    // Direct execution emits its local hook before release; the runner does not inject that hook.
+    expect(directEvents).toEqual(["strategy", "browser.close", "direct.outcome", "lock.release"]);
+
+    async function runWithEvents(options?: { trigger?: unknown }) {
+      const events: string[] = [];
+      const run = createScrapeTimeAutoLoginRunner({
+        adapterRegistry: { get: () => ({ bankCode: "popular", createAutoLoginStrategy: () => ({ bankCode: "popular", autoLogin: async () => { events.push("strategy"); return { status: "succeeded" as const }; } }) }) },
+        autoLoginConfigs: { getByBankCode: async () => ({ autoLoginEnabled: true, breakerState: "closed" as const }) },
+        credentials: { findByBankCode: async () => encryptedCredentialRecord() }, keyResolver,
+        lock: { acquire: async () => ({ leaseToken: "lease-1", fencingToken: 1, expiresAt: 1 }), release: async () => { events.push("lock.release"); return true; } },
+        cdpUrlForBankCode: () => "http://127.0.0.1:9222",
+        ensureBrowser: async () => ({ status: "ready", page: makePage(), close: async () => { events.push("browser.close"); } }),
+        afterAutoLoginOutcome: async () => { events.push("runner.outcome"); },
+      });
+      const job = { data: { bankId: "popular", ...(options ? {} : { expiredEventId: "E1" }) } };
+      if (options) await run(job, options);
+      else await run(job);
+      return events;
+    }
+
+    const legacyEvents = await runWithEvents();
+    const explicitEvents = await runWithEvents({ trigger: { kind: "session_expiry", id: "E1" } });
+    expect(legacyEvents).toEqual(["strategy", "browser.close", "lock.release", "runner.outcome"]);
+    expect(explicitEvents).toEqual(legacyEvents);
   });
 
   it("does not call the mutation hook when config is off or credentials are absent", async () => {

--- a/src/worker/scraper/auto-login.ts
+++ b/src/worker/scraper/auto-login.ts
@@ -11,6 +11,7 @@ import {
 } from "./browser-runtime";
 import { decryptCredentialField, type AesGcmEnvelope, type KeyResolver } from "../../modules/bank-credentials/crypto";
 import type { AutoLoginLock } from "../../modules/bank-auto-login-lock";
+import { parseAutoLoginTriggerIdentity } from "../../modules/bank-auto-login-trigger";
 
 export interface BankAutoLoginCredential {
   bankCode: string;
@@ -54,6 +55,8 @@ export type BankAutoLoginAdminActionReason =
   | "unauthorized_login_page"
   | "unknown_post_submit_state"
   | "browser_unavailable"
+  | "invalid_trigger"
+  | "authentication_trigger_not_ready"
   | "auto_login_execution_failed";
 
 export type BankAutoLoginOutcome =
@@ -101,6 +104,10 @@ export interface ScrapeTimeAutoLoginRunnerJob {
     expiredEventId?: string;
     runId?: string;
   };
+}
+
+export interface ScrapeTimeAutoLoginRunOptions {
+  trigger?: unknown;
 }
 
 export interface ScrapeTimeAutoLoginCredentialRecord {
@@ -333,11 +340,16 @@ async function recordBrowserCleanupFailure(
   return Promise.resolve(recordCleanupFailure?.({ bankCode, failure })).then(() => undefined);
 }
 export function createScrapeTimeAutoLoginRunner(deps: ScrapeTimeAutoLoginRunnerDependencies) {
-  return async function runScrapeTimeAutoLogin(job: ScrapeTimeAutoLoginRunnerJob): Promise<ScrapeTimeAutoLoginOutcome | null> {
-    const expiredEventId = job.data.expiredEventId;
-    if (!expiredEventId) return null;
+  return async function runScrapeTimeAutoLogin(
+    job: ScrapeTimeAutoLoginRunnerJob,
+    options?: ScrapeTimeAutoLoginRunOptions,
+  ): Promise<ScrapeTimeAutoLoginOutcome | null> {
+    const trigger = resolveRunnerTrigger(job, options, arguments.length > 1);
+    if (trigger.status === "invalid") return needsAdminAction("invalid_trigger");
+    if (trigger.status === "authentication_attempt") return needsAdminAction("authentication_trigger_not_ready");
+    if (trigger.status === "none") return null;
 
-    const outcome = await resolveScrapeTimeAutoLoginOutcome(deps, job, expiredEventId);
+    const outcome = await resolveScrapeTimeAutoLoginOutcome(deps, job, trigger.expiredEventId);
     if (outcome.status === "needs_admin_action" && outcome.reason === "unknown_post_submit_state") {
       try {
         await deps.recordFailure?.(job.data.bankId, new Date());
@@ -348,7 +360,7 @@ export function createScrapeTimeAutoLoginRunner(deps: ScrapeTimeAutoLoginRunnerD
     try {
       await deps.afterAutoLoginOutcome?.({
         bankCode: job.data.bankId,
-        expiredEventId,
+        expiredEventId: trigger.expiredEventId,
         runId: job.data.runId,
         outcome,
       });
@@ -357,6 +369,47 @@ export function createScrapeTimeAutoLoginRunner(deps: ScrapeTimeAutoLoginRunnerD
     }
     return outcome;
   };
+}
+
+type RunnerTriggerResolution =
+  | { status: "legacy"; expiredEventId: string }
+  | { status: "authentication_attempt" }
+  | { status: "invalid" }
+  | { status: "none" };
+
+function resolveRunnerTrigger(
+  job: ScrapeTimeAutoLoginRunnerJob,
+  options: unknown,
+  hasOptions: boolean,
+): RunnerTriggerResolution {
+  const legacyExpiredEventId = job.data.expiredEventId;
+  if (!hasOptions) return legacyExpiredEventId ? { status: "legacy", expiredEventId: legacyExpiredEventId } : { status: "none" };
+
+  const parsedOptions = readRunnerOptions(options);
+  if (!parsedOptions) return { status: "invalid" };
+  if (!parsedOptions.hasTrigger) return legacyExpiredEventId ? { status: "legacy", expiredEventId: legacyExpiredEventId } : { status: "none" };
+
+  let trigger;
+  try {
+    trigger = parseAutoLoginTriggerIdentity(parsedOptions.trigger);
+  } catch {
+    return { status: "invalid" };
+  }
+  if (legacyExpiredEventId !== undefined) return { status: "invalid" };
+  return trigger.kind === "session_expiry"
+    ? { status: "legacy", expiredEventId: trigger.id }
+    : { status: "authentication_attempt" };
+}
+
+function readRunnerOptions(value: unknown): { hasTrigger: boolean; trigger?: unknown } | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return null;
+  if (Object.getPrototypeOf(value) !== Object.prototype && Object.getPrototypeOf(value) !== null) return null;
+  const keys = Reflect.ownKeys(value);
+  if (keys.length === 0) return { hasTrigger: false };
+  if (keys.length !== 1 || keys[0] !== "trigger") return null;
+  const descriptor = Object.getOwnPropertyDescriptor(value, "trigger");
+  if (!descriptor || !descriptor.enumerable || !("value" in descriptor)) return null;
+  return { hasTrigger: true, trigger: descriptor.value };
 }
 
 async function resolveScrapeTimeAutoLoginOutcome(


### PR DESCRIPTION
## Summary
- Resolves typed runner triggers per run, with the legacy trigger path retained as an explicit fallback.
- Malformed or conflicting triggers resolve with zero dependencies; an authentication-attempt trigger fails closed as not-ready before auth and never synthesizes an expiry.
- Explicit expiry preserves legacy lock, string, metadata, page, and order behavior.

## Ordering Contract
- Direct execution order is exact: `strategy -> browser.close -> direct.outcome -> lock.release`.
- Runner execution order is exact: `strategy -> browser.close -> lock.release -> runner.outcome`.

## Scope and Follow-up
- No queue, payload, or composition change. Production continues to call the runner with one argument; the fenced adapter is the next integration step.
- #100 and #98 are merged prerequisites; this PR does not close them.
- The second commit independently closes coverage gaps for the translated trigger behavior.
- Review size: 2 files, +262/-6 (268 changed lines), under the 400-line review budget.

## Verification
- Local evidence only: focused tests `82`; full suite `1,643 passed, 2 skipped`; lint, typecheck, Prisma validate, and `git diff --check` passed.
- The repository has no CI workflows, so zero checks are expected. Receipt-driven review is disabled and unmanaged.

## Rollback
- Roll back the two commits: `ed16f9b` then `83bbe9f`.

Closes #102