### PR TITLE
feat(worker): add collection-only ingestion processor

### DIFF
--- a/src/worker/collection-ingestion-processor.test.ts
+++ b/src/worker/collection-ingestion-processor.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it, vi } from "vitest";
 
 import type { AuthenticatedIngestionDeliveryDependencies } from "./authenticated-ingestion-delivery";
-import { createCollectionIngestionProcessor, type CollectionIngestionProcessorDependencies } from "./collection-ingestion-processor";
+import { CollectionIngestionPersistenceError, createCollectionIngestionProcessor, type CollectionIngestionProcessorDependencies } from "./collection-ingestion-processor";
 import type { IngestionResult } from "./queues";
 
 const job = { data: { runId: "run-1", bankId: "popular", accountFingerprint: "account-secret" } };
@@ -65,6 +65,44 @@ describe("createCollectionIngestionProcessor", () => {
     expect(dependencies.scrapeRuns.markFailed).toHaveBeenCalledWith("run-1", "Ingestion collection failed", expect.any(Date));
   });
 
+  it("rejects safely when it cannot mark a run running", async () => {
+    const fixture = createDependencies();
+    fixture.dependencies.scrapeRuns.markRunning = vi.fn(async () => { throw new Error("secret-sentinel"); });
+    const { dependencies } = fixture;
+    let error: unknown;
+    try { await createCollectionIngestionProcessor(dependencies)(job); } catch (caught) { error = caught; }
+    expect(error).toBeInstanceOf(CollectionIngestionPersistenceError);
+    expect(String(error)).not.toContain("secret-sentinel");
+    expect(dependencies.resolveScraper).not.toHaveBeenCalled();
+    expect(dependencies.scrapeRuns.markFailed).not.toHaveBeenCalled();
+  });
+
+  it("compensates a failed succeeded transition exactly once", async () => {
+    const fixture = createDependencies();
+    fixture.dependencies.scrapeRuns.markSucceeded = vi.fn(async () => { fixture.calls.push("succeeded"); throw new Error("secret-sentinel"); });
+    const { dependencies, calls } = fixture;
+    await expect(createCollectionIngestionProcessor(dependencies)(job)).resolves.toEqual({ status: "failed", inserted: 0, skipped: 0 });
+    expect(calls).toEqual(["running", "scrape_run.started", "upsert", "succeeded", "failed", "alert", "scrape_run.failed"]);
+    expect(dependencies.scrapeRuns.markFailed).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects safely when succeeded and compensating terminal transitions both fail", async () => {
+    const fixture = createDependencies();
+    fixture.dependencies.scrapeRuns.markSucceeded = vi.fn(async () => { throw new Error("secret-sentinel"); });
+    fixture.dependencies.scrapeRuns.markFailed = vi.fn(async () => { throw new Error("secret-sentinel"); });
+    const { dependencies } = fixture;
+    await expect(createCollectionIngestionProcessor(dependencies)(job)).rejects.toBeInstanceOf(CollectionIngestionPersistenceError);
+    expect(dependencies.scrapeRuns.markFailed).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves a trusted non-expiry admin summary in terminal state, alert, and audit", async () => {
+    const { dependencies } = createDependencies({ resolveScraper: vi.fn(() => ({ collect: vi.fn(async () => ({ status: "needs_admin_action" as const, movements: [], safeErrorSummary: "Portal requires a human review" })) })) });
+    await expect(createCollectionIngestionProcessor(dependencies)(job)).resolves.toEqual({ status: "needs_admin_action", inserted: 0, skipped: 0 });
+    expect(dependencies.scrapeRuns.markNeedsAdminAction).toHaveBeenCalledWith("run-1", "Portal requires a human review", expect.any(Date));
+    expect(dependencies.adminAlerts?.notifyIngestionAttention).toHaveBeenCalledWith(expect.objectContaining({ safeErrorSummary: "Portal requires a human review" }));
+    expect(dependencies.auditSink?.record).toHaveBeenLastCalledWith(expect.objectContaining({ metadata: expect.objectContaining({ safeErrorSummary: "Portal requires a human review" }) }));
+  });
+
   it.each([
     ["collector throw", { collect: vi.fn(async () => { throw new Error("secret-sentinel"); }) }],
     ["malformed collector result", { collect: vi.fn(async () => ({ status: "collected", movements: "secret-sentinel" } as unknown as never)) }],
@@ -81,8 +119,21 @@ describe("createCollectionIngestionProcessor", () => {
     await expect(createCollectionIngestionProcessor(malformed.dependencies)(hostile)).resolves.toEqual({ status: "failed", inserted: 0, skipped: 0 });
     const persistence = createDependencies({ transactions: { upsertMany: vi.fn(async () => { throw new Error("secret-sentinel"); }) } });
     await expect(createCollectionIngestionProcessor(persistence.dependencies)(job)).resolves.toEqual({ status: "failed", inserted: 0, skipped: 0 });
+    expect(persistence.dependencies.scrapeRuns.markFailed).toHaveBeenCalledTimes(1);
     const terminal = createDependencies({ scrapeRuns: { ...persistence.dependencies.scrapeRuns, markSucceeded: vi.fn(async () => { throw new Error("secret-sentinel"); }) } });
     await expect(createCollectionIngestionProcessor(terminal.dependencies)(job)).resolves.toEqual({ status: "failed", inserted: 0, skipped: 0 });
+  });
+
+  it("rejects safely when upsert and its failed transition both reject", async () => {
+    const fixture = createDependencies({ transactions: { upsertMany: vi.fn(async () => { throw new Error("secret-sentinel"); }) } });
+    fixture.dependencies.scrapeRuns.markFailed = vi.fn(async () => { throw new Error("secret-sentinel"); });
+    await expect(createCollectionIngestionProcessor(fixture.dependencies)(job)).rejects.toBeInstanceOf(CollectionIngestionPersistenceError);
+    expect(fixture.dependencies.scrapeRuns.markFailed).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not let audit or alert delivery alter a completed result", async () => {
+    const { dependencies } = createDependencies({ resolveScraper: vi.fn(() => ({ collect: vi.fn(async () => ({ status: "needs_admin_action" as const, movements: [] })) })), adminAlerts: { notifyIngestionAttention: vi.fn(async () => { throw new Error("secret-sentinel"); }), notifySessionAttention: vi.fn() }, auditSink: { record: vi.fn(async () => { throw new Error("secret-sentinel"); }) } });
+    await expect(createCollectionIngestionProcessor(dependencies)(job)).resolves.toEqual({ status: "needs_admin_action", inserted: 0, skipped: 0 });
   });
 
   it("is compatible as authenticated delivery downstream and contains no recovery or runtime secrets", () => {

--- a/src/worker/collection-ingestion-processor.test.ts
+++ b/src/worker/collection-ingestion-processor.test.ts
@@ -1,0 +1,94 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it, vi } from "vitest";
+
+import type { AuthenticatedIngestionDeliveryDependencies } from "./authenticated-ingestion-delivery";
+import { createCollectionIngestionProcessor, type CollectionIngestionProcessorDependencies } from "./collection-ingestion-processor";
+import type { IngestionResult } from "./queues";
+
+const job = { data: { runId: "run-1", bankId: "popular", accountFingerprint: "account-secret" } };
+const movement = { bankId: "popular", accountFingerprint: "account-secret", postedAt: "2026-01-02", amount: "10.00", currency: "DOP", direction: "debit" as const, reference: "raw-reference" };
+
+function createDependencies(overrides: Partial<CollectionIngestionProcessorDependencies> = {}) {
+  const calls: string[] = [];
+  const dependencies: CollectionIngestionProcessorDependencies = {
+    scrapeRuns: {
+      markRunning: vi.fn(async () => { calls.push("running"); }),
+      markSucceeded: vi.fn(async () => { calls.push("succeeded"); }),
+      markNeedsAdminAction: vi.fn(async () => { calls.push("admin"); }),
+      markThrottled: vi.fn(),
+      markFailed: vi.fn(async () => { calls.push("failed"); }),
+    },
+    transactions: { upsertMany: vi.fn(async () => { calls.push("upsert"); return { inserted: 1, skipped: 2 }; }) },
+    resolveScraper: vi.fn(() => ({ collect: vi.fn(async () => ({ status: "collected" as const, movements: [movement] })) })),
+    adminAlerts: { notifyIngestionAttention: vi.fn(async () => { calls.push("alert"); }), notifySessionAttention: vi.fn() },
+    auditSink: { record: vi.fn(async (event) => { calls.push(event.action); }) },
+    now: () => new Date("2026-01-03T00:00:00.000Z"),
+    ...overrides,
+  };
+  return { dependencies, calls };
+}
+
+describe("createCollectionIngestionProcessor", () => {
+  it("collects once, persists normalized records, and completes a successful run", async () => {
+    const { dependencies, calls } = createDependencies();
+    const result = await createCollectionIngestionProcessor(dependencies)(job);
+    expect(result).toEqual({ status: "succeeded", inserted: 1, skipped: 2 });
+    expect(calls).toEqual(["running", "scrape_run.started", "upsert", "succeeded", "scrape_run.succeeded"]);
+    expect(dependencies.resolveScraper).toHaveBeenCalledWith("popular");
+    expect(dependencies.transactions.upsertMany).toHaveBeenCalledWith(expect.arrayContaining([expect.objectContaining({ scrapeRunId: "run-1", sourceHash: expect.any(String) })]));
+  });
+
+  it("succeeds with an empty collection without an upsert", async () => {
+    const { dependencies } = createDependencies({ resolveScraper: vi.fn(() => ({ collect: vi.fn(async () => ({ status: "collected" as const, movements: [] })) })) });
+    await expect(createCollectionIngestionProcessor(dependencies)(job)).resolves.toEqual({ status: "succeeded", inserted: 0, skipped: 0 });
+    expect(dependencies.transactions.upsertMany).not.toHaveBeenCalled();
+  });
+
+  it("preserves repository duplicate counts after normalization", async () => {
+    const { dependencies } = createDependencies({ transactions: { upsertMany: vi.fn(async () => ({ inserted: 0, skipped: 1 })) } });
+    await expect(createCollectionIngestionProcessor(dependencies)(job)).resolves.toEqual({ status: "succeeded", inserted: 0, skipped: 1 });
+  });
+
+  it("makes session expiry terminal without retrying, recovering, or persisting", async () => {
+    const { dependencies, calls } = createDependencies({ resolveScraper: vi.fn(() => ({ collect: vi.fn(async () => ({ status: "needs_admin_action" as const, cause: "session_expired" as const, movements: [] })) })) });
+    await expect(createCollectionIngestionProcessor(dependencies)(job)).resolves.toEqual({ status: "needs_admin_action", inserted: 0, skipped: 0 });
+    expect(dependencies.transactions.upsertMany).not.toHaveBeenCalled();
+    expect(calls).toContain("admin");
+    expect(calls).toContain("scrape_run.needs_admin_action");
+    expect(dependencies.scrapeRuns.markNeedsAdminAction).toHaveBeenCalledWith("run-1", "Bank session requires admin action", expect.any(Date));
+  });
+
+  it("fails closed for unknown banks without collecting", async () => {
+    const { dependencies } = createDependencies({ resolveScraper: vi.fn(() => { throw new Error("unknown bank"); }) });
+    await expect(createCollectionIngestionProcessor(dependencies)(job)).resolves.toEqual({ status: "failed", inserted: 0, skipped: 0 });
+    expect(dependencies.transactions.upsertMany).not.toHaveBeenCalled();
+    expect(dependencies.scrapeRuns.markFailed).toHaveBeenCalledWith("run-1", "Ingestion collection failed", expect.any(Date));
+  });
+
+  it.each([
+    ["collector throw", { collect: vi.fn(async () => { throw new Error("secret-sentinel"); }) }],
+    ["malformed collector result", { collect: vi.fn(async () => ({ status: "collected", movements: "secret-sentinel" } as unknown as never)) }],
+  ])("fails safely for %s without leaking diagnostics", async (_name, scraper) => {
+    const { dependencies } = createDependencies({ resolveScraper: vi.fn(() => scraper) });
+    await expect(createCollectionIngestionProcessor(dependencies)(job)).resolves.toEqual({ status: "failed", inserted: 0, skipped: 0 });
+    expect(JSON.stringify([vi.mocked(dependencies.scrapeRuns.markFailed).mock.calls, vi.mocked(dependencies.adminAlerts!.notifyIngestionAttention).mock.calls, vi.mocked(dependencies.auditSink!.record).mock.calls])).not.toContain("secret-sentinel");
+  });
+
+  it("fails closed for hostile job descriptors and persistence or terminal failures", async () => {
+    const hostile = { data: {} };
+    Object.defineProperty(hostile.data, "runId", { enumerable: true, get: () => { throw new Error("secret-sentinel"); } });
+    const malformed = createDependencies();
+    await expect(createCollectionIngestionProcessor(malformed.dependencies)(hostile)).resolves.toEqual({ status: "failed", inserted: 0, skipped: 0 });
+    const persistence = createDependencies({ transactions: { upsertMany: vi.fn(async () => { throw new Error("secret-sentinel"); }) } });
+    await expect(createCollectionIngestionProcessor(persistence.dependencies)(job)).resolves.toEqual({ status: "failed", inserted: 0, skipped: 0 });
+    const terminal = createDependencies({ scrapeRuns: { ...persistence.dependencies.scrapeRuns, markSucceeded: vi.fn(async () => { throw new Error("secret-sentinel"); }) } });
+    await expect(createCollectionIngestionProcessor(terminal.dependencies)(job)).resolves.toEqual({ status: "failed", inserted: 0, skipped: 0 });
+  });
+
+  it("is compatible as authenticated delivery downstream and contains no recovery or runtime secrets", () => {
+    const processAuthenticated: AuthenticatedIngestionDeliveryDependencies<IngestionResult>["downstream"] = createCollectionIngestionProcessor(createDependencies().dependencies);
+    expect(processAuthenticated).toBeTypeOf("function");
+    const source = readFileSync(new URL("./collection-ingestion-processor.ts", import.meta.url), "utf8");
+    expect(source).not.toMatch(/expiryEpisodes|runScrapeTimeAutoLogin|recoverExpiredSession|credential|browser|process\.env|bullmq/i);
+  });
+});

--- a/src/worker/collection-ingestion-processor.ts
+++ b/src/worker/collection-ingestion-processor.ts
@@ -4,6 +4,7 @@ import type { AdminAlertSink, IngestionResult, ResolveScraper, ScrapeRunReposito
 
 type JobData = Readonly<{ runId: string; bankId: string; accountFingerprint: string }>;
 type TerminalStatus = "failed" | "needs_admin_action";
+type CollectionOutcome = readonly BankMovement[] | Readonly<{ status: "needs_admin_action"; summary: string }> | null;
 
 export type CollectionIngestionProcessorDependencies = Readonly<{
   scrapeRuns: ScrapeRunRepository;
@@ -17,6 +18,10 @@ export type CollectionIngestionProcessorDependencies = Readonly<{
 const systemActor = "system:ingestion-worker";
 const failureSummary = "Ingestion collection failed";
 const sessionSummary = "Bank session requires admin action";
+
+export class CollectionIngestionPersistenceError extends Error {
+  constructor() { super("Collection ingestion persistence failed."); this.name = "CollectionIngestionPersistenceError"; }
+}
 
 function exact(value: unknown, required: readonly string[], optional: readonly string[] = []): Record<string, unknown> | null {
   if (value === null || typeof value !== "object" || Array.isArray(value) || (Object.getPrototypeOf(value) !== Object.prototype && Object.getPrototypeOf(value) !== null)) return null;
@@ -47,11 +52,12 @@ function safeRunId(value: unknown): string | null {
   } catch { return null; }
 }
 
-function collection(value: unknown): readonly BankMovement[] | TerminalStatus | null {
+function collection(value: unknown): CollectionOutcome {
   const result = exact(value, ["status", "movements"], ["safeErrorSummary", "cause"]);
-  if (!result || !Array.isArray(result.movements)) return null;
-  if (result.status === "collected") return result.movements as BankMovement[];
-  return result.status === "needs_admin_action" ? "needs_admin_action" : null;
+  if (!result || !Array.isArray(result.movements) || (result.safeErrorSummary !== undefined && typeof result.safeErrorSummary !== "string")) return null;
+  if (result.status === "collected" && result.cause === undefined) return result.movements as BankMovement[];
+  if (result.status !== "needs_admin_action" || (result.cause !== undefined && result.cause !== "session_expired")) return null;
+  return { status: "needs_admin_action", summary: result.cause === "session_expired" ? sessionSummary : result.safeErrorSummary ?? sessionSummary };
 }
 
 export function createCollectionIngestionProcessor(dependencies: CollectionIngestionProcessorDependencies): (job: unknown) => Promise<IngestionResult> {
@@ -63,7 +69,7 @@ export function createCollectionIngestionProcessor(dependencies: CollectionInges
     try {
       if (status === "needs_admin_action") await dependencies.scrapeRuns.markNeedsAdminAction(data.runId, summary, now());
       else await dependencies.scrapeRuns.markFailed(data.runId, summary, now());
-    } catch { return { status: "failed", inserted: 0, skipped: 0 }; }
+    } catch { throw new CollectionIngestionPersistenceError(); }
     try { await dependencies.adminAlerts?.notifyIngestionAttention({ runId: data.runId, bankId: data.bankId, status, safeErrorSummary: summary }); } catch { /* alerts are non-blocking */ }
     await audit(`scrape_run.${status}`, data, { safeErrorSummary: summary });
     return { status, inserted: 0, skipped: 0 };
@@ -78,17 +84,17 @@ export function createCollectionIngestionProcessor(dependencies: CollectionInges
       if (!runId) return { status: "failed", inserted: 0, skipped: 0 };
       return terminal("failed", { runId, bankId: "unknown", accountFingerprint: "unknown" }, failureSummary);
     }
-    try { await dependencies.scrapeRuns.markRunning(data.runId, now()); } catch { return { status: "failed", inserted: 0, skipped: 0 }; }
+    try { await dependencies.scrapeRuns.markRunning(data.runId, now()); } catch { throw new CollectionIngestionPersistenceError(); }
     await audit("scrape_run.started", data);
-    let outcome: readonly BankMovement[] | TerminalStatus | null;
+    let outcome: CollectionOutcome;
     try {
       outcome = collection(await dependencies.resolveScraper(data.bankId).collect());
       if (outcome === null) return terminal("failed", data, failureSummary);
-      if (!Array.isArray(outcome)) return terminal("needs_admin_action", data, sessionSummary);
+      if ("summary" in outcome) return terminal("needs_admin_action", data, outcome.summary);
       const counts = outcome.length === 0 ? { inserted: 0, skipped: 0 } : await dependencies.transactions.upsertMany(outcome.map((movement) => normalizeBankMovement(movement, { scrapeRunId: data.runId })));
-      try { await dependencies.scrapeRuns.markSucceeded(data.runId, { insertedCount: counts.inserted, skippedCount: counts.skipped }, now()); } catch { return { status: "failed", inserted: 0, skipped: 0 }; }
+      try { await dependencies.scrapeRuns.markSucceeded(data.runId, { insertedCount: counts.inserted, skippedCount: counts.skipped }, now()); } catch { return terminal("failed", data, failureSummary); }
       await audit("scrape_run.succeeded", data, { inserted: counts.inserted, skipped: counts.skipped });
       return { status: "succeeded", inserted: counts.inserted, skipped: counts.skipped };
-    } catch { return terminal("failed", data, failureSummary); }
+    } catch (error) { if (error instanceof CollectionIngestionPersistenceError) throw error; return terminal("failed", data, failureSummary); }
   };
 }

--- a/src/worker/collection-ingestion-processor.ts
+++ b/src/worker/collection-ingestion-processor.ts
@@ -1,0 +1,94 @@
+import { createAuditEvent, type AuditSink } from "../modules/audit";
+import { normalizeBankMovement, type BankMovement } from "../modules/transactions";
+import type { AdminAlertSink, IngestionResult, ResolveScraper, ScrapeRunRepository, TransactionUpsertRepository } from "./queues";
+
+type JobData = Readonly<{ runId: string; bankId: string; accountFingerprint: string }>;
+type TerminalStatus = "failed" | "needs_admin_action";
+
+export type CollectionIngestionProcessorDependencies = Readonly<{
+  scrapeRuns: ScrapeRunRepository;
+  transactions: TransactionUpsertRepository;
+  resolveScraper: ResolveScraper;
+  adminAlerts?: AdminAlertSink;
+  auditSink?: Pick<AuditSink, "record">;
+  now?: () => Date;
+}>;
+
+const systemActor = "system:ingestion-worker";
+const failureSummary = "Ingestion collection failed";
+const sessionSummary = "Bank session requires admin action";
+
+function exact(value: unknown, required: readonly string[], optional: readonly string[] = []): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value) || (Object.getPrototypeOf(value) !== Object.prototype && Object.getPrototypeOf(value) !== null)) return null;
+  const keys = Reflect.ownKeys(value);
+  if (keys.some((key) => typeof key !== "string" || (![...required, ...optional].includes(key))) || !required.every((key) => keys.includes(key))) return null;
+  const descriptors = Object.getOwnPropertyDescriptors(value);
+  const record: Record<string, unknown> = {};
+  for (const key of keys) {
+    const descriptor = descriptors[key as string];
+    if (!descriptor?.enumerable || !("value" in descriptor)) return null;
+    record[key as string] = descriptor.value;
+  }
+  return record;
+}
+
+function parseData(value: unknown): JobData | null {
+  const data = exact(value, ["runId", "bankId", "accountFingerprint"]);
+  return data && [data.runId, data.bankId, data.accountFingerprint].every((part) => typeof part === "string" && /\S/.test(part))
+    ? { runId: data.runId as string, bankId: data.bankId as string, accountFingerprint: data.accountFingerprint as string }
+    : null;
+}
+
+function safeRunId(value: unknown): string | null {
+  try {
+    if (value === null || typeof value !== "object") return null;
+    const descriptor = Object.getOwnPropertyDescriptor(value, "runId");
+    return descriptor?.enumerable && "value" in descriptor && typeof descriptor.value === "string" && /\S/.test(descriptor.value) ? descriptor.value : null;
+  } catch { return null; }
+}
+
+function collection(value: unknown): readonly BankMovement[] | TerminalStatus | null {
+  const result = exact(value, ["status", "movements"], ["safeErrorSummary", "cause"]);
+  if (!result || !Array.isArray(result.movements)) return null;
+  if (result.status === "collected") return result.movements as BankMovement[];
+  return result.status === "needs_admin_action" ? "needs_admin_action" : null;
+}
+
+export function createCollectionIngestionProcessor(dependencies: CollectionIngestionProcessorDependencies): (job: unknown) => Promise<IngestionResult> {
+  const now = dependencies.now ?? (() => new Date());
+  const audit = async (action: string, data: JobData, metadata?: Record<string, unknown>) => {
+    try { await dependencies.auditSink?.record(createAuditEvent({ actorId: systemActor, actorRole: null, action, target: "scrape_run", targetId: data.runId, metadata: { bankId: data.bankId, ...metadata } })); } catch { /* audit is non-blocking */ }
+  };
+  const terminal = async (status: TerminalStatus, data: JobData, summary: string): Promise<IngestionResult> => {
+    try {
+      if (status === "needs_admin_action") await dependencies.scrapeRuns.markNeedsAdminAction(data.runId, summary, now());
+      else await dependencies.scrapeRuns.markFailed(data.runId, summary, now());
+    } catch { return { status: "failed", inserted: 0, skipped: 0 }; }
+    try { await dependencies.adminAlerts?.notifyIngestionAttention({ runId: data.runId, bankId: data.bankId, status, safeErrorSummary: summary }); } catch { /* alerts are non-blocking */ }
+    await audit(`scrape_run.${status}`, data, { safeErrorSummary: summary });
+    return { status, inserted: 0, skipped: 0 };
+  };
+
+  return async (job): Promise<IngestionResult> => {
+    let rawData: unknown;
+    try { rawData = exact(job, ["data"])?.data; } catch { rawData = undefined; }
+    const data = (() => { try { return parseData(rawData); } catch { return null; } })();
+    if (!data) {
+      const runId = safeRunId(rawData);
+      if (!runId) return { status: "failed", inserted: 0, skipped: 0 };
+      return terminal("failed", { runId, bankId: "unknown", accountFingerprint: "unknown" }, failureSummary);
+    }
+    try { await dependencies.scrapeRuns.markRunning(data.runId, now()); } catch { return { status: "failed", inserted: 0, skipped: 0 }; }
+    await audit("scrape_run.started", data);
+    let outcome: readonly BankMovement[] | TerminalStatus | null;
+    try {
+      outcome = collection(await dependencies.resolveScraper(data.bankId).collect());
+      if (outcome === null) return terminal("failed", data, failureSummary);
+      if (!Array.isArray(outcome)) return terminal("needs_admin_action", data, sessionSummary);
+      const counts = outcome.length === 0 ? { inserted: 0, skipped: 0 } : await dependencies.transactions.upsertMany(outcome.map((movement) => normalizeBankMovement(movement, { scrapeRunId: data.runId })));
+      try { await dependencies.scrapeRuns.markSucceeded(data.runId, { insertedCount: counts.inserted, skippedCount: counts.skipped }, now()); } catch { return { status: "failed", inserted: 0, skipped: 0 }; }
+      await audit("scrape_run.succeeded", data, { inserted: counts.inserted, skipped: counts.skipped });
+      return { status: "succeeded", inserted: counts.inserted, skipped: counts.skipped };
+    } catch { return terminal("failed", data, failureSummary); }
+  };
+}


### PR DESCRIPTION
Closes #120

## Summary
- Adds the recovery-free collection-only ingestion processor as an inert, verified replacement boundary.
- Keeps the current processor active until a later product switch proves this replacement in composition.

## Chain Context
Only tracker #111 targets `main` and it MUST remain open and unmerged.

#111 tracker -> #110 integrated -> #113 integrated -> #115 integrated -> #117 integrated -> #119 OPEN -> 📍 WU6d.1 THIS PR OPEN -> WU6d.2 -> WU6d.3 -> WU6d.4 -> WU6d.5 -> WU6d.6 -> WU6d.7 -> WU6d.8 -> WU6d.9

This PR is based on #119 at `8dffd27`. The immediate next child is WU6d.2, based on this head `13f61cc`; it must remain open and unmerged.

## Behavior
- The processor marks the run running, collects exactly once, normalizes and upserts records, and returns counts with safe terminal persistence, audit, and alert handling.
- A `session_expired` result is terminal `needs_admin_action`; it never obtains credentials, starts recovery, or recollects.
- Persistence transitions use fixed failure handling and compensation, while trusted safe summaries retain parity for non-expiry terminal outcomes.

## Intentional Scope
There is intentionally no production caller. The old processor remains active until the replacement is proven before the later product switch and cleanup.

Out of scope: queue V1 identity, probe behavior, composition, product switch, and cleanup.

## Changes
| File | Change |
| --- | --- |
| `src/worker/collection-ingestion-processor.ts` | Adds the recovery-free collection-only processor and persistence transition handling. |
| `src/worker/collection-ingestion-processor.test.ts` | Adds behavior coverage, including the audit correction. |

245 added / 0 removed across 2 files and 2 commits: the processor feature plus the audit correction.

## Evidence
- Focused tests: 15 passed.
- Queue tests: 30 passed.
- WU6c tests: 37 passed.
- Full suite: 1,796 passed, 2 skipped.
- Lint, typecheck, Prisma, and `git diff --check` passed.
- No CI is configured: GitHub reports zero checks.
- Review is disabled and unmanaged.

## Rollback
Abandoning this open PR or reverting its two commits removes only this inert replacement. WU6c and current production behavior remain preserved.