### PR TITLE
feat(queue): add durable authenticated ingestion identity

### DIFF
--- a/src/app/api/scrape-runs/run-now.route.test.ts
+++ b/src/app/api/scrape-runs/run-now.route.test.ts
@@ -53,6 +53,10 @@ describe("POST /api/scrape-runs/run-now", () => {
           runId: "popular-manual-run",
           bankId: "popular",
           accountFingerprint: "popular-0000000000",
+          authentication: {
+            version: 1,
+            attemptId: "auth-attempt-v1:de0938f0201b05dd2b025ca6c9ad5ba57eb82b23d24bb020cb89887f99008e01",
+          },
         },
       },
     ]);

--- a/src/app/api/scrape-runs/run-now.test.ts
+++ b/src/app/api/scrape-runs/run-now.test.ts
@@ -56,6 +56,10 @@ describe("scheduleIngestionRunNow", () => {
           runId: "run-popular-now",
           bankId: "popular",
           accountFingerprint: "popular-0000000000",
+          authentication: {
+            version: 1,
+            attemptId: "auth-attempt-v1:d743851183d7c5ec7d8b87fd750d60886a6656597b5c9d5e8435849129066999",
+          },
         },
         options: {
           jobId: "run-popular-now",

--- a/src/worker/queues/bullmq-queue.test.ts
+++ b/src/worker/queues/bullmq-queue.test.ts
@@ -26,6 +26,10 @@ const jobData: IngestionJobData = {
   runId: "run-bullmq-1",
   bankId: "popular",
   accountFingerprint: "acct-main",
+  authentication: {
+    version: 1,
+    attemptId: "auth-attempt-v1:0802674dadacdf86fce600258dabacdfd1e73a48953678879dd1fdacf2efa94f",
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -80,6 +84,7 @@ describe("createBullmqIngestionQueue", () => {
       data: jobData,
       options,
     });
+    expect(fakeQueue.calls[0]?.data).toBe(jobData);
   });
 
   it("passes the BullMQ options including jobId=runId, attempts=3, exponential backoff", async () => {

--- a/src/worker/queues/index.ts
+++ b/src/worker/queues/index.ts
@@ -1,5 +1,5 @@
 import type { JobsOptions } from "bullmq";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 
 import { createAuditEvent, type AuditSink } from "../../modules/audit";
 import { BANK_AUTOLOGIN_ACTIONS } from "../../modules/audit/bank-actions";
@@ -11,7 +11,7 @@ import { redactDiagnosticText, type ScrapeCollectionResult } from "../scraper";
 
 export type ScrapeRunStatus = "queued" | "running" | "succeeded" | "failed" | "needs_admin_action" | "throttled";
 
-export interface IngestionJobData {
+export interface IngestionSchedulingInput {
   runId: string;
   /**
    * Canonical bank code (`Bank.code`), e.g. `"popular"`. Named `bankId` for
@@ -19,9 +19,23 @@ export interface IngestionJobData {
    * the value is a domain code, NOT the Prisma `Bank.id` cuid.
    */
   bankId: string;
+  accountFingerprint: string;
+}
+
+export interface AuthenticatedIngestionEnvelope {
+  version: 1;
+  attemptId: string;
+}
+
+export interface AuthenticatedIngestionJobData extends IngestionSchedulingInput {
+  authentication: AuthenticatedIngestionEnvelope;
+}
+
+export interface IngestionJobData extends IngestionSchedulingInput {
   /** Stable session-expiry event id. When present, the processor may run the canonical scrape-time auto-login trigger before collection. */
   expiredEventId?: string;
-  accountFingerprint: string;
+  /** Optional so previously queued legacy jobs stay processor-compatible. */
+  authentication?: AuthenticatedIngestionEnvelope;
 }
 
 export interface IngestionJob {
@@ -116,6 +130,29 @@ export interface QueueLike {
 export const ingestionJobName = "bank-transaction-ingestion";
 const SYSTEM_INGESTION_ACTOR = "system:ingestion-worker";
 const SYSTEM_AUTOLOGIN_ACTOR = "system:auto-login";
+const AUTHENTICATED_INGESTION_ATTEMPT_DOMAIN = "rd-sync:authenticated-ingestion-attempt:v1\0";
+const AUTHENTICATED_INGESTION_ATTEMPT_VERSION = 1;
+
+function encodeAuthenticatedIngestionAttemptField(value: string): string {
+  return `${Buffer.byteLength(value, "utf8")}:${value}`;
+}
+
+export function deriveAuthenticatedIngestionAttemptId(bankId: string, runId: string): string {
+  if (!/\S/.test(bankId) || !/\S/.test(runId)) {
+    throw new Error("Invalid ingestion identity.");
+  }
+
+  const canonicalInput = [
+    String(AUTHENTICATED_INGESTION_ATTEMPT_VERSION),
+    bankId,
+    runId,
+  ].map(encodeAuthenticatedIngestionAttemptField).join("");
+  const digest = createHash("sha256")
+    .update(`${AUTHENTICATED_INGESTION_ATTEMPT_DOMAIN}${canonicalInput}`, "utf8")
+    .digest("hex");
+
+  return `auth-attempt-v1:${digest}`;
+}
 
 export function createIngestionProcessor(dependencies: IngestionProcessorDependencies) {
   const now = dependencies.now ?? (() => new Date());
@@ -354,8 +391,17 @@ export function createIngestionQueueOptions(runId: string): JobsOptions {
   };
 }
 
-export async function scheduleIngestionJob(queue: QueueLike, data: IngestionJobData): Promise<void> {
-  await queue.add(ingestionJobName, data, createIngestionQueueOptions(data.runId));
+export async function scheduleIngestionJob(queue: QueueLike, data: IngestionSchedulingInput): Promise<void> {
+  const payload: AuthenticatedIngestionJobData = {
+    runId: data.runId,
+    bankId: data.bankId,
+    accountFingerprint: data.accountFingerprint,
+    authentication: {
+      version: AUTHENTICATED_INGESTION_ATTEMPT_VERSION,
+      attemptId: deriveAuthenticatedIngestionAttemptId(data.bankId, data.runId),
+    },
+  };
+  await queue.add(ingestionJobName, payload, createIngestionQueueOptions(data.runId));
 }
 
 function normalizeMovements(movements: readonly BankMovement[], scrapeRunId: string): TransactionRecord[] {

--- a/src/worker/queues/index.ts
+++ b/src/worker/queues/index.ts
@@ -137,8 +137,23 @@ function encodeAuthenticatedIngestionAttemptField(value: string): string {
   return `${Buffer.byteLength(value, "utf8")}:${value}`;
 }
 
+function isWellFormedUtf16(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index);
+    if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+      if (index + 1 >= value.length) return false;
+      const nextCodeUnit = value.charCodeAt(index + 1);
+      if (nextCodeUnit < 0xdc00 || nextCodeUnit > 0xdfff) return false;
+      index += 1;
+    } else if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+      return false;
+    }
+  }
+  return true;
+}
+
 export function deriveAuthenticatedIngestionAttemptId(bankId: string, runId: string): string {
-  if (!/\S/.test(bankId) || !/\S/.test(runId)) {
+  if (!/\S/.test(bankId) || !/\S/.test(runId) || !isWellFormedUtf16(bankId) || !isWellFormedUtf16(runId)) {
     throw new Error("Invalid ingestion identity.");
   }
 

--- a/src/worker/queues/queues.test.ts
+++ b/src/worker/queues/queues.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
+import { readFile } from "node:fs/promises";
 
 import {
   createIngestionProcessor,
   createIngestionQueueOptions,
+  deriveAuthenticatedIngestionAttemptId,
   ingestionJobName,
   scheduleIngestionJob,
   type IngestionJobData,
@@ -13,6 +15,7 @@ import type { BankMovement } from "../../modules/transactions";
 import { InMemoryAuditSink } from "../../modules/audit";
 import { BANK_AUTOLOGIN_ACTIONS } from "../../modules/audit/bank-actions";
 import { InMemoryBankSessionExpiryEpisodeRepository } from "../../modules/bank-sessions/expiry-episodes";
+import { InMemoryScheduledIngestionQueue } from "../../app/api/scrape-runs/defaults";
 
 const jobData: IngestionJobData = {
   runId: "run-1",
@@ -347,7 +350,15 @@ describe("BullMQ ingestion scheduling", () => {
     expect(queue.addCalls).toEqual([
       {
         name: "bank-transaction-ingestion",
-        data: jobData,
+        data: {
+          runId: "run-1",
+          bankId: "popular",
+          accountFingerprint: "acct-main",
+          authentication: {
+            version: 1,
+            attemptId: "auth-attempt-v1:0802674dadacdf86fce600258dabacdfd1e73a48953678879dd1fdacf2efa94f",
+          },
+        },
         options: {
           jobId: "run-1",
           attempts: 3,
@@ -358,6 +369,122 @@ describe("BullMQ ingestion scheduling", () => {
       },
     ]);
     expect(createIngestionQueueOptions("run-2").jobId).toBe("run-2");
+  });
+});
+
+describe("durable authenticated ingestion identity", () => {
+  it("derives the independently calculated V1 golden attempt id", () => {
+    expect(deriveAuthenticatedIngestionAttemptId("popular", "run-1")).toBe(
+      "auth-attempt-v1:0802674dadacdf86fce600258dabacdfd1e73a48953678879dd1fdacf2efa94f",
+    );
+  });
+
+  it("is stable for the same bank and run, regardless of account fingerprint", () => {
+    const first = deriveAuthenticatedIngestionAttemptId("popular", "run-1");
+    const second = deriveAuthenticatedIngestionAttemptId("popular", "run-1");
+
+    expect(first).toBe(second);
+    expect(first).toBe(deriveAuthenticatedIngestionAttemptId("popular", "run-1"));
+    expect(first).not.toBe(deriveAuthenticatedIngestionAttemptId("banreservas", "run-1"));
+    expect(first).not.toBe(deriveAuthenticatedIngestionAttemptId("popular", "run-2"));
+  });
+
+  it("uses unambiguous UTF-8 length-prefixed fields for delimiter and Unicode collision pairs", () => {
+    expect(deriveAuthenticatedIngestionAttemptId("a", "bc")).not.toBe(
+      deriveAuthenticatedIngestionAttemptId("ab", "c"),
+    );
+    expect(deriveAuthenticatedIngestionAttemptId("banco|\u0000", "cuenta:á")).not.toBe(
+      deriveAuthenticatedIngestionAttemptId("banco", "|\u0000cuenta:á"),
+    );
+  });
+
+  it("returns only the safe fixed-format digest and rejects blank identity inputs", () => {
+    const attemptId = deriveAuthenticatedIngestionAttemptId("popular|\u0000", "run:á");
+
+    expect(attemptId).toMatch(/^auth-attempt-v1:[a-f0-9]{64}$/);
+    expect(attemptId).not.toContain("popular");
+    expect(attemptId).not.toContain("run");
+    expect(() => deriveAuthenticatedIngestionAttemptId(" ", "run-1")).toThrow(
+      "Invalid ingestion identity.",
+    );
+    expect(() => deriveAuthenticatedIngestionAttemptId("popular", "\t")).toThrow(
+      "Invalid ingestion identity.",
+    );
+  });
+
+  it("uses no runtime entropy, clock, owner token, or fingerprint in the derivation", async () => {
+    const source = await readFile(new URL("./index.ts", import.meta.url), "utf8");
+    const start = source.indexOf("export function deriveAuthenticatedIngestionAttemptId");
+    const end = source.indexOf("export function createIngestionProcessor", start);
+    const derivation = source.slice(start, end);
+
+    expect(derivation).not.toMatch(/randomUUID|Date|Math\.random|ownerToken|accountFingerprint/);
+  });
+
+  it("persists the exact V1 envelope through the in-memory queue", async () => {
+    const queue = new InMemoryScheduledIngestionQueue();
+
+    await scheduleIngestionJob(queue, {
+      runId: "run-memory",
+      bankId: "popular",
+      accountFingerprint: "fingerprint-a",
+    });
+
+    expect(queue.jobs).toEqual([{
+      name: ingestionJobName,
+      data: {
+        runId: "run-memory",
+        bankId: "popular",
+        accountFingerprint: "fingerprint-a",
+        authentication: {
+          version: 1,
+          attemptId: deriveAuthenticatedIngestionAttemptId("popular", "run-memory"),
+        },
+      },
+      options: createIngestionQueueOptions("run-memory"),
+    }]);
+  });
+
+  it("keeps the scheduled attempt id stable when only the account fingerprint changes", async () => {
+    const queue = new FakeQueue();
+
+    await scheduleIngestionJob(queue, {
+      runId: "run-stable",
+      bankId: "popular",
+      accountFingerprint: "fingerprint-a",
+    });
+    await scheduleIngestionJob(queue, {
+      runId: "run-stable",
+      bankId: "popular",
+      accountFingerprint: "fingerprint-b",
+    });
+
+    expect(queue.addCalls.map((call) => call.data.authentication?.attemptId)).toEqual([
+      deriveAuthenticatedIngestionAttemptId("popular", "run-stable"),
+      deriveAuthenticatedIngestionAttemptId("popular", "run-stable"),
+    ]);
+  });
+
+  it("does not change legacy processor behavior when it receives the V1 envelope", async () => {
+    const scrapeRuns = new FakeScrapeRunRepository();
+    const processor = createIngestionProcessor({
+      scrapeRuns,
+      transactions: new FakeTransactionRepository({ inserted: 0, skipped: 0 }),
+      scraper: { collect: async () => ({ status: "collected" as const, movements: [] }) },
+    });
+
+    await expect(processor({
+      data: {
+        runId: "run-v1",
+        bankId: "popular",
+        accountFingerprint: "acct-main",
+        authentication: { version: 1, attemptId: deriveAuthenticatedIngestionAttemptId("popular", "run-v1") },
+      },
+    })).resolves.toEqual({ status: "succeeded", inserted: 0, skipped: 0 });
+    expect(scrapeRuns.transitions).toEqual([
+      { runId: "run-v1", status: "running" },
+      { runId: "run-v1", status: "succeeded", insertedCount: 0, skippedCount: 0 },
+    ]);
   });
 });
 

--- a/src/worker/queues/queues.test.ts
+++ b/src/worker/queues/queues.test.ts
@@ -412,6 +412,33 @@ describe("durable authenticated ingestion identity", () => {
     );
   });
 
+  it.each([
+    ["\uD800", "run-1"],
+    ["\uD800x", "run-1"],
+    ["\uDC00", "run-1"],
+    ["popular", "run-\uD800"],
+  ])("rejects malformed UTF-16 identity input without exposing it", (bankId, runId) => {
+    expect(() => deriveAuthenticatedIngestionAttemptId(bankId, runId)).toThrow(
+      "Invalid ingestion identity.",
+    );
+  });
+
+  it("rejects an isolated high surrogate instead of colliding with U+FFFD", () => {
+    expect(() => deriveAuthenticatedIngestionAttemptId("\uD800", "run-1")).toThrow(
+      "Invalid ingestion identity.",
+    );
+    expect(deriveAuthenticatedIngestionAttemptId("\uFFFD", "run-1")).toMatch(
+      /^auth-attempt-v1:[a-f0-9]{64}$/,
+    );
+  });
+
+  it("keeps valid emoji identities deterministic with the existing UTF-8 fixture", () => {
+    const expected = "auth-attempt-v1:8be9f5f3be4787dcbb5b79b9e0f6d9fbf45244167c52110c61a06d5d03396232";
+
+    expect(deriveAuthenticatedIngestionAttemptId("🏦", "run-😀")).toBe(expected);
+    expect(deriveAuthenticatedIngestionAttemptId("🏦", "run-😀")).toBe(expected);
+  });
+
   it("uses no runtime entropy, clock, owner token, or fingerprint in the derivation", async () => {
     const source = await readFile(new URL("./index.ts", import.meta.url), "utf8");
     const start = source.indexOf("export function deriveAuthenticatedIngestionAttemptId");


### PR DESCRIPTION
Closes #122  ## Type - [x] New feature  ## Summary - Adds a durable, deterministic V1 authenticated-ingestion identity at queue scheduling time without activating authenticated delivery. - Preserves the existing collection processor and legacy queued-job behavior while creating the contract needed by later gated delivery work.  ## Chain Context Feature Branch Chain. #119 is the sole tracker PR targeting `main`; it remains the only PR in this chain that targets `main`.  ```text #119 tracker (base: main, remains open/unmerged)   -> #121 WU6d.1 collection-only ingestion processor (base: feat/authenticated-ingestion-delivery-gate)     -> 📍 WU6d.2 THIS PR durable authenticated ingestion identity (base: feat/collection-only-ingestion-processor, OPEN/unmerged)       -> WU6d.3 probe owner gate         -> WU6d.4-.9 ```  Review boundary: WU6d.2 only. Review `src/worker/queues/index.ts` first, then its focused queue and scheduling regressions. Follow-up work is deliberately excluded from this PR.  ## Identity Contract `deriveAuthenticatedIngestionAttemptId(bankId, runId)` computes SHA-256 from a canonical, domain-separated, UTF-8 byte-length-framed input: `rd-sync:authenticated-ingestion-attempt:v1\0` followed by framed version, `bankId`, and `runId`. The only identity inputs are canonical bank ID and run ID; it does not include an account fingerprint, random value, or token.  Output format: `auth-attempt-v1:<64 lowercase SHA-256 hex characters>`.  Malformed UTF-16 in either identity input is rejected before hashing, preventing replacement-character collisions. Scheduling now enqueues the V1 `authentication` envelope separately from the existing queue data. `jobId` remains `runId` and retry policy remains three exponential attempts. The adapter contracts receive the exact V1 payload. The active legacy collection processor ignores the optional envelope, so existing queued legacy payloads and processor behavior remain inert and compatible; no authenticated-delivery caller is activated.  ## Changes | File | Change | |---|---| | `src/worker/queues/index.ts` | Derive canonical V1 attempt IDs, reject malformed UTF-16, and attach the scheduling envelope without changing job IDs or retries. | | `src/worker/queues/queues.test.ts` | Cover canonical digest framing, output format, malformed Unicode rejection, scheduling, and legacy compatibility. | | `src/worker/queues/bullmq-queue.test.ts` | Verify the BullMQ adapter receives the exact V1 payload and unchanged options. | | `src/app/api/scrape-runs/run-now.test.ts` | Verify scheduled manual runs retain the V1 queue contract. | | `src/app/api/scrape-runs/run-now.route.test.ts` | Verify route-triggered scheduling retains the V1 queue contract. |  ## Evidence - Range: `13f61cc..150c909`; 2 commits: `ef67230` and audit correction `150c909`. - Review size: 5 files, +234/-6 (240 changed lines), within the 400-line work-unit budget. - Focused tests: 77 passed. - Broader prior tests: 143 passed. - Full suite: 1,810 passed, 2 skipped. - Passed: lint, typecheck, Prisma validation, and `git diff --check`. - CI: no checks were triggered for this unpublished branch; no CI is disabled. - Review: no review is disabled or bypassed.  ## Out Of Scope - WU6d.3 probe owner gate. - Authentication composition and delivery switch activation. - Processor cleanup, queue schema migration, or legacy-payload removal.  ## Rollback Revert the two commits (`150c909`, then `ef67230`) or abandon this child branch/PR. WU6d.1 remains intact; queued V1 payloads remain safe because the active legacy processor ignores the optional envelope and legacy payloads remain compatible.  ## Checklist - [x] Linked approved issue #122 with `Closes #122` - [x] Added exactly one type label: `type:feature` - [x] Conventional commits; no `Co-Authored-By` trailers - [x] Focused and full verification completed - [x] No source changes outside this 5-file work unit 