### PR TITLE
feat(worker): add bounded authenticated session probe

### DIFF
--- a/src/modules/bank-sessions/bank-sessions.test.ts
+++ b/src/modules/bank-sessions/bank-sessions.test.ts
@@ -144,13 +144,12 @@ function makeFakeScheduler(): FakeScheduler {
 // ---------------------------------------------------------------------------
 
 describe("checkPopularSessionHealth — active session", () => {
-  it("returns active when URL includes /dashboard and Producto is visible", async () => {
+  it("returns active only for the exact trusted dashboard URL with Producto visible", async () => {
     const page = new FakeSessionProbePage({
       urlAfterGoto: "https://ib.bpd.com.do/dashboard",
       waitForVisibleTextResult: true,
     });
     const result = await checkPopularSessionHealth(page, {
-      baseUrl: "https://ib.bpd.com.do",
       clock: () => new Date("2026-01-01T00:00:00.000Z"),
     });
 
@@ -159,12 +158,12 @@ describe("checkPopularSessionHealth — active session", () => {
     expect(result.checkedAt).toBe("2026-01-01T00:00:00.000Z");
   });
 
-  it("navigates to {baseUrl}/dashboard", async () => {
+  it("navigates only to the trusted dashboard URL", async () => {
     const page = new FakeSessionProbePage({
       urlAfterGoto: "https://ib.bpd.com.do/dashboard",
       waitForVisibleTextResult: true,
     });
-    await checkPopularSessionHealth(page, { baseUrl: "https://ib.bpd.com.do" });
+    await checkPopularSessionHealth(page);
 
     expect(page.operations[0]).toBe("goto:https://ib.bpd.com.do/dashboard");
   });
@@ -180,6 +179,19 @@ describe("checkPopularSessionHealth — expired: redirect", () => {
 
     expect(result.status).toBe("expired");
     expect(result.safeSummary).toBe("Bank session expired or requires verification");
+  });
+});
+
+describe("checkPopularSessionHealth — bounded navigation", () => {
+  it.each([
+    "https://evil.example/dashboard",
+    "https://ib.bpd.com.do/dashboard/evil",
+    "https://ib.bpd.com.do/dashboard?next=https://evil.example",
+  ])("rejects a foreign or non-exact dashboard URL: %s", async (urlAfterGoto) => {
+    const page = new FakeSessionProbePage({ urlAfterGoto, waitForVisibleTextResult: true });
+
+    await expect(checkPopularSessionHealth(page)).resolves.toMatchObject({ status: "expired" });
+    expect(page.operations).not.toContainEqual(expect.stringContaining("waitForVisibleText"));
   });
 });
 
@@ -274,6 +286,28 @@ describe("createCdpSessionChecker — unconfigured CDP fallback", () => {
 });
 
 describe("createCdpSessionChecker — cleanup in finally", () => {
+  it("closes its separate page and CDP handle after a successful check", async () => {
+    let pageClosed = false;
+    let browserClosed = false;
+    const page: import("../../worker/scraper/navigation/popular-cdp").CdpPageLike = {
+      url: () => "https://ib.bpd.com.do/dashboard",
+      goto: async () => undefined,
+      waitForSelector: async () => undefined,
+      waitForTimeout: async () => undefined,
+      evaluate: async <T>() => null as unknown as T,
+      close: async () => { pageClosed = true; },
+    };
+    const browser: CdpBrowserLike = {
+      contexts: () => [{ newPage: async () => page }],
+      newPage: async () => page,
+      close: async () => { browserClosed = true; },
+    };
+
+    await expect(createCdpSessionChecker({ connect: async () => browser }).check()).resolves.toMatchObject({ status: "active" });
+    expect(pageClosed).toBe(true);
+    expect(browserClosed).toBe(true);
+  });
+
   it("closes page and browser even when check throws internally", async () => {
     const pageCloses: number[] = [];
     const browserCloses: number[] = [];

--- a/src/modules/bank-sessions/bank-sessions.test.ts
+++ b/src/modules/bank-sessions/bank-sessions.test.ts
@@ -41,6 +41,27 @@ class FakeSessionProbePage implements SessionProbePage {
   }
 }
 
+async function checkBoundedUrl(urlAfterGoto: string): Promise<{ result: BankSessionCheckResult; pageClosed: boolean; browserClosed: boolean; selectorCalls: string[] }> {
+  let pageClosed = false;
+  let browserClosed = false;
+  const selectorCalls: string[] = [];
+  const page: import("../../worker/scraper/navigation/popular-cdp").CdpPageLike = {
+    url: () => urlAfterGoto,
+    goto: async () => undefined,
+    waitForSelector: async (selector) => { selectorCalls.push(selector); },
+    waitForTimeout: async () => undefined,
+    evaluate: async <T>() => null as unknown as T,
+    close: async () => { pageClosed = true; },
+  };
+  const browser: CdpBrowserLike = {
+    contexts: () => [{ newPage: async () => page }],
+    newPage: async () => page,
+    close: async () => { browserClosed = true; },
+  };
+  const result = await createCdpSessionChecker({ connect: async () => browser }).check();
+  return { result, pageClosed, browserClosed, selectorCalls };
+}
+
 // ---------------------------------------------------------------------------
 // Fake alert sink
 // ---------------------------------------------------------------------------
@@ -192,6 +213,28 @@ describe("checkPopularSessionHealth — bounded navigation", () => {
 
     await expect(checkPopularSessionHealth(page)).resolves.toMatchObject({ status: "expired" });
     expect(page.operations).not.toContainEqual(expect.stringContaining("waitForVisibleText"));
+  });
+
+  it.each([
+    ["userinfo", "https://trusted@ib.bpd.com.do/dashboard", false],
+    ["subdomain", "https://evil.ib.bpd.com.do/dashboard", false],
+    ["suffix host", "https://ib.bpd.com.do.evil/dashboard", false],
+    ["non-default port", "https://ib.bpd.com.do:444/dashboard", false],
+    ["explicit default HTTPS port canonicalizes", "https://ib.bpd.com.do:443/dashboard", true],
+    ["percent-encoded path segment", "https://ib.bpd.com.do/%64ashboard", false],
+    ["encoded slash path", "https://ib.bpd.com.do/%2Fdashboard", false],
+    ["dot segment canonicalizes", "https://ib.bpd.com.do/a/../dashboard", true],
+    ["encoded dot segment canonicalizes", "https://ib.bpd.com.do/a/%2e%2e/dashboard", true],
+    ["fragment", "https://ib.bpd.com.do/dashboard#ignored", false],
+    ["query", "https://ib.bpd.com.do/dashboard?ignored=true", false],
+    ["trailing slash", "https://ib.bpd.com.do/dashboard/", false],
+  ])("%s is %s", async (_name, urlAfterGoto, accepted) => {
+    const { result, pageClosed, browserClosed, selectorCalls } = await checkBoundedUrl(urlAfterGoto);
+
+    expect(result.status).toBe(accepted ? "active" : "expired");
+    expect(selectorCalls.length > 0).toBe(accepted);
+    expect(pageClosed).toBe(true);
+    expect(browserClosed).toBe(true);
   });
 });
 

--- a/src/modules/bank-sessions/index.ts
+++ b/src/modules/bank-sessions/index.ts
@@ -73,18 +73,20 @@ export interface SessionProbePage {
 // ---------------------------------------------------------------------------
 
 export interface CheckPopularSessionHealthOptions {
-  baseUrl?: string;
   waitTimeoutMs?: number;
   clock?: () => Date;
 }
+
+const POPULAR_PORTAL_ORIGIN = "https://ib.bpd.com.do";
+const POPULAR_DASHBOARD_URL = `${POPULAR_PORTAL_ORIGIN}/dashboard`;
 
 /**
  * Probes the Popular portal dashboard to determine whether the bank session
  * is active or expired.
  *
  * Steps:
- *   1. goto {baseUrl}/dashboard
- *   2. currentUrl() does not include "/dashboard" → expired
+ *   1. goto the trusted Popular /dashboard URL
+ *   2. currentUrl() is not exactly that URL → expired
  *   3. waitForVisibleText("Producto") returns false → expired
  *   4. Otherwise → active
  *
@@ -96,17 +98,21 @@ export async function checkPopularSessionHealth(
   options: CheckPopularSessionHealthOptions = {},
 ): Promise<BankSessionCheckResult> {
   const {
-    baseUrl = "https://ib.bpd.com.do",
     waitTimeoutMs = 15_000,
     clock = () => new Date(),
   } = options;
 
   const checkedAt = clock().toISOString();
 
-  await page.goto(`${baseUrl}/dashboard`);
+  await page.goto(POPULAR_DASHBOARD_URL);
 
-  const url = await page.currentUrl();
-  if (!url.includes("/dashboard")) {
+  let url: URL;
+  try {
+    url = new URL(await page.currentUrl());
+  } catch {
+    return { status: "expired", checkedAt, safeSummary: SUMMARY_EXPIRED };
+  }
+  if (url.href !== POPULAR_DASHBOARD_URL) {
     return { status: "expired", checkedAt, safeSummary: SUMMARY_EXPIRED };
   }
 
@@ -126,7 +132,6 @@ export async function checkPopularSessionHealth(
 
 export interface CdpSessionCheckerOptions {
   cdpUrl?: string;
-  baseUrl?: string;
   waitTimeoutMs?: number;
   connect?: (cdpUrl: string) => Promise<CdpBrowserLike>;
   clock?: () => Date;
@@ -148,7 +153,6 @@ export function createCdpSessionChecker(
 ): CdpSessionChecker {
   const {
     cdpUrl = DEFAULT_CDP_URL,
-    baseUrl = "https://ib.bpd.com.do",
     waitTimeoutMs = 15_000,
     connect = connectPlaywrightOverCdp<CdpBrowserLike>,
     clock = () => new Date(),
@@ -183,7 +187,7 @@ export function createCdpSessionChecker(
         cdpPage = await openCdpPageInDefaultContext(browser);
 
         const probePage = new CdpPopularPortalPage(cdpPage);
-        return await checkPopularSessionHealth(probePage, { baseUrl, waitTimeoutMs, clock });
+        return await checkPopularSessionHealth(probePage, { waitTimeoutMs, clock });
       } finally {
         if (cdpPage !== null) {
           try {

--- a/src/worker/scraper/authenticated-session-probe.test.ts
+++ b/src/worker/scraper/authenticated-session-probe.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+
+import type { AuthenticatedSessionProbe } from "../../modules/bank-sessions/ensure-authenticated-session";
+import { createAuthenticatedSessionProbe, type ReadonlySessionChecker } from "./authenticated-session-probe";
+
+const checkedAt = "2026-08-16T12:00:00.000Z";
+type Equal<Left, Right> = (<Value>() => Value extends Left ? 1 : 2) extends (<Value>() => Value extends Right ? 1 : 2) ? true : false;
+const checkerHasOnlyReadCapability: Equal<keyof ReadonlySessionChecker, "check"> = true;
+
+function checker(result: unknown) {
+  let calls = 0;
+  return {
+    checker: { check: async () => { calls += 1; return result; } },
+    calls: () => calls,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  return { promise: new Promise<T>((done) => { resolve = done; }), resolve };
+}
+
+describe("createAuthenticatedSessionProbe", () => {
+  it("requires only the read-only checker capability", () => {
+    expect(checkerHasOnlyReadCapability).toBe(true);
+  });
+
+  it("maps one valid active Popular check to a cloned authenticated observation", async () => {
+    const source = { status: "active", checkedAt, safeSummary: "Bank session is active" };
+    const fake = checker(source);
+    const probe: AuthenticatedSessionProbe = createAuthenticatedSessionProbe({ popularSessionChecker: fake.checker });
+
+    const result = await probe.observe({ bankCode: "popular" });
+
+    expect(result).toEqual({ status: "authenticated", observedAt: new Date(checkedAt) });
+    expect(result.status === "authenticated" && result.observedAt).not.toBe(source.checkedAt);
+    expect(fake.calls()).toBe(1);
+  });
+
+  it("maps expired and browser_unavailable checks without exposing checker data", async () => {
+    const expired = await createAuthenticatedSessionProbe({ popularSessionChecker: checker({ status: "expired", checkedAt, safeSummary: "x" }).checker }).observe({ bankCode: "popular" });
+    const unavailable = await createAuthenticatedSessionProbe({ popularSessionChecker: checker({ status: "browser_unavailable", checkedAt, safeSummary: "x" }).checker }).observe({ bankCode: "popular" });
+
+    expect(expired).toEqual({ status: "unauthenticated" });
+    expect(unavailable).toEqual({ status: "unavailable" });
+  });
+
+  it("does not call the checker for unknown or mismatched banks", async () => {
+    const fake = checker({ status: "active", checkedAt, safeSummary: "x" });
+    const probe = createAuthenticatedSessionProbe({ popularSessionChecker: fake.checker });
+
+    await expect(probe.observe({ bankCode: "bhd" })).resolves.toEqual({ status: "unavailable" });
+    await expect(probe.observe({ bankCode: "Popular" })).resolves.toEqual({ status: "unavailable" });
+    expect(fake.calls()).toBe(0);
+  });
+
+  it("does not call a checker for a pre-aborted signal", async () => {
+    const fake = checker({ status: "active", checkedAt, safeSummary: "x" });
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(createAuthenticatedSessionProbe({ popularSessionChecker: fake.checker }).observe({ bankCode: "popular", signal: controller.signal })).resolves.toEqual({ status: "unavailable" });
+    expect(fake.calls()).toBe(0);
+  });
+
+  it("never returns authenticated when cancelled during a deferred check", async () => {
+    const pending = deferred<unknown>();
+    let calls = 0;
+    const controller = new AbortController();
+    const probe = createAuthenticatedSessionProbe({ popularSessionChecker: { check: async () => { calls += 1; return pending.promise; } } });
+    const observation = probe.observe({ bankCode: "popular", signal: controller.signal });
+
+    controller.abort();
+    pending.resolve({ status: "active", checkedAt, safeSummary: "x" });
+
+    await expect(observation).resolves.toEqual({ status: "unavailable" });
+    expect(calls).toBe(1);
+  });
+
+  it("fails closed for hostile signals, thrown checkers, and malformed checker results", async () => {
+    const sentinel = new Error("sentinel");
+    const hostileSignal = { get aborted(): boolean { throw sentinel; } } as AbortSignal;
+    const malformed = [null, [], { status: "other", checkedAt, safeSummary: "x" }, { status: "active", checkedAt: new Date("invalid"), safeSummary: "x" }, { status: "active", checkedAt: Number.POSITIVE_INFINITY, safeSummary: "x" }, { status: "active", checkedAt: "invalid", safeSummary: "x" }, { status: "active", checkedAt, safeSummary: "x", extra: true }];
+
+    await expect(createAuthenticatedSessionProbe({ popularSessionChecker: checker({ status: "active", checkedAt, safeSummary: "x" }).checker }).observe({ bankCode: "popular", signal: hostileSignal })).resolves.toEqual({ status: "unavailable" });
+    await expect(createAuthenticatedSessionProbe({ popularSessionChecker: { check: async () => { throw sentinel; } } }).observe({ bankCode: "popular" })).resolves.toEqual({ status: "unavailable" });
+    for (const result of malformed) await expect(createAuthenticatedSessionProbe({ popularSessionChecker: checker(result).checker }).observe({ bankCode: "popular" })).resolves.toEqual({ status: "unavailable" });
+  });
+
+  it("does not invoke accessors or accept symbols or hidden fields", async () => {
+    const accessor = Object.defineProperty({}, "status", { enumerable: true, get: () => { throw new Error("sentinel"); } });
+    const symbol = { status: "active", checkedAt, safeSummary: "x", [Symbol("hidden")]: true };
+    const hidden = Object.defineProperty({ status: "active", checkedAt, safeSummary: "x" }, "hidden", { value: true });
+
+    for (const result of [accessor, symbol, hidden]) await expect(createAuthenticatedSessionProbe({ popularSessionChecker: checker(result).checker }).observe({ bankCode: "popular" })).resolves.toEqual({ status: "unavailable" });
+  });
+});

--- a/src/worker/scraper/authenticated-session-probe.ts
+++ b/src/worker/scraper/authenticated-session-probe.ts
@@ -1,0 +1,71 @@
+import type { AuthenticatedSessionProbe } from "../../modules/bank-sessions/ensure-authenticated-session";
+
+export interface ReadonlySessionChecker {
+  check(): Promise<unknown>;
+}
+type CheckerResult = Readonly<{ status: "active" | "expired" | "browser_unavailable"; checkedAt: string; safeSummary: string }>;
+
+export type AuthenticatedSessionProbeDependencies = Readonly<{ popularSessionChecker: ReadonlySessionChecker }>;
+
+const unavailable = (): Awaited<ReturnType<AuthenticatedSessionProbe["observe"]>> => ({ status: "unavailable" });
+
+function exact(value: unknown, keys: readonly string[]): Record<string, unknown> | null {
+  try {
+    if (value === null || typeof value !== "object" || Array.isArray(value) || (Object.getPrototypeOf(value) !== Object.prototype && Object.getPrototypeOf(value) !== null)) return null;
+    const ownKeys = Reflect.ownKeys(value);
+    if (ownKeys.length !== keys.length || ownKeys.some((key) => typeof key !== "string" || !keys.includes(key))) return null;
+    const descriptors = Object.getOwnPropertyDescriptors(value);
+    const record: Record<string, unknown> = {};
+    for (const key of keys) {
+      const descriptor = descriptors[key];
+      if (!descriptor || !descriptor.enumerable || !("value" in descriptor)) return null;
+      record[key] = descriptor.value;
+    }
+    return record;
+  } catch {
+    return null;
+  }
+}
+
+function parseResult(value: unknown): CheckerResult | null {
+  const record = exact(value, ["status", "checkedAt", "safeSummary"]);
+  return record && (record.status === "active" || record.status === "expired" || record.status === "browser_unavailable") && typeof record.checkedAt === "string" && typeof record.safeSummary === "string"
+    ? record as CheckerResult
+    : null;
+}
+
+function observedAt(value: string): Date | null {
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) && new Date(timestamp).toISOString() === value ? new Date(timestamp) : null;
+}
+
+function isAborted(signal: AbortSignal | undefined): boolean | null {
+  if (signal === undefined) return false;
+  try {
+    return signal.aborted;
+  } catch {
+    return null;
+  }
+}
+
+/** Maps a read-only, already-attached CDP checker to the coordinator probe port.
+ * The checker owns its timeout and page closure; cancellation only suppresses its result. */
+export function createAuthenticatedSessionProbe(
+  { popularSessionChecker }: AuthenticatedSessionProbeDependencies,
+): AuthenticatedSessionProbe {
+  return {
+    async observe(input) {
+      try {
+        if (input.bankCode !== "popular" || isAborted(input.signal) !== false) return unavailable();
+        const result = parseResult(await popularSessionChecker.check());
+        if (isAborted(input.signal) !== false || !result) return unavailable();
+        if (result.status === "expired") return { status: "unauthenticated" };
+        if (result.status !== "active") return unavailable();
+        const timestamp = observedAt(result.checkedAt);
+        return timestamp ? { status: "authenticated", observedAt: timestamp } : unavailable();
+      } catch {
+        return unavailable();
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Adds a bounded, authenticated session probe for the canonical Banco Popular dashboard.
- Keeps the probe isolated from product flow: it depends on `check()` only and returns a strict, cancellation-aware result.

Closes #124

## Chain Context

Start: WU6d.2 (`#123`, durable authenticated ingestion identity)
End: WU6d.3 bounded authenticated session probe
Immediate dependency: `#123`
Follow-up: WU6d.4 composition, then WU6d.5 switch, then WU6d.6-WU6d.9 cleanup

```text
#121 -> #123 -> 📍 WU6d.3 THIS PR (OPEN) -> WU6d.4 composition -> WU6d.5 switch -> WU6d.6-WU6d.9 cleanup
```

This child PR targets its immediate parent, `feat/durable-authenticated-ingestion-identity` (`#123`). It must remain open and unmerged. Only the tracker targets `main`.

## Owner-Approved Boundary

- The policy permits one bounded GET navigation on a separate fake-tested CDP page, only for the trusted canonical dashboard URL.
- A target is allowed only when `URL.href` canonicalizes exactly to `https://ib.bpd.com.do/dashboard`; syntactic normalization such as explicit HTTPS port `:443` and dot segments is accepted only when it produces that exact canonical URL. Other schemes, hosts, ports, paths, queries, fragments, credentials, or user-info are rejected.
- The result requires the visible authenticated-page indicator, closes the page and browser handles in `finally`, and maps cancellation and all probe outcomes through the strict result contract.
- The adapter has a check-only dependency: no credentials, forms, clicks, storage mutation, browser launch, product caller, or live-bank validation.

## Changes

| File | Change |
|---|---|
| `src/worker/scraper/authenticated-session-probe.ts` | Add bounded probe adapter with URL, visibility, cancellation, and cleanup boundaries. |
| `src/worker/scraper/authenticated-session-probe.test.ts` | Cover probe behavior using isolated fakes. |
| `src/modules/bank-sessions/index.ts` | Expose the check-only session probe dependency. |
| `src/modules/bank-sessions/bank-sessions.test.ts` | Verify module-level integration and cancellation/result mapping. |

Review size: 4 files, +263/-14 = 277 changed lines. Two commits, including audit URL-boundary tests.

## Evidence

- PASS focused: 8 tests; WU6b regression: 47 tests; broader suite: 65 tests.
- PASS full suite: 1,834 tests, 2 skipped.
- PASS lint, typecheck, Prisma validation, and `git diff --check`.
- No CI or review automation is enabled; no live bank or product caller was exercised.

## Exclusions

- WU6d.4 composition and wiring.
- WU6d.5 runtime switch.
- Environment configuration, live validation, and WU6d.6-WU6d.9 cleanup.

## Rollback

Abandon this child PR or revert its two commits (`410fbc5`, `24a6aad`). Either path preserves the WU6d.2 state from `#123`.

## Checklist

- [x] Linked approved issue `#124`.
- [x] Added exactly one `type:feature` label.
- [x] Conventional commits with no attribution trailers.
- [x] Bounded, fake-tested behavior and rollback scope recorded.