### PR TITLE
feat(worker): retire expiry publication producer

### DIFF
--- a/docs/runbooks/bank-session.md
+++ b/docs/runbooks/bank-session.md
@@ -94,9 +94,9 @@ Because the profile is persistent, cookies survive browser restarts. After the i
 
 ## What the session monitor does
 
-The API-process monitor is deliberately dormant. `RD_SYNC_SESSION_MONITOR=enabled` does not start polling; a dedicated always-on producer bootstrap is required before background monitoring can be activated. The status endpoint still performs a live, read-only session check and reports these three states:
+When `RD_SYNC_SESSION_MONITOR=enabled`, the ingestion worker performs live CDP checks and emits only safe alert transitions and monitor audits. The status endpoint still performs a live, read-only session check and reports these three states:
 
-The dormant B1 implementation stores one durable expiry episode per bank and guarantees canonical expiry and restoration audit records exactly once when a future lifecycle owner activates it. The creation winner makes one best-effort expiry-notification attempt, and the identity-safe close winner makes one best-effort restoration-notification attempt. Notification delivery and retry are not durable and have no exactly-once guarantee. If PostgreSQL is unavailable and the process is lost before an episode is persisted, B1 cannot recover that observation. It has no publication, outbox, queue, or consumer path.
+The expiry runtime is alert/outbox-only. It does not create expiry episodes, schedule publication jobs, observe publication state, or require Redis for monitoring. Existing durable episode and manual-resolution rows remain untouched. Publication retirement is in progress; authenticated-ingestion activation is not part of this runbook change.
 
 | Status | Meaning |
 |--------|---------|
@@ -152,7 +152,7 @@ Response shape:
 |----------|---------|-------------|
 | `RD_SYNC_SCRAPER` | — | Set to `popular-cdp` to enable the CDP-backed scraper and session checker |
 | `RD_SYNC_CDP_URL` | `http://127.0.0.1:9222` | Global CDP endpoint for the running Brave session (bind to 127.0.0.1 only). Single-bank-only fallback — with 2+ registered banks each must set a distinct `RD_SYNC_BANK_<BANK>_CDP_URL` |
-| `RD_SYNC_SESSION_MONITOR` | — | Reserved for a future dedicated monitor bootstrap; it does not activate API-process polling |
+| `RD_SYNC_SESSION_MONITOR` | — | Set to `enabled` in the ingestion worker to activate alert/outbox-only monitoring |
 | `RD_SYNC_SESSION_CHECK_INTERVAL_MS` | `300000` (5 min) | Poll interval in milliseconds; minimum 60000 (1 min) |
 | `RD_SYNC_ALERT_SMTP_URL` | — | SMTP URL for alert emails; falls back to console.warn if absent |
 | `RD_SYNC_ADMIN_EMAIL` | — | Recipient address for alert emails |

--- a/docs/runbooks/bank-session.md
+++ b/docs/runbooks/bank-session.md
@@ -98,6 +98,8 @@ When `RD_SYNC_SESSION_MONITOR=enabled`, the ingestion worker performs live CDP c
 
 The expiry runtime is alert/outbox-only. It does not create expiry episodes, schedule publication jobs, observe publication state, or require Redis for monitoring. Existing durable episode and manual-resolution rows remain untouched. Publication retirement is in progress; authenticated-ingestion activation is not part of this runbook change.
 
+Los trabajos `bank-session-expiry-publication` ya encolados todavía no se retiran con WU5a y continúan pasando por el consumidor existente. WU5b los validará y confirmará como inertes, sin ingesta ni mutación; ese comportamiento aún no está activo. WU5a solo se despliega dentro del artefacto completo del corte coordinado de ramas, nunca de forma independiente a `main`.
+
 | Status | Meaning |
 |--------|---------|
 | `active` | Session is live and the dashboard loaded correctly |

--- a/docs/runbooks/worker.md
+++ b/docs/runbooks/worker.md
@@ -117,40 +117,33 @@ The following scenarios are only verifiable with a live Redis instance and are
 ## Two-replica expiry runtime proof
 
 Run the gated runtime proof only against a dedicated database with committed
-migrations and a dedicated Redis instance:
+migrations:
 
 ```bash
 RD_SYNC_TEST_DATABASE_URL="postgresql://test-user:test-password@localhost:5432/rd_sync_test" \
-RD_SYNC_TEST_REDIS_URL="redis://localhost:6379" \
 RD_SYNC_REQUIRE_INTEGRATION=true pnpm exec vitest run src/worker/expiry-runtime.integration.test.ts
 ```
 
-This command fails if either service URL is absent. Without
+This command fails if the database URL is absent. Without
 `RD_SYNC_REQUIRE_INTEGRATION=true`, the normal full suite still skips this
-integration proof when services are unavailable. Until the required command
-completes successfully against both dedicated services, the proof remains
-blocked and B2.5 remains pending.
+integration proof when PostgreSQL is unavailable.
 
 Expected evidence:
 
 - Two independently constructed runtimes use distinct lease owners, timer
-  handles, and BullMQ queue clients.
-- Concurrent expiry observations persist one episode, one expiry audit, and
-  one publication job.
-- A test-only worker forces that synthetic job to retained `failed`; concurrent
-  terminal observation emits one durable reconciliation audit and one fixed,
-  safe operator alert.
+  handles, and no publication ownership.
+- Concurrent monitor ticks retain safe alerts and monitor audits without
+  creating expiry episodes or publication jobs.
 - A pending manual-recovery audit outbox row is leased once and becomes one
   delivered row with one resolution audit.
-- Shutdown waits for blocked ticks, clears both timers, closes each owned queue
-  once, and is idempotent.
+- Shutdown waits for blocked ticks, clears both timers, closes retained
+  resources once, and is idempotent.
 
-Cleanup is scoped to the test UUID queue through BullMQ `obliterate` and to
-the test's UUID database records. The test never calls Redis `FLUSHALL`.
+Cleanup is scoped to the test's UUID database records.
 
 Safety boundaries:
 
-- Both variables must target disposable test services, never `DATABASE_URL`,
+- The database URL must target a disposable test service, never `DATABASE_URL`,
   developer data, or production data.
 - The proof creates no ingestion, scraper, browser, CDP, credential, bank URL,
   or login activity.

--- a/docs/runbooks/worker.md
+++ b/docs/runbooks/worker.md
@@ -141,6 +141,8 @@ Expected evidence:
 
 Cleanup is scoped to the test's UUID database records.
 
+`bank-session-expiry-publication` jobs already queued are not retired by WU5a and still route through the existing consumer. WU5b will validate and acknowledge them inertly, without ingestion or mutation; this is not active yet. Deploy WU5a only in the complete coordinated feature-branch cutover artifact, never independently to `main`.
+
 Safety boundaries:
 
 - The database URL must target a disposable test service, never `DATABASE_URL`,

--- a/src/worker/expiry-runtime.integration.test.ts
+++ b/src/worker/expiry-runtime.integration.test.ts
@@ -66,7 +66,7 @@ describe.skipIf(!RUN_INTEGRATION)("expiry runtime integration (requires dedicate
     const timers: number[] = [];
     const clearedTimers: number[] = [];
     const ownersSeen = new Set<string>();
-    const alerts: Array<{ safeSummary: string }> = [];
+    const alerts: Array<{ status: string; safeSummary: string; checkedAt: string }> = [];
     const runtimeTickGate: { wait?: Promise<void>; release?: () => void; signalReplicaATick?: () => void } = {};
     const runtimeTickStats = new Map<string, { calls: number; active: number; max: number }>();
     let releaseClaimBarrier!: () => void;
@@ -148,6 +148,12 @@ describe.skipIf(!RUN_INTEGRATION)("expiry runtime integration (requires dedicate
     await Promise.all([runtimeA.tick(), runtimeB.tick()]);
     expect(await prisma.bankSessionExpiryEpisode.count({ where: { bankCode } })).toBe(0);
     expect(monitorAudits).toEqual(["bank_session.expired", "bank_session.expired"]);
+    expect(alerts).toHaveLength(2);
+    for (const alert of alerts) {
+      expect(alert).toEqual(expect.objectContaining({ status: "expired", safeSummary: "Synthetic expiry" }));
+      expect(alert.checkedAt).toEqual(expect.any(String));
+      expect(Number.isNaN(Date.parse(alert.checkedAt))).toBe(false);
+    }
 
     await prisma.manualRecoveryResolution.create({
       data: {
@@ -177,8 +183,6 @@ describe.skipIf(!RUN_INTEGRATION)("expiry runtime integration (requires dedicate
       },
     });
     expect(await prisma.auditEvent.count({ where: manualAuditWhere })).toBe(2);
-    expect(alerts).toEqual(expect.arrayContaining([{ safeSummary: "Synthetic expiry" }]));
-
     runtimeTickGate.wait = new Promise<void>((resolve) => { runtimeTickGate.release = resolve; });
     const replicaATickEntered = new Promise<void>((resolve) => { runtimeTickGate.signalReplicaATick = resolve; });
     const replicaAStats = runtimeTickStats.get("replica-a")!;

--- a/src/worker/expiry-runtime.integration.test.ts
+++ b/src/worker/expiry-runtime.integration.test.ts
@@ -1,94 +1,56 @@
 /**
- * Real PostgreSQL + Redis two-replica runtime proof.
+ * Real PostgreSQL two-replica runtime proof.
  *
- * This suite is skipped unless BOTH dedicated test-service URLs are supplied:
+ * This suite is skipped unless a dedicated PostgreSQL test-service URL is supplied:
  *
- *   RD_SYNC_REQUIRE_INTEGRATION=true RD_SYNC_TEST_DATABASE_URL="postgresql://..." RD_SYNC_TEST_REDIS_URL="redis://..." pnpm test -- src/worker/expiry-runtime.integration.test.ts
+ *   RD_SYNC_REQUIRE_INTEGRATION=true RD_SYNC_TEST_DATABASE_URL="postgresql://..." pnpm test -- src/worker/expiry-runtime.integration.test.ts
  *
- * It uses a UUID queue and deletes only its own database rows and Redis queue.
- * Do not point either variable at development or production infrastructure.
+ * It uses UUID database rows only. Do not point the variable at development or production infrastructure.
  */
 import { randomUUID } from "node:crypto";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { PrismaPg } from "@prisma/adapter-pg";
 import type { PrismaClient, Prisma } from "../generated/prisma/client";
 import type { AuditSink } from "../modules/audit";
-import { createBankSessionMonitor, createExpiredSessionRunId } from "../modules/bank-sessions";
-import { publishExpiryEpisode } from "../modules/bank-sessions/expiry-episodes";
-import { PrismaBankSessionExpiryEpisodeRepository } from "../modules/persistence/prisma-bank-session-expiry-episode-repository";
+import { createBankSessionMonitor } from "../modules/bank-sessions";
 import { PrismaManualRecoveryResolutionAuditOutboxRepository } from "../modules/persistence/prisma-manual-recovery-resolution-audit-outbox-repository";
-import { buildRedisConnectionOptions } from "./queues/bullmq-queue";
 import { createExpiryRuntime, type ExpiryRuntime } from "./expiry-runtime";
-import { observeExpiryPublicationJob, scheduleExpiryPublicationJob } from "../modules/bank-sessions/expiry-publication";
 
 const TEST_DATABASE_URL = process.env.RD_SYNC_TEST_DATABASE_URL;
-const TEST_REDIS_URL = process.env.RD_SYNC_TEST_REDIS_URL;
-const RUN_INTEGRATION = Boolean(TEST_DATABASE_URL && TEST_REDIS_URL);
+const RUN_INTEGRATION = Boolean(TEST_DATABASE_URL);
 const REQUIRE_INTEGRATION = process.env.RD_SYNC_REQUIRE_INTEGRATION === "true";
-const WORKER_READY_TIMEOUT_MS = 5_000;
 if (REQUIRE_INTEGRATION && !RUN_INTEGRATION) {
-  throw new Error("RD_SYNC_REQUIRE_INTEGRATION=true requires RD_SYNC_TEST_DATABASE_URL and RD_SYNC_TEST_REDIS_URL");
+  throw new Error("RD_SYNC_REQUIRE_INTEGRATION=true requires RD_SYNC_TEST_DATABASE_URL");
 }
-const queueName = `expiry-runtime-integration-${randomUUID()}`;
 const bankCode = `runtime-${randomUUID()}`;
-const expiredEventId = `event-${randomUUID()}`;
-const runId = createExpiredSessionRunId(bankCode, expiredEventId);
 const manualExpiredEventId = `manual-${randomUUID()}`;
 const manualResolutionId = `resolution-${randomUUID()}`;
 const manualOutboxId = `outbox-${randomUUID()}`;
-const expiryAuditWhere = { action: "bank_session.expired", target: "bank_session", metadata: { path: ["expiredEventId"], equals: expiredEventId } } satisfies Prisma.AuditEventWhereInput;
-const terminalAuditWhere = { action: "bank_autologin.needs_admin_action", target: "bank_session_expiry_episode", AND: [{ metadata: { path: ["expiredEventId"], equals: expiredEventId } }, { metadata: { path: ["runId"], equals: runId } }] } satisfies Prisma.AuditEventWhereInput;
-const manualAuditWhere = { action: "bank_autologin.manual_recovery_resolved", target: "manual_recovery_resolution", AND: [{ metadata: { path: ["expiredEventId"], equals: manualExpiredEventId } }, { metadata: { path: ["runId"], equals: `manual-${runId}` } }] } satisfies Prisma.AuditEventWhereInput;
+const manualRunId = `manual-${randomUUID()}`;
+const manualAuditWhere = { action: "bank_autologin.manual_recovery_resolved", target: "manual_recovery_resolution", AND: [{ metadata: { path: ["expiredEventId"], equals: manualExpiredEventId } }, { metadata: { path: ["runId"], equals: manualRunId } }] } satisfies Prisma.AuditEventWhereInput;
 let prisma: PrismaClient | undefined;
-let Queue: typeof import("bullmq").Queue;
-let Worker: typeof import("bullmq").Worker;
-let queueA: import("bullmq").Queue | undefined;
-let queueB: import("bullmq").Queue | undefined;
-let worker: import("bullmq").Worker | undefined;
-const closedQueues = new Set<import("bullmq").Queue>();
-const closeCounts = new Map<import("bullmq").Queue, number>();
 
-describe.skipIf(!RUN_INTEGRATION)("expiry runtime integration (requires dedicated PostgreSQL and Redis)", () => {
+describe.skipIf(!RUN_INTEGRATION)("expiry runtime integration (requires dedicated PostgreSQL)", () => {
   beforeAll(async () => {
     const prismaModule = await import("../generated/prisma/client");
-    const bullmq = await import("bullmq");
-    Queue = bullmq.Queue;
-    Worker = bullmq.Worker;
     prisma = new prismaModule.PrismaClient({
       adapter: new PrismaPg({ connectionString: TEST_DATABASE_URL! }),
     });
   });
 
   afterEach(async () => {
-    await worker?.close().catch(() => undefined);
-    worker = undefined;
-    if (TEST_REDIS_URL) {
-      const cleanupQueue = new Queue(queueName, {
-        connection: buildRedisConnectionOptions(TEST_REDIS_URL),
-      });
-      await cleanupQueue.obliterate({ force: true }).catch(() => undefined);
-      await cleanupQueue.close().catch(() => undefined);
-    }
-    await prisma?.auditEvent.deleteMany({ where: { OR: [expiryAuditWhere, terminalAuditWhere, manualAuditWhere] } });
+    await prisma?.auditEvent.deleteMany({ where: manualAuditWhere });
     await prisma?.manualRecoveryResolutionAuditOutbox.deleteMany({ where: { id: manualOutboxId } });
     await prisma?.manualRecoveryResolution.deleteMany({ where: { id: manualResolutionId } });
     await prisma?.bankSessionExpiryEpisode.deleteMany({ where: { bankCode } });
   });
 
   afterAll(async () => {
-    await worker?.close().catch(() => undefined);
-    for (const queue of [queueA, queueB]) {
-      if (queue && !closedQueues.has(queue)) await queue.close();
-    }
     await prisma?.$disconnect();
   });
 
-  it("elects durable owners, terminal reconciliation, delivery, and graceful shutdown across two replicas", async () => {
-    if (!prisma || !TEST_REDIS_URL) throw new Error("Dedicated integration services are required");
-    const connection = buildRedisConnectionOptions(TEST_REDIS_URL);
-    queueA = new Queue(queueName, { connection });
-    queueB = new Queue(queueName, { connection });
-    const episodes = new PrismaBankSessionExpiryEpisodeRepository(prisma);
+  it("elects one manual-recovery audit delivery without publication ownership across two replicas", async () => {
+    if (!prisma) throw new Error("Dedicated PostgreSQL service is required");
     const outbox = new PrismaManualRecoveryResolutionAuditOutboxRepository(prisma);
     const auditSink: AuditSink = {
       async record(event) {
@@ -100,40 +62,29 @@ describe.skipIf(!RUN_INTEGRATION)("expiry runtime integration (requires dedicate
       },
       async list() { return []; },
     };
+    const monitorAudits: string[] = [];
     const timers: number[] = [];
     const clearedTimers: number[] = [];
     const ownersSeen = new Set<string>();
-    const proposedTokens = new Map<string, string>();
     const alerts: Array<{ safeSummary: string }> = [];
     const runtimeTickGate: { wait?: Promise<void>; release?: () => void; signalReplicaATick?: () => void } = {};
     const runtimeTickStats = new Map<string, { calls: number; active: number; max: number }>();
     let releaseClaimBarrier!: () => void;
     const claimBarrier = new Promise<void>((resolve) => { releaseClaimBarrier = resolve; });
 
-    function replica(owner: string, queue: import("bullmq").Queue): ExpiryRuntime {
+    const closeCounts = new Map<string, number>();
+
+    function replica(owner: string): ExpiryRuntime {
       const stats = { calls: 0, active: 0, max: 0 };
-      const proposedToken = `publication-${owner}-${randomUUID()}`;
-      proposedTokens.set(owner, proposedToken);
       runtimeTickStats.set(owner, stats);
-      const publisher = {
-        schedule: (envelope: { bankCode: string; expiredEventId: string; runId: string; token: string }) =>
-          scheduleExpiryPublicationJob(queue, envelope),
-        observe: (envelope: { runId: string }) => observeExpiryPublicationJob(queue, envelope.runId),
-      };
       const monitor = createBankSessionMonitor({
         check: async () => {
           return { status: "expired", checkedAt: new Date().toISOString(), safeSummary: "Synthetic expiry" };
         },
         intervalMs: 60_000,
         alertSink: { notifySessionAttention: async (alert) => { alerts.push(alert); } },
-        auditSink,
-        monitorMode: {
-          mode: "expiry_events",
-          bankCode,
-          episodes,
-          createExpiredEventId: () => expiredEventId,
-          publish: (episode) => publishExpiryEpisode(episodes, episode, proposedToken, publisher).then(() => undefined),
-        },
+        auditSink: { record: async (event) => { monitorAudits.push(event.action); } },
+        monitorMode: { mode: "alert_only" },
       });
       const runtimeMonitor = {
         async tick() {
@@ -153,12 +104,9 @@ describe.skipIf(!RUN_INTEGRATION)("expiry runtime integration (requires dedicate
         {
           RD_SYNC_SESSION_MONITOR: "enabled",
           DATABASE_URL: TEST_DATABASE_URL,
-          RD_SYNC_REDIS_URL: TEST_REDIS_URL,
         },
         () => ({
           monitor: runtimeMonitor,
-          episodes,
-          publisher,
           auditSink,
           bankCode,
           leaseOwner: owner,
@@ -185,65 +133,28 @@ describe.skipIf(!RUN_INTEGRATION)("expiry runtime integration (requires dedicate
           },
           clearSchedule: (timer) => { clearedTimers.push(timer as number); },
           close: async () => {
-            if (closedQueues.has(queue)) return;
-            closedQueues.add(queue);
-            closeCounts.set(queue, (closeCounts.get(queue) ?? 0) + 1);
-            await queue.close();
+            closeCounts.set(owner, (closeCounts.get(owner) ?? 0) + 1);
           },
         }),
       );
     }
 
-    const runtimeA = replica("replica-a", queueA);
-    const runtimeB = replica("replica-b", queueB);
+    const runtimeA = replica("replica-a");
+    const runtimeB = replica("replica-b");
     runtimeA.start();
     runtimeB.start();
-    expect(queueA).not.toBe(queueB);
     expect(timers).toEqual([1, 2]);
 
     await Promise.all([runtimeA.tick(), runtimeB.tick()]);
-    const episode = await episodes.findByBankCode(bankCode);
-    expect(episode).toMatchObject({
-      expiredEventId,
-      runId,
-      publicationState: "published",
-      publicationClaimToken: expect.any(String),
-    });
-    expect([...proposedTokens.values()]).toEqual(expect.arrayContaining([episode!.publicationClaimToken!]));
-    expect(new Set(proposedTokens.values())).toHaveLength(2);
-    expect(await prisma.auditEvent.count({ where: expiryAuditWhere })).toBe(1);
-    expect((await queueA.getJob(runId))?.data.token).toBe(episode!.publicationClaimToken);
-
-    worker = new Worker(
-      queueName,
-      async (job) => {
-        job.discard();
-        throw new Error("synthetic publication failure");
-      },
-      { connection, concurrency: 1 },
-    );
-    await new Promise<void>((resolve, reject) => {
-      const timeout = setTimeout(() => reject(new Error(`Timed out after ${WORKER_READY_TIMEOUT_MS}ms waiting for BullMQ worker readiness`)), WORKER_READY_TIMEOUT_MS);
-      worker!.once("ready", () => { clearTimeout(timeout); resolve(); });
-      worker!.once("error", (error) => { clearTimeout(timeout); reject(error); });
-    });
-    await new Promise<void>((resolve, reject) => {
-      const timeout = setTimeout(() => reject(new Error("Timed out waiting for synthetic terminal failure")), 5_000);
-      worker!.on("failed", (job) => {
-        if (job?.id === runId) {
-          clearTimeout(timeout);
-          resolve();
-        }
-      });
-    });
-    await expect((await queueA.getJob(runId))?.getState()).resolves.toBe("failed");
+    expect(await prisma.bankSessionExpiryEpisode.count({ where: { bankCode } })).toBe(0);
+    expect(monitorAudits).toEqual(["bank_session.expired", "bank_session.expired"]);
 
     await prisma.manualRecoveryResolution.create({
       data: {
         id: manualResolutionId,
         expiredEventId: manualExpiredEventId,
         bankCode,
-        runId: `manual-${runId}`,
+        runId: manualRunId,
         outcome: "resolved_no_retry",
         reason: "closed_without_retry",
         operatorId: "operator-integration",
@@ -256,19 +167,17 @@ describe.skipIf(!RUN_INTEGRATION)("expiry runtime integration (requires dedicate
       where: { id: manualOutboxId, state: "delivered" },
     })).toBe(1);
     expect(await prisma.auditEvent.count({ where: manualAuditWhere })).toBe(1);
-    expect(await prisma.auditEvent.count({ where: terminalAuditWhere })).toBe(1);
     await prisma.auditEvent.create({
       data: {
         id: `semantic-duplicate-${randomUUID()}`,
         action: "bank_autologin.manual_recovery_resolved",
         target: "manual_recovery_resolution",
         targetId: `duplicate-${manualResolutionId}`,
-        metadata: { bankCode, expiredEventId: manualExpiredEventId, runId: `manual-${runId}` },
+        metadata: { bankCode, expiredEventId: manualExpiredEventId, runId: manualRunId },
       },
     });
     expect(await prisma.auditEvent.count({ where: manualAuditWhere })).toBe(2);
-    expect(alerts.filter((alert) => alert.safeSummary === "Automatic session recovery requires administrative review")).toHaveLength(1);
-    expect(JSON.stringify(alerts)).not.toMatch(/token|https?:\/\/|synthetic publication failure/i);
+    expect(alerts).toEqual(expect.arrayContaining([{ safeSummary: "Synthetic expiry" }]));
 
     runtimeTickGate.wait = new Promise<void>((resolve) => { runtimeTickGate.release = resolve; });
     const replicaATickEntered = new Promise<void>((resolve) => { runtimeTickGate.signalReplicaATick = resolve; });
@@ -290,7 +199,7 @@ describe.skipIf(!RUN_INTEGRATION)("expiry runtime integration (requires dedicate
     runtimeTickGate.release?.();
     await Promise.all([firstTick, finalTick, stoppingA, stoppingB, runtimeA.shutdown(), runtimeB.shutdown()]);
     expect(new Set(clearedTimers)).toEqual(new Set([1, 2]));
-    expect(closeCounts.get(queueA)).toBe(1);
-    expect(closeCounts.get(queueB)).toBe(1);
+    expect(closeCounts.get("replica-a")).toBe(1);
+    expect(closeCounts.get("replica-b")).toBe(1);
   });
 });

--- a/src/worker/expiry-runtime.test.ts
+++ b/src/worker/expiry-runtime.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 
 import type { ExpiryRuntimeDependencies } from "./expiry-runtime";
@@ -6,7 +8,6 @@ import { createExpiryRuntime } from "./expiry-runtime";
 const enabled = {
   RD_SYNC_SESSION_MONITOR: "enabled",
   DATABASE_URL: "postgres://test",
-  RD_SYNC_REDIS_URL: "redis://test",
 };
 const episode = {
   bankCode: "popular",
@@ -19,13 +20,6 @@ const episode = {
 function dependencies(overrides: Partial<ExpiryRuntimeDependencies> = {}): ExpiryRuntimeDependencies {
   return {
     monitor: { tick: vi.fn().mockResolvedValue(undefined) },
-    episodes: {
-      findByBankCode: vi.fn().mockResolvedValue(episode),
-      reconcileTerminalFailure: vi.fn()
-        .mockResolvedValueOnce({ status: "reconciled", operatorSignal: "safe" })
-        .mockResolvedValue({ status: "already_reconciled", operatorSignal: "safe" }),
-    },
-    publisher: { observe: vi.fn().mockResolvedValue("failed") },
     outbox: {
       findClaimable: vi.fn().mockResolvedValue(null),
       claim: vi.fn(),
@@ -41,6 +35,20 @@ function dependencies(overrides: Partial<ExpiryRuntimeDependencies> = {}): Expir
   };
 }
 
+function legacyDependencies(overrides: Partial<ExpiryRuntimeDependencies> = {}): ExpiryRuntimeDependencies {
+  const episodes = {
+    findByBankCode: vi.fn().mockResolvedValue(episode),
+    reconcileTerminalFailure: vi.fn()
+      .mockResolvedValueOnce({ status: "reconciled", operatorSignal: "safe" })
+      .mockResolvedValue({ status: "already_reconciled", operatorSignal: "safe" }),
+  };
+  const publisher = { observe: vi.fn().mockResolvedValue("failed") };
+  return dependencies({
+    legacyPublicationObservation: { episodes, publisher },
+    ...overrides,
+  });
+}
+
 describe("expiry runtime", () => {
   it("is default-off without constructing runtime effects", async () => {
     const create = vi.fn();
@@ -52,23 +60,24 @@ describe("expiry runtime", () => {
     expect(create).not.toHaveBeenCalled();
   });
 
-  it("fails enabled startup before construction when configuration is missing", () => {
+  it("starts enabled with DATABASE_URL and no Redis URL", () => {
+    const create = vi.fn(() => dependencies());
+    const runtime = createExpiryRuntime({ RD_SYNC_SESSION_MONITOR: "enabled", DATABASE_URL: "postgres://test" }, create);
+    expect(runtime.enabled).toBe(true);
+    expect(create).toHaveBeenCalledOnce();
+  });
+
+  it("fails enabled startup before construction when DATABASE_URL is missing", () => {
     const create = vi.fn();
     expect(() => createExpiryRuntime({ RD_SYNC_SESSION_MONITOR: "enabled" }, create))
       .toThrow("DATABASE_URL");
     expect(create).not.toHaveBeenCalled();
   });
 
-  it("leaves unavailable checks without an episode unobserved", async () => {
-    const deps = dependencies({
-      episodes: {
-        findByBankCode: vi.fn().mockResolvedValue(null),
-        reconcileTerminalFailure: vi.fn(),
-      },
-    });
+  it("never observes or reconciles publication without the explicit legacy seam", async () => {
+    const deps = dependencies();
     await createExpiryRuntime(enabled, () => deps).tick();
-    expect(deps.publisher.observe).not.toHaveBeenCalled();
-    expect(deps.episodes.reconcileTerminalFailure).not.toHaveBeenCalled();
+    expect(deps.monitor.tick).toHaveBeenCalledOnce();
   });
 
   it("reobserves a deferred terminal lease on the next tick and alerts only after reconciliation", async () => {
@@ -76,12 +85,12 @@ describe("expiry runtime", () => {
     const reconcileTerminalFailure = vi.fn()
       .mockResolvedValueOnce({ status: "deferred_active_lease", operatorSignal: "safe" })
       .mockResolvedValueOnce({ status: "reconciled", operatorSignal: "safe" });
-    const deps = dependencies({ alerts: { notifySessionAttention }, episodes: { findByBankCode: vi.fn().mockResolvedValue(episode), reconcileTerminalFailure } });
+    const deps = legacyDependencies({ alerts: { notifySessionAttention }, legacyPublicationObservation: { episodes: { findByBankCode: vi.fn().mockResolvedValue(episode), reconcileTerminalFailure }, publisher: { observe: vi.fn().mockResolvedValue("failed") } } });
     const runtime = createExpiryRuntime(enabled, () => deps);
     await runtime.tick();
     expect(notifySessionAttention).not.toHaveBeenCalled();
     await runtime.tick();
-    expect(deps.publisher.observe).toHaveBeenCalledTimes(2);
+    expect(deps.legacyPublicationObservation!.publisher.observe).toHaveBeenCalledTimes(2);
     expect(reconcileTerminalFailure).toHaveBeenCalledTimes(2);
     expect(deps.alerts.notifySessionAttention).toHaveBeenCalledOnce();
     expect(deps.alerts.notifySessionAttention).toHaveBeenCalledWith({
@@ -93,11 +102,17 @@ describe("expiry runtime", () => {
   });
 
   it("rejects unsafe observations without durable terminal state or alerts", async () => {
-    const deps = dependencies({
-      publisher: { observe: vi.fn().mockRejectedValue(new Error("redis://secret")) },
+    const deps = legacyDependencies({
+      legacyPublicationObservation: {
+        episodes: {
+          findByBankCode: vi.fn().mockResolvedValue(episode),
+          reconcileTerminalFailure: vi.fn(),
+        },
+        publisher: { observe: vi.fn().mockRejectedValue(new Error("redis://secret")) },
+      },
     });
     await createExpiryRuntime(enabled, () => deps).tick();
-    expect(deps.episodes.reconcileTerminalFailure).not.toHaveBeenCalled();
+    expect(deps.legacyPublicationObservation!.episodes.reconcileTerminalFailure).not.toHaveBeenCalled();
     expect(deps.alerts.notifySessionAttention).not.toHaveBeenCalled();
   });
 
@@ -166,5 +181,11 @@ describe("expiry runtime", () => {
     await expect(stopping).resolves.toBeUndefined();
     await expect(runtime.shutdown()).resolves.toBeUndefined();
     expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("keeps production composition free of publication and Redis ownership", () => {
+    const source = readFileSync(fileURLToPath(new URL("./expiry-runtime.ts", import.meta.url)), "utf8");
+    const production = source.slice(source.indexOf("export function createDefaultExpiryRuntime"));
+    expect(production).not.toMatch(/Queue|publishExpiryEpisode|observeExpiryPublicationJob|RD_SYNC_REDIS_URL|createExpiredEventId|runId/);
   });
 });

--- a/src/worker/expiry-runtime.ts
+++ b/src/worker/expiry-runtime.ts
@@ -1,19 +1,15 @@
 import { randomUUID } from "node:crypto";
-import { Queue } from "bullmq";
 
 import { popularScraperProfile } from "../modules/bank-adapters/popular";
 import { createBankSessionMonitor, createCdpSessionChecker, type BankSessionMonitor } from "../modules/bank-sessions";
 import { deliverManualRecoveryResolutionAudit, type ManualRecoveryResolutionAuditOutboxRepository } from "../modules/bank-sessions/manual-recovery-resolution-audit-delivery";
 import { reconcileExpiryTerminalObservation, type ExpiryTerminalReconciliationRepository } from "../modules/bank-sessions/expiry-terminal-reconciliation";
-import { observeExpiryPublicationJob, scheduleExpiryPublicationJob, type ExpiryPublicationQueue } from "../modules/bank-sessions/expiry-publication";
-import { publishExpiryEpisode, type BankSessionExpiryEpisode, type BankSessionExpiryEpisodeRepository, type ExpiryPublicationPublisher } from "../modules/bank-sessions/expiry-episodes";
+import type { BankSessionExpiryEpisodeRepository, ExpiryPublicationPublisher } from "../modules/bank-sessions/expiry-episodes";
 import type { AuditSink } from "../modules/audit";
 import { PrismaAuditSink } from "../modules/persistence/prisma-audit-sink";
-import { PrismaBankSessionExpiryEpisodeRepository } from "../modules/persistence/prisma-bank-session-expiry-episode-repository";
 import { PrismaManualRecoveryResolutionAuditOutboxRepository } from "../modules/persistence/prisma-manual-recovery-resolution-audit-outbox-repository";
 import { getPrismaClient } from "../modules/persistence/prisma-client";
 import { resolveDefaultAlertSink } from "./alerts/email-alert-sink";
-import { buildRedisConnectionOptions } from "./queues/bullmq-queue";
 import { resolveBankBrowserEnv } from "./scraper/browser-runtime";
 import type { AdminAlertSink } from "./queues";
 
@@ -32,8 +28,10 @@ export interface ExpiryRuntime {
 
 export interface ExpiryRuntimeDependencies {
   monitor: Pick<BankSessionMonitor, "tick">;
-  episodes: Pick<BankSessionExpiryEpisodeRepository, "findByBankCode"> & ExpiryTerminalReconciliationRepository;
-  publisher: Pick<ExpiryPublicationPublisher, "observe">;
+  legacyPublicationObservation?: {
+    episodes: Pick<BankSessionExpiryEpisodeRepository, "findByBankCode"> & ExpiryTerminalReconciliationRepository;
+    publisher: Pick<ExpiryPublicationPublisher, "observe">;
+  };
   outbox: ManualRecoveryResolutionAuditOutboxRepository;
   auditSink: AuditSink;
   alerts: Pick<AdminAlertSink, "notifySessionAttention">;
@@ -50,8 +48,8 @@ export function createExpiryRuntime(
   create: () => ExpiryRuntimeDependencies,
 ): ExpiryRuntime {
   if (env.RD_SYNC_SESSION_MONITOR !== "enabled") return disabledRuntime;
-  if (!env.DATABASE_URL || !env.RD_SYNC_REDIS_URL) {
-    throw new Error("Expiry runtime requires DATABASE_URL and RD_SYNC_REDIS_URL");
+  if (!env.DATABASE_URL) {
+    throw new Error("Expiry runtime requires DATABASE_URL");
   }
   return createEnabledRuntime(create());
 }
@@ -72,7 +70,9 @@ function createEnabledRuntime(deps: ExpiryRuntimeDependencies): ExpiryRuntime {
   let shutdown: Promise<void> | undefined;
 
   async function observeTerminalEpisode(): Promise<void> {
-    const episode = await deps.episodes.findByBankCode(deps.bankCode);
+    const legacy = deps.legacyPublicationObservation;
+    if (!legacy) return;
+    const episode = await legacy.episodes.findByBankCode(deps.bankCode);
     if (!episode || episode.publicationState !== "published" || !episode.publicationClaimToken) return;
     const envelope = {
       bankCode: episode.bankCode,
@@ -81,8 +81,8 @@ function createEnabledRuntime(deps: ExpiryRuntimeDependencies): ExpiryRuntime {
       token: episode.publicationClaimToken,
     };
     const observation = await reconcileExpiryTerminalObservation(
-      () => deps.publisher.observe(envelope),
-      deps.episodes,
+      () => legacy.publisher.observe(envelope),
+      legacy.episodes,
       envelope,
       clock,
     );
@@ -140,40 +140,23 @@ export function createDefaultExpiryRuntime(
 ): ExpiryRuntime {
   return createExpiryRuntime(env, () => {
     const prisma = getPrismaClient();
-    const episodes = new PrismaBankSessionExpiryEpisodeRepository(prisma);
-    const queue = new Queue("bank-transaction-ingestion", {
-      connection: buildRedisConnectionOptions(env.RD_SYNC_REDIS_URL!),
-    });
-    const publicationQueue = queue as unknown as ExpiryPublicationQueue;
-    const publisher: ExpiryPublicationPublisher = {
-      schedule: (job) => scheduleExpiryPublicationJob(publicationQueue, job),
-      observe: (job) => observeExpiryPublicationJob(publicationQueue, job.runId),
-    };
     const alerts = resolveDefaultAlertSink();
+    const auditSink = new PrismaAuditSink();
     const bankCode = popularScraperProfile.bankId;
     return {
       bankCode,
-      episodes,
-      publisher,
       outbox: new PrismaManualRecoveryResolutionAuditOutboxRepository(prisma),
-      auditSink: new PrismaAuditSink(),
+      auditSink,
       alerts,
       leaseOwner: `expiry-runtime:${randomUUID()}`,
-      close: () => queue.close(),
       monitor: createBankSessionMonitor({
         check: createCdpSessionChecker({
           cdpUrl: resolveBankBrowserEnv(bankCode, env).cdpUrl,
         }).check,
         alertSink: alerts,
-        auditSink: new PrismaAuditSink(),
+        auditSink,
         intervalMs: INTERVAL_MS,
-        monitorMode: {
-          mode: "expiry_events",
-          bankCode,
-          episodes,
-          publish: (episode: BankSessionExpiryEpisode) =>
-            publishExpiryEpisode(episodes, episode, randomUUID(), publisher).then(() => undefined),
-        },
+        monitorMode: { mode: "alert_only" },
       }),
     };
   });


### PR DESCRIPTION
Closes #109

## Summary
- Retires the default expiry publication producer, leaving the worker alert/outbox-only by default.
- Keeps the legacy terminal observer available only through explicit test injection while preserving recovery audits and monitor lifecycle behavior.
- Already queued expiry-publication jobs still target the existing consumer until WU5b makes that consumer inert.

## Chain Context

| Topic | Detail |
| --- | --- |
| Strategy | Feature Branch Chain |
| Start state | `ed948d0` |
| End state | Alert/outbox-only default |
| Dependency | Targets tracker `feat/coordinated-authenticated-ingestion-cutover`; WU5b depends on this PR |
| Merge/deployment | Do not deploy or merge to `main` from this PR. The tracker is the only final merge, during the stop-worker window. |
| Rollback | Revert commits `e096c3f` and `c1116b8`; this restores the producer/observer work unit without unrelated chain changes. |

```text
main
  -> tracker feat/coordinated-authenticated-ingestion-cutover
       -> 📍 WU5a retire producer/observer (THIS PR)
            -> WU5b retired consumer
                 -> WU6a scheduler
                      -> WU6b composition
                           -> WU6c processor
                                -> WU6d wiring/docs
```

### Behavior Boundary

| Retained | Removed |
| --- | --- |
| Alerting, manual-recovery audit outbox, monitor lifecycle, and live CDP checks | Default expiry Queue/Redis composition, episode/publication production, and publication ownership |
| Injection-only legacy terminal observer seam for tests | Legacy observer as a production default |
| Existing queued expiry-publication jobs continue to reach the current consumer until WU5b | Any claim that WU5a drains, deletes, or consumes existing queued jobs |

## Changed Files

| File | Change |
| --- | --- |
| `src/worker/expiry-runtime.ts` | Removes default expiry publication composition and keeps alert/outbox behavior. |
| `src/worker/expiry-runtime.test.ts` | Covers the default runtime boundary and the injection-only legacy observer seam. |
| `src/worker/expiry-runtime.integration.test.ts` | Retains PostgreSQL two-replica outbox delivery evidence without producer ownership. |
| `docs/runbooks/bank-session.md` | Documents alert/outbox-only session monitoring. |
| `docs/runbooks/worker.md` | Documents the PostgreSQL integration evidence path. |

Review budget: 5 files, +112/-198, 310 changed lines. No size exception.

## Verification

- [x] Focused tests: 11 passing.
- [x] Full suite: 1,686 passed, 2 skipped.
- [x] Fresh PostgreSQL 16: all 16 migrations applied; integration 1/1 passed.
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm exec prisma validate`, and `git diff --check` passed.
- [x] The repository has no CI workflows, so zero checks are expected. Evidence is local; receipt-driven review is disabled/unmanaged.
- [x] Linked approved issue #109 and added the sole `type:feature` label.