### PR TITLE
feat(worker): emit authenticated ingestion terminal telemetry

### DIFF
--- a/src/worker/authenticated-ingestion-composition.test.ts
+++ b/src/worker/authenticated-ingestion-composition.test.ts
@@ -5,7 +5,7 @@ import {
   AuthenticatedIngestionRetryError,
   AuthenticatedIngestionTerminalError,
 } from "./authenticated-ingestion-delivery";
-import { createAuthenticatedIngestionProcessor } from "./authenticated-ingestion-composition";
+import { createAuthenticatedIngestionProcessor, createAuthenticatedTerminalCompleter } from "./authenticated-ingestion-composition";
 import type { FencedScrapeTimeAutoLoginRunnerDependencies } from "./scraper/scrape-time-auto-login-authentication-execution";
 import type { BankAutoLoginPage } from "./scraper/auto-login";
 
@@ -31,17 +31,90 @@ function fixture(overrides: Record<string, unknown> = {}) {
     keyResolver: () => key, lock: { acquire: vi.fn().mockResolvedValue({ leaseToken: "lease", fencingToken: 1, expiresAt: 1 }), release: vi.fn().mockResolvedValue(true) }, cdpUrlForBankCode: () => "http://127.0.0.1:9222", ensureBrowser: vi.fn().mockResolvedValue({ status: "ready", page, close: vi.fn() }),
   };
   const scrapeRuns = { markRunning: vi.fn(async () => {}), markSucceeded: vi.fn(async () => {}), markNeedsAdminAction: vi.fn(async () => {}), markThrottled: vi.fn(), markFailed: vi.fn(async () => {}) };
+  const auditSink = { record: vi.fn(async () => {}) };
+  const adminAlerts = { notifyIngestionAttention: vi.fn(async () => {}), notifySessionAttention: vi.fn(async () => {}) };
   const collect = vi.fn(async () => ({ status: "collected" as const, movements: [] }));
   const createOwnerToken = vi.fn().mockReturnValueOnce("owner-1").mockReturnValueOnce("owner-2");
   const processor = createAuthenticatedIngestionProcessor({
     env, popularSessionChecker: { check: async () => ({ status: authenticated ? "active" : "expired", checkedAt: "2026-08-21T00:00:00.000Z", safeSummary: "safe" }) },
     attempts: { findExact: async () => authenticated ? { status: "found", record: record() } : { status: "missing" }, getOrCreate: async () => ({ status: "created", record: record() }), acquireLease: async (input: { ownerToken: string }) => { ownerToken = input.ownerToken; return { status: "lease_acquired", owner: { identity, ownerToken, generation: 0n }, record: record(true) }; }, reconcileExpiredLease: async () => ({ status: "missing" }), renewLease: async () => ({ status: "lease_renewed", record: record(true) }), beginCredentialInteraction: async () => { phase = "credentials_may_have_reached_portal"; return { status: "interaction_started", record: record(true) }; }, recordSubmitBarrier: async () => { phase = "submit_may_have_been_dispatched"; return { status: "recorded", record: record(true) }; }, claimRetry: async () => ({ status: "retry_claimed", retryCount: 1 as const, record: record() }), completeAuthenticated: async () => { authenticated = true; return { status: "authenticated", record: record() }; }, completeFailed: async () => ({ status: "failed", record: record() }) } as never,
-    runnerDependencies, heartbeat: scheduler, scrapeRuns, transactions: { upsertMany: vi.fn(async () => ({ inserted: 0, skipped: 0 })) }, resolveScraper: vi.fn(() => ({ collect })), createOwnerToken, now: () => now, ...overrides,
+    runnerDependencies, heartbeat: scheduler, scrapeRuns, auditSink, adminAlerts, transactions: { upsertMany: vi.fn(async () => ({ inserted: 0, skipped: 0 })) }, resolveScraper: vi.fn(() => ({ collect })), createOwnerToken, now: () => now, ...overrides,
   });
-  return { processor, page, scheduler, runnerDependencies, scrapeRuns, collect, createOwnerToken };
+  return { processor, page, scheduler, runnerDependencies, scrapeRuns, auditSink, adminAlerts, collect, createOwnerToken };
 }
 
 describe("createAuthenticatedIngestionProcessor", () => {
+  it.each([
+    ["failed", "invalid_authenticated_ingestion_delivery", "scrape_run.failed", "Authenticated ingestion delivery failed"],
+    ["needs_admin_action", "legacy_authenticated_ingestion_delivery", "scrape_run.needs_admin_action", "Authenticated ingestion requires admin action"],
+    ["needs_admin_action", "temporary_authentication_problem", "scrape_run.needs_admin_action", "Authenticated ingestion requires admin action"],
+    ["needs_admin_action", "protected_authentication_step_detected", "scrape_run.needs_admin_action", "Authenticated ingestion requires admin action"],
+    ["needs_admin_action", "bank_login_configuration_requires_review", "scrape_run.needs_admin_action", "Authenticated ingestion requires admin action"],
+    ["needs_admin_action", "authentication_attempt_requires_review", "scrape_run.needs_admin_action", "Authenticated ingestion requires admin action"],
+    ["needs_admin_action", "identity_conflict", "scrape_run.needs_admin_action", "Authenticated ingestion requires admin action"],
+    ["needs_admin_action", "restoration_state_conflict", "scrape_run.needs_admin_action", "Authenticated ingestion requires admin action"],
+    ["failed", "invalid_authenticated_ingestion_precondition", "scrape_run.failed", "Authenticated ingestion delivery failed"],
+    ["needs_admin_action", "authentication_precondition_requires_review", "scrape_run.needs_admin_action", "Authenticated ingestion requires admin action"],
+  ] as const)("records and alerts the closed %s/%s terminal safely", async (status, reason, action, summary) => {
+    const scrapeRuns = { markFailed: vi.fn(async () => {}), markNeedsAdminAction: vi.fn(async () => {}) };
+    const auditSink = { record: vi.fn<(event: { id: string }) => Promise<void>>(async () => {}) };
+    const adminAlerts = { notifyIngestionAttention: vi.fn(async () => {}) };
+    const complete = createAuthenticatedTerminalCompleter({ scrapeRuns, auditSink, adminAlerts, now: () => new Date("2026-08-21T00:00:00.000Z") });
+
+    await expect(complete({ runId: "run-1", bankId: "popular", status, reason })).resolves.toEqual({ status, inserted: 0, skipped: 0 });
+    expect(scrapeRuns[status === "failed" ? "markFailed" : "markNeedsAdminAction"]).toHaveBeenCalledExactlyOnceWith("run-1", summary, new Date("2026-08-21T00:00:00.000Z"));
+    expect(auditSink.record).toHaveBeenCalledOnce();
+    expect(auditSink.record).toHaveBeenCalledWith(expect.objectContaining({ id: `authenticated-terminal:run-1:${status}:${reason}`, actorId: "system:ingestion-worker", actorRole: null, action, target: "scrape_run", targetId: "run-1", metadata: { stage: "precollection_authentication", reason, status, bankId: "popular" } }));
+    expect(adminAlerts.notifyIngestionAttention).toHaveBeenCalledExactlyOnceWith({ runId: "run-1", bankId: "popular", status, safeErrorSummary: summary });
+  });
+
+  it("uses a fixed unknown alert bank and omits bank metadata when no descriptor-validated bank is available", async () => {
+    const scrapeRuns = { markFailed: vi.fn(async () => {}), markNeedsAdminAction: vi.fn(async () => {}) };
+    const auditSink = { record: vi.fn(async () => {}) };
+    const adminAlerts = { notifyIngestionAttention: vi.fn(async () => {}) };
+    const complete = createAuthenticatedTerminalCompleter({ scrapeRuns, auditSink, adminAlerts });
+
+    await complete({ runId: "run-1", status: "failed", reason: "invalid_authenticated_ingestion_delivery" });
+    expect(auditSink.record).toHaveBeenCalledWith(expect.objectContaining({ metadata: { stage: "precollection_authentication", reason: "invalid_authenticated_ingestion_delivery", status: "failed" } }));
+    expect(adminAlerts.notifyIngestionAttention).toHaveBeenCalledWith({ runId: "run-1", bankId: "unknown", status: "failed", safeErrorSummary: "Authenticated ingestion delivery failed" });
+  });
+
+  it("keeps telemetry non-blocking and independent after exactly-once persistence", async () => {
+    const sentinel = "raw-telemetry-sentinel";
+    const scrapeRuns = { markFailed: vi.fn(async () => {}), markNeedsAdminAction: vi.fn(async () => {}) };
+    const auditSink = { record: vi.fn(async () => { throw new Error(sentinel); }) };
+    const adminAlerts = { notifyIngestionAttention: vi.fn(async () => { throw new Error(sentinel); }) };
+    const complete = createAuthenticatedTerminalCompleter({ scrapeRuns, auditSink, adminAlerts });
+
+    await expect(complete({ runId: "run-1", bankId: "popular", status: "failed", reason: "invalid_authenticated_ingestion_delivery" })).resolves.toEqual({ status: "failed", inserted: 0, skipped: 0 });
+    expect(scrapeRuns.markFailed).toHaveBeenCalledOnce(); expect(auditSink.record).toHaveBeenCalledOnce(); expect(adminAlerts.notifyIngestionAttention).toHaveBeenCalledOnce();
+    expect(JSON.stringify({ result: await complete({ runId: "run-2", bankId: "popular", status: "failed", reason: "invalid_authenticated_ingestion_delivery" }), calls: [auditSink.record.mock.calls, adminAlerts.notifyIngestionAttention.mock.calls] })).not.toContain(sentinel);
+  });
+
+  it.each(["audit", "alert"] as const)("returns the persisted terminal result when only %s delivery fails", async (failing) => {
+    const auditSink = { record: vi.fn(async () => { if (failing === "audit") throw new Error("raw-audit-sentinel"); }) };
+    const adminAlerts = { notifyIngestionAttention: vi.fn(async () => { if (failing === "alert") throw new Error("raw-alert-sentinel"); }) };
+    const complete = createAuthenticatedTerminalCompleter({ scrapeRuns: { markFailed: vi.fn(async () => {}), markNeedsAdminAction: vi.fn(async () => {}) }, auditSink, adminAlerts });
+
+    await expect(complete({ runId: "run-1", bankId: "popular", status: "failed", reason: "invalid_authenticated_ingestion_delivery" })).resolves.toEqual({ status: "failed", inserted: 0, skipped: 0 });
+    expect(auditSink.record).toHaveBeenCalledOnce(); expect(adminAlerts.notifyIngestionAttention).toHaveBeenCalledOnce();
+  });
+
+  it("does not emit telemetry when terminal persistence fails and uses stable audit identity for redelivery", async () => {
+    let persistenceFails = true;
+    const scrapeRuns = { markFailed: vi.fn(async () => { if (persistenceFails) throw new Error("raw-persistence-sentinel"); }), markNeedsAdminAction: vi.fn(async () => {}) };
+    const auditSink = { record: vi.fn<(event: { id: string }) => Promise<void>>(async () => {}) };
+    const adminAlerts = { notifyIngestionAttention: vi.fn(async () => {}) };
+    const complete = createAuthenticatedTerminalCompleter({ scrapeRuns, auditSink, adminAlerts });
+    const outcome = { runId: "run-1", bankId: "popular", status: "failed" as const, reason: "invalid_authenticated_ingestion_delivery" as const };
+
+    await expect(complete(outcome)).rejects.toEqual(new AuthenticatedIngestionTerminalError());
+    expect(auditSink.record).not.toHaveBeenCalled(); expect(adminAlerts.notifyIngestionAttention).not.toHaveBeenCalled();
+    persistenceFails = false; await complete(outcome); await complete(outcome);
+    expect(auditSink.record.mock.calls.map(([event]) => (event as { id: string }).id)).toEqual(["authenticated-terminal:run-1:failed:invalid_authenticated_ingestion_delivery", "authenticated-terminal:run-1:failed:invalid_authenticated_ingestion_delivery"]);
+    expect(adminAlerts.notifyIngestionAttention).toHaveBeenCalledTimes(2);
+  });
+
   it("composes the actual authenticated path once and reuses durable authentication on duplicate delivery", async () => {
     const f = fixture();
     const first = await f.processor(payload()); const second = await f.processor(payload());
@@ -73,7 +146,7 @@ describe("createAuthenticatedIngestionProcessor", () => {
   it("propagates cancellation as typed retry before mutation or collection", async () => {
     const f = fixture(); const controller = new AbortController(); controller.abort();
     await expect(f.processor({ ...payload(), signal: controller.signal })).rejects.toEqual(new AuthenticatedIngestionRetryError("cancelled"));
-    expect(f.runnerDependencies.credentials.findByBankCode).not.toHaveBeenCalled(); expect(f.collect).not.toHaveBeenCalled();
+    expect(f.runnerDependencies.credentials.findByBankCode).not.toHaveBeenCalled(); expect(f.collect).not.toHaveBeenCalled(); expect(f.scrapeRuns.markFailed).not.toHaveBeenCalled(); expect(f.scrapeRuns.markNeedsAdminAction).not.toHaveBeenCalled(); expect(f.auditSink.record).not.toHaveBeenCalled(); expect(f.adminAlerts.notifyIngestionAttention).not.toHaveBeenCalled();
   });
 
   it("does not let an aborted delivery signal affect the next fresh delivery", async () => {
@@ -96,7 +169,7 @@ describe("createAuthenticatedIngestionProcessor", () => {
     const sessionExpiredCollect = vi.fn(async () => ({ status: "needs_admin_action" as const, cause: "session_expired" as const, movements: [] }));
     const f = fixture({ resolveScraper: vi.fn(() => ({ collect: sessionExpiredCollect })) });
     await expect(f.processor(payload())).resolves.toEqual({ status: "needs_admin_action", inserted: 0, skipped: 0 });
-    expect(f.scrapeRuns.markNeedsAdminAction).toHaveBeenCalledOnce(); expect(sessionExpiredCollect).toHaveBeenCalledOnce();
+    expect(f.scrapeRuns.markNeedsAdminAction).toHaveBeenCalledOnce(); expect(sessionExpiredCollect).toHaveBeenCalledOnce(); expect(f.auditSink.record).not.toHaveBeenCalledWith(expect.objectContaining({ metadata: expect.objectContaining({ stage: "precollection_authentication" }) }));
   });
 
   it("fails invalid heartbeat configuration during construction before low-level dependencies", () => {
@@ -108,6 +181,6 @@ describe("createAuthenticatedIngestionProcessor", () => {
   it("remains factory-compatible and free of production activation dependencies", async () => {
     const source = await readFile(new URL("./authenticated-ingestion-composition.ts", import.meta.url), "utf8");
     const f = fixture(); const factoryCompatible: (job: { data: unknown }) => Promise<{ status: string; inserted: number; skipped: number }> = f.processor;
-    expect(factoryCompatible).toBeTypeOf("function"); expect(source).not.toMatch(/bullmq|prisma|process\.env|ingestion-worker|recoverExpiredSession|from ["'][^"']*queues\/index/i);
+    expect(factoryCompatible).toBeTypeOf("function"); expect(source).not.toMatch(/bullmq|prisma|process\.env|from ["'][^"']*ingestion-worker|recoverExpiredSession|from ["'][^"']*queues\/index/i);
   });
 });

--- a/src/worker/authenticated-ingestion-composition.test.ts
+++ b/src/worker/authenticated-ingestion-composition.test.ts
@@ -64,11 +64,12 @@ describe("createAuthenticatedIngestionProcessor", () => {
     await expect(complete({ runId: "run-1", bankId: "popular", status, reason })).resolves.toEqual({ status, inserted: 0, skipped: 0 });
     expect(scrapeRuns[status === "failed" ? "markFailed" : "markNeedsAdminAction"]).toHaveBeenCalledExactlyOnceWith("run-1", summary, new Date("2026-08-21T00:00:00.000Z"));
     expect(auditSink.record).toHaveBeenCalledOnce();
-    expect(auditSink.record).toHaveBeenCalledWith(expect.objectContaining({ id: `authenticated-terminal:run-1:${status}:${reason}`, actorId: "system:ingestion-worker", actorRole: null, action, target: "scrape_run", targetId: "run-1", metadata: { stage: "precollection_authentication", reason, status, bankId: "popular" } }));
+    expect(auditSink.record).toHaveBeenCalledWith(expect.objectContaining({ id: expect.stringMatching(/^authenticated-terminal:v1:/), actorId: "system:ingestion-worker", actorRole: null, action, target: "scrape_run", targetId: "run-1", metadata: { stage: "precollection_authentication", reason, status, bankId: "popular" } }));
+    expect((auditSink.record.mock.calls[0]?.[0] as { id: string }).id).not.toMatch(/run-1|popular|invalid_authenticated_ingestion_delivery/);
     expect(adminAlerts.notifyIngestionAttention).toHaveBeenCalledExactlyOnceWith({ runId: "run-1", bankId: "popular", status, safeErrorSummary: summary });
   });
 
-  it("uses a fixed unknown alert bank and omits bank metadata when no descriptor-validated bank is available", async () => {
+  it("omits bank metadata and skips alerts when no descriptor-validated bank is available", async () => {
     const scrapeRuns = { markFailed: vi.fn(async () => {}), markNeedsAdminAction: vi.fn(async () => {}) };
     const auditSink = { record: vi.fn(async () => {}) };
     const adminAlerts = { notifyIngestionAttention: vi.fn(async () => {}) };
@@ -76,7 +77,8 @@ describe("createAuthenticatedIngestionProcessor", () => {
 
     await complete({ runId: "run-1", status: "failed", reason: "invalid_authenticated_ingestion_delivery" });
     expect(auditSink.record).toHaveBeenCalledWith(expect.objectContaining({ metadata: { stage: "precollection_authentication", reason: "invalid_authenticated_ingestion_delivery", status: "failed" } }));
-    expect(adminAlerts.notifyIngestionAttention).toHaveBeenCalledWith({ runId: "run-1", bankId: "unknown", status: "failed", safeErrorSummary: "Authenticated ingestion delivery failed" });
+    expect(adminAlerts.notifyIngestionAttention).not.toHaveBeenCalled();
+    expect(JSON.stringify({ audit: auditSink.record.mock.calls, alerts: adminAlerts.notifyIngestionAttention.mock.calls })).not.toContain("unknown");
   });
 
   it("keeps telemetry non-blocking and independent after exactly-once persistence", async () => {
@@ -100,7 +102,7 @@ describe("createAuthenticatedIngestionProcessor", () => {
     expect(auditSink.record).toHaveBeenCalledOnce(); expect(adminAlerts.notifyIngestionAttention).toHaveBeenCalledOnce();
   });
 
-  it("does not emit telemetry when terminal persistence fails and uses stable audit identity for redelivery", async () => {
+  it("does not emit telemetry when terminal persistence fails and redelivery repeats persistence and alert delivery", async () => {
     let persistenceFails = true;
     const scrapeRuns = { markFailed: vi.fn(async () => { if (persistenceFails) throw new Error("raw-persistence-sentinel"); }), markNeedsAdminAction: vi.fn(async () => {}) };
     const auditSink = { record: vi.fn<(event: { id: string }) => Promise<void>>(async () => {}) };
@@ -111,8 +113,21 @@ describe("createAuthenticatedIngestionProcessor", () => {
     await expect(complete(outcome)).rejects.toEqual(new AuthenticatedIngestionTerminalError());
     expect(auditSink.record).not.toHaveBeenCalled(); expect(adminAlerts.notifyIngestionAttention).not.toHaveBeenCalled();
     persistenceFails = false; await complete(outcome); await complete(outcome);
-    expect(auditSink.record.mock.calls.map(([event]) => (event as { id: string }).id)).toEqual(["authenticated-terminal:run-1:failed:invalid_authenticated_ingestion_delivery", "authenticated-terminal:run-1:failed:invalid_authenticated_ingestion_delivery"]);
+    expect(scrapeRuns.markFailed).toHaveBeenCalledTimes(3);
+    expect(auditSink.record.mock.calls.map(([event]) => (event as { id: string }).id)).toEqual([expect.stringMatching(/^authenticated-terminal:v1:/), expect.stringMatching(/^authenticated-terminal:v1:/)]);
+    expect((auditSink.record.mock.calls[0]?.[0] as { id: string }).id).toBe((auditSink.record.mock.calls[1]?.[0] as { id: string }).id);
     expect(adminAlerts.notifyIngestionAttention).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses collision-resistant opaque audit IDs for every terminal identity tuple", async () => {
+    const auditSink = { record: vi.fn<(event: { id: string }) => Promise<void>>(async () => {}) };
+    const complete = createAuthenticatedTerminalCompleter({ scrapeRuns: { markFailed: vi.fn(async () => {}), markNeedsAdminAction: vi.fn(async () => {}) }, auditSink });
+    const base = { runId: "run\ud800", bankId: "bank\ud800", status: "failed" as const, reason: "invalid_authenticated_ingestion_delivery" as const };
+
+    await complete(base); await complete(base); await complete({ ...base, bankId: "bank\ufffd" }); await complete({ ...base, runId: "run\ufffd" }); await complete({ ...base, status: "needs_admin_action", reason: "authentication_precondition_requires_review" });
+    const ids = auditSink.record.mock.calls.map(([event]) => (event as { id: string }).id);
+    expect(ids[0]).toBe(ids[1]); expect(new Set(ids.slice(0, 1).concat(ids.slice(2))).size).toBe(4);
+    expect(ids.join(" ")).not.toMatch(/bank|run|\ud800|\ufffd/);
   });
 
   it("composes the actual authenticated path once and reuses durable authentication on duplicate delivery", async () => {

--- a/src/worker/authenticated-ingestion-composition.ts
+++ b/src/worker/authenticated-ingestion-composition.ts
@@ -1,4 +1,5 @@
 import type { AuthenticatedSessionCoordinatorDependencies } from "../modules/bank-sessions/ensure-authenticated-session";
+import { createAuditEvent } from "../modules/audit";
 import { createAuthenticatedIngestionDeliveryProcessor, AuthenticatedIngestionTerminalError, type AuthenticatedIngestionTerminalOutcome } from "./authenticated-ingestion-delivery";
 import { createAuthenticatedIngestionPrecondition } from "./authenticated-ingestion-precondition";
 import { createCollectionIngestionProcessor, type CollectionIngestionProcessorDependencies } from "./collection-ingestion-processor";
@@ -10,6 +11,12 @@ import { resolveAuthenticationHeartbeatConfig } from "./scraper/authentication-h
 
 type HeartbeatDependencies = Omit<AuthenticationHeartbeatSchedulerDependencies<unknown>, "delayMs">;
 type CollectionDependencies = Pick<CollectionIngestionProcessorDependencies, "scrapeRuns" | "transactions" | "resolveScraper" | "adminAlerts" | "auditSink" | "now">;
+type TerminalDependencies = Readonly<{
+  scrapeRuns: Pick<CollectionDependencies["scrapeRuns"], "markFailed" | "markNeedsAdminAction">;
+  auditSink?: Pick<NonNullable<CollectionDependencies["auditSink"]>, "record">;
+  adminAlerts?: Pick<NonNullable<CollectionDependencies["adminAlerts"]>, "notifyIngestionAttention">;
+  now?: () => Date;
+}>;
 
 export type AuthenticatedIngestionProcessorDependencies = Readonly<{
   env: Record<string, string | undefined>;
@@ -26,15 +33,35 @@ const terminalSummaries = {
 } as const;
 
 export function createAuthenticatedTerminalCompleter(
-  dependencies: Pick<CollectionDependencies, "scrapeRuns" | "now">,
+  dependencies: TerminalDependencies,
 ): (outcome: AuthenticatedIngestionTerminalOutcome) => Promise<IngestionResult> {
   const now = dependencies.now ?? (() => new Date());
-  return async ({ runId, status }) => {
+  return async ({ runId, bankId, status, reason }) => {
     try {
       if (status === "failed") await dependencies.scrapeRuns.markFailed(runId, terminalSummaries.failed, now());
       else await dependencies.scrapeRuns.markNeedsAdminAction(runId, terminalSummaries.needs_admin_action, now());
     } catch {
       throw new AuthenticatedIngestionTerminalError();
+    }
+    const summary = terminalSummaries[status];
+    const safeBankId = typeof bankId === "string" && /\S/.test(bankId) ? bankId : undefined;
+    try {
+      await dependencies.auditSink?.record(createAuditEvent({
+        id: `authenticated-terminal:${runId}:${status}:${reason}`,
+        actorId: "system:ingestion-worker",
+        actorRole: null,
+        action: `scrape_run.${status}`,
+        target: "scrape_run",
+        targetId: runId,
+        metadata: { stage: "precollection_authentication", reason, status, ...(safeBankId === undefined ? {} : { bankId: safeBankId }) },
+      }));
+    } catch {
+      // Audit delivery cannot change the already-persisted terminal result.
+    }
+    try {
+      await dependencies.adminAlerts?.notifyIngestionAttention({ runId, bankId: safeBankId ?? "unknown", status, safeErrorSummary: summary });
+    } catch {
+      // Alert delivery cannot change the already-persisted terminal result.
     }
     return { status, inserted: 0, skipped: 0 };
   };

--- a/src/worker/authenticated-ingestion-composition.ts
+++ b/src/worker/authenticated-ingestion-composition.ts
@@ -32,6 +32,17 @@ const terminalSummaries = {
   needs_admin_action: "Authenticated ingestion requires admin action",
 } as const;
 
+function auditIdentityPart(value: string | null): string {
+  if (value === null) return "n";
+  let codeUnits = "";
+  for (let index = 0; index < value.length; index += 1) codeUnits += value.charCodeAt(index).toString(16).padStart(4, "0");
+  return `s${value.length.toString(16)}-${codeUnits}`;
+}
+
+function terminalAuditId(runId: string, bankId: string | null, status: "failed" | "needs_admin_action", reason: string): string {
+  return `authenticated-terminal:v1:${[bankId, runId, status, reason].map(auditIdentityPart).join(":")}`;
+}
+
 export function createAuthenticatedTerminalCompleter(
   dependencies: TerminalDependencies,
 ): (outcome: AuthenticatedIngestionTerminalOutcome) => Promise<IngestionResult> {
@@ -47,7 +58,7 @@ export function createAuthenticatedTerminalCompleter(
     const safeBankId = typeof bankId === "string" && /\S/.test(bankId) ? bankId : undefined;
     try {
       await dependencies.auditSink?.record(createAuditEvent({
-        id: `authenticated-terminal:${runId}:${status}:${reason}`,
+        id: terminalAuditId(runId, safeBankId ?? null, status, reason),
         actorId: "system:ingestion-worker",
         actorRole: null,
         action: `scrape_run.${status}`,
@@ -58,10 +69,12 @@ export function createAuthenticatedTerminalCompleter(
     } catch {
       // Audit delivery cannot change the already-persisted terminal result.
     }
-    try {
-      await dependencies.adminAlerts?.notifyIngestionAttention({ runId, bankId: safeBankId ?? "unknown", status, safeErrorSummary: summary });
-    } catch {
-      // Alert delivery cannot change the already-persisted terminal result.
+    if (safeBankId !== undefined) {
+      try {
+        await dependencies.adminAlerts?.notifyIngestionAttention({ runId, bankId: safeBankId, status, safeErrorSummary: summary });
+      } catch {
+        // Alert delivery cannot change the already-persisted terminal result.
+      }
     }
     return { status, inserted: 0, skipped: 0 };
   };

--- a/src/worker/authenticated-ingestion-delivery.test.ts
+++ b/src/worker/authenticated-ingestion-delivery.test.ts
@@ -74,7 +74,7 @@ describe("createAuthenticatedIngestionDeliveryProcessor", () => {
   it.each([{ runId: "run-1", bankId: "popular", accountFingerprint: "fingerprint-1" }, { runId: "run-1", bankId: "popular", accountFingerprint: "fingerprint-1", expiredEventId: "expired-1" }])("completes legacy payloads safely", async (data) => {
     const { processor, authenticate, downstream, complete } = setup();
     await expect(processor({ data })).resolves.toEqual({ status: "needs_admin_action", inserted: 0, skipped: 0 });
-    expect(complete).toHaveBeenCalledWith({ runId: "run-1", status: "needs_admin_action", reason: "legacy_authenticated_ingestion_delivery" });
+    expect(complete).toHaveBeenCalledWith({ runId: "run-1", bankId: "popular", status: "needs_admin_action", reason: "legacy_authenticated_ingestion_delivery" });
     expect(authenticate).not.toHaveBeenCalled(); expect(downstream).not.toHaveBeenCalled();
   });
 
@@ -92,6 +92,7 @@ describe("createAuthenticatedIngestionDeliveryProcessor", () => {
     await expect(processor({ data })).resolves.toEqual({ status: "needs_admin_action", inserted: 0, skipped: 0 });
     expect(authenticate).not.toHaveBeenCalled(); expect(downstream).not.toHaveBeenCalled();
     expect(complete).toHaveBeenCalledWith(expect.objectContaining({ status: "failed", reason: "invalid_authenticated_ingestion_delivery" }));
+    expect(complete.mock.calls[0]?.[0]).not.toHaveProperty("bankId");
   });
 
   it("throws a fixed typed invalid-job error when no safe run id is available", async () => {
@@ -112,7 +113,7 @@ describe("createAuthenticatedIngestionDeliveryProcessor", () => {
   it.each(["temporary_authentication_problem", "protected_authentication_step_detected", "bank_login_configuration_requires_review", "authentication_attempt_requires_review", "identity_conflict", "restoration_state_conflict"])("maps operator reason %s to a safe terminal outcome", async (reason) => {
     const { processor, downstream, complete } = setup({ status: "needs_operator_action", reason });
     await processor({ data: payload() });
-    expect(complete).toHaveBeenCalledWith({ runId: "run-1", status: "needs_admin_action", reason });
+    expect(complete).toHaveBeenCalledWith({ runId: "run-1", bankId: "popular", status: "needs_admin_action", reason });
     expect(downstream).not.toHaveBeenCalled();
   });
 
@@ -176,7 +177,7 @@ describe("createAuthenticatedIngestionDeliveryProcessor", () => {
   it("treats forged authenticated precondition results as operator review", async () => {
     const { processor, downstream, complete } = setup({ status: "authenticated", extra: "raw-sentinel" });
     await processor({ data: payload() });
-    expect(downstream).not.toHaveBeenCalled(); expect(complete).toHaveBeenCalledWith({ runId: "run-1", status: "needs_admin_action", reason: "authentication_precondition_requires_review" });
+    expect(downstream).not.toHaveBeenCalled(); expect(complete).toHaveBeenCalledWith({ runId: "run-1", bankId: "popular", status: "needs_admin_action", reason: "authentication_precondition_requires_review" });
     expect(JSON.stringify(complete.mock.calls)).not.toContain("raw-sentinel");
   });
 

--- a/src/worker/authenticated-ingestion-delivery.ts
+++ b/src/worker/authenticated-ingestion-delivery.ts
@@ -6,7 +6,7 @@ type Identity = Readonly<{ bankCode: string; runId: string; attemptId: string }>
 type OperatorReason = "temporary_authentication_problem" | "protected_authentication_step_detected" | "bank_login_configuration_requires_review" | "authentication_attempt_requires_review" | "identity_conflict" | "restoration_state_conflict";
 type TerminalReason = OperatorReason | "legacy_authenticated_ingestion_delivery" | "invalid_authenticated_ingestion_delivery" | "invalid_authenticated_ingestion_precondition" | "authentication_precondition_requires_review";
 
-export type AuthenticatedIngestionTerminalOutcome = Readonly<{ runId: string; status: "needs_admin_action" | "failed"; reason: TerminalReason }>;
+export type AuthenticatedIngestionTerminalOutcome = Readonly<{ runId: string; bankId?: string; status: "needs_admin_action" | "failed"; reason: TerminalReason }>;
 export type AuthenticatedIngestionAuthenticationInput = Readonly<{ identity: Identity; ownerToken: string; job: Readonly<{ data: IngestionData }>; signal?: AbortSignal }>;
 export type AuthenticatedIngestionDeliveryDependencies<TResult> = Readonly<{
   authenticate: (input: AuthenticatedIngestionAuthenticationInput) => Promise<AuthenticatedSessionPreconditionResult>;
@@ -82,8 +82,8 @@ export function createAuthenticatedIngestionDeliveryProcessor<TResult>(dependenc
       if (!runId) throw new AuthenticatedIngestionInvalidJobError();
       return complete({ runId, status: "failed", reason: "invalid_authenticated_ingestion_delivery" });
     }
-    if (parsed.kind === "legacy") return complete({ runId: parsed.data.runId, status: "needs_admin_action", reason: "legacy_authenticated_ingestion_delivery" });
-    if (jobSignal === null) return complete({ runId: parsed.data.runId, status: "failed", reason: "invalid_authenticated_ingestion_delivery" });
+    if (parsed.kind === "legacy") return complete({ runId: parsed.data.runId, bankId: parsed.data.bankId, status: "needs_admin_action", reason: "legacy_authenticated_ingestion_delivery" });
+    if (jobSignal === null) return complete({ runId: parsed.data.runId, bankId: parsed.data.bankId, status: "failed", reason: "invalid_authenticated_ingestion_delivery" });
     let decision: ReturnType<typeof preconditionDecision>;
     try {
       const ownerToken = dependencies.createOwnerToken();
@@ -94,6 +94,6 @@ export function createAuthenticatedIngestionDeliveryProcessor<TResult>(dependenc
       return dependencies.downstream({ data: parsed.data });
     }
     if (decision === "retry_delivery" || decision === "in_progress" || decision === "cancelled") throw new AuthenticatedIngestionRetryError(decision);
-    return complete({ runId: parsed.data.runId, status: decision === "invalid_authenticated_ingestion_precondition" ? "failed" : "needs_admin_action", reason: decision });
+    return complete({ runId: parsed.data.runId, bankId: parsed.data.bankId, status: decision === "invalid_authenticated_ingestion_precondition" ? "failed" : "needs_admin_action", reason: decision });
   };
 }


### PR DESCRIPTION
Closes #128

## Summary
- Makes authenticated-ingestion terminal persistence the primary outcome, then emits best-effort audit and alert telemetry.
- Emits exact scrape-run audit actions: `scrape_run.failed` and `scrape_run.needs_admin_action`.
- Sends fixed operator alerts only when `bankId` is validated; it never fabricates an unknown bank.

## Chain Context

`#127 authenticated ingestion composition -> 📍 WU6d.5a THIS PR -> WU6d.5b fail-closed policy -> WU6d.5c attempts -> WU6d.5d in-memory -> WU6d.5e shutdown -> WU6d.5f lock-before-decrypt -> WU6d.5g production builder -> WU6d.5h final activator -> cleanup`

This remains an open, unmerged child PR with base `feat/authenticated-ingestion-composition`; each next work unit targets the immediate predecessor. Only the tracker targets `main`.

## Behavior

Terminal run persistence happens first. Audit and alert sinks are independent and nonblocking, so a sink failure cannot replace the terminal result.

The audit identity is a canonical opaque identifier framed from `bank|null`, `run`, `status`, and `reason`. It preserves the bank only when validated and does not invent one for unknown input. Prisma audit `P2002` is treated as the stable-ID dedupe case.

Redelivery may repeat terminal persistence and fixed alerts. Only the audit event is deduplicated.

## Changes

| File | Change |
|---|---|
| `src/worker/authenticated-ingestion-composition.ts` | Adds persistence-first terminal completion with nonblocking audit and alert telemetry. |
| `src/worker/authenticated-ingestion-composition.test.ts` | Covers terminal action, identity, ordering, sink isolation, and dedupe behavior. |
| `src/worker/authenticated-ingestion-delivery.ts` | Passes terminal outcome identity through authenticated-delivery completion. |
| `src/worker/authenticated-ingestion-delivery.test.ts` | Covers delivery terminal outcome propagation. |

Scope: 4 files, +144/-15 (159 changed lines), 2 commits.

## Verification

- [x] Focused suite: 69 passed.
- [x] Full suite: 1,872 passed, 2 skipped (isolated rerun after unrelated concurrent timeouts).
- [x] `pnpm lint`, `pnpm typecheck`, Prisma validation, and `git diff --check` passed.
- [x] No CI or review checks are enabled for this PR; no checks are expected.
- [x] Confirmed inert/no caller before activation work.

## Exclusions

Activation, retry policy, shutdown, lock-before-decrypt, and production wiring are intentionally deferred to the following chain units.

## Rollback

Revert commits `9abbe86` and `9aa49b4`, or abandon this unmerged child PR.