### PR TITLE
feat(worker): add fail-closed ingestion activation policy

### DIFF
--- a/src/worker/authenticated-ingestion-activation.test.ts
+++ b/src/worker/authenticated-ingestion-activation.test.ts
@@ -1,0 +1,122 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it, vi } from "vitest";
+import { AuthenticatedIngestionInvalidJobError } from "./authenticated-ingestion-delivery";
+import { createAuthenticatedTerminalCompleter } from "./authenticated-ingestion-composition";
+import {
+  createDisabledAuthenticatedIngestionProcessor,
+  resolveAuthenticatedIngestionActivation,
+} from "./authenticated-ingestion-activation";
+
+const v1 = () => ({ runId: "run-1", bankId: "popular", accountFingerprint: "fingerprint-1", authentication: { version: 1, attemptId: "attempt-1" } });
+const legacy = () => ({ runId: "run-1", bankId: "popular", accountFingerprint: "fingerprint-1" });
+
+function setup() {
+  const complete = vi.fn(async (outcome: unknown) => ({ status: (outcome as { status: string }).status, inserted: 0, skipped: 0 }));
+  return { complete, processor: createDisabledAuthenticatedIngestionProcessor({ complete }) };
+}
+
+describe("resolveAuthenticatedIngestionActivation", () => {
+  it.each(["enabled", undefined, "", " ", " enabled", "enabled ", "ENABLED", "Enabled", "true", "1", "disabled", "no"])
+    ("recognizes only the exact raw value %j", (raw) => {
+      const result = resolveAuthenticatedIngestionActivation(raw);
+      expect(result).toEqual(raw === "enabled" ? { status: "enabled" } : { status: "disabled" });
+      expect(Object.isFrozen(result)).toBe(true);
+    });
+
+  it("does not mutate input or read process environment", async () => {
+    const raw = new String("enabled");
+    expect(resolveAuthenticatedIngestionActivation(raw as unknown as string)).toEqual({ status: "disabled" });
+    expect(raw.valueOf()).toBe("enabled");
+    const source = await readFile(new URL("./authenticated-ingestion-activation.ts", import.meta.url), "utf8");
+    expect(source).not.toMatch(/process\.env|\.trim\(|\.toLowerCase\(|\.toUpperCase\(/);
+  });
+});
+
+describe("createDisabledAuthenticatedIngestionProcessor", () => {
+  it("completes a V1 delivery with disabled telemetry and no owner token", async () => {
+    const scrapeRuns = { markFailed: vi.fn(async () => {}), markNeedsAdminAction: vi.fn(async () => {}) };
+    const auditSink = { record: vi.fn(async () => {}) };
+    const adminAlerts = { notifyIngestionAttention: vi.fn(async () => {}) };
+    const processor = createDisabledAuthenticatedIngestionProcessor({
+      complete: createAuthenticatedTerminalCompleter({ scrapeRuns, auditSink, adminAlerts, now: () => new Date("2026-08-21T00:00:00.000Z") }),
+    });
+
+    await expect(processor({ data: v1() })).resolves.toEqual({ status: "needs_admin_action", inserted: 0, skipped: 0 });
+    expect(scrapeRuns.markNeedsAdminAction).toHaveBeenCalledExactlyOnceWith("run-1", "Authenticated ingestion requires admin action", new Date("2026-08-21T00:00:00.000Z"));
+    expect(auditSink.record).toHaveBeenCalledWith(expect.objectContaining({ action: "scrape_run.needs_admin_action", metadata: { stage: "precollection_authentication", reason: "authenticated_ingestion_disabled", status: "needs_admin_action", bankId: "popular" } }));
+    expect(adminAlerts.notifyIngestionAttention).toHaveBeenCalledWith({ runId: "run-1", bankId: "popular", status: "needs_admin_action", safeErrorSummary: "Authenticated ingestion requires admin action" });
+    expect(JSON.stringify(auditSink.record.mock.calls)).not.toMatch(/enabled|owner|fingerprint|attempt/);
+  });
+
+  it.each([legacy(), { ...legacy(), expiredEventId: "expired-1" }])("completes legacy delivery terminally without high-level capabilities", async (data) => {
+    const { processor, complete } = setup();
+    await processor({ data });
+    expect(complete).toHaveBeenCalledWith({ runId: "run-1", bankId: "popular", status: "needs_admin_action", reason: "legacy_authenticated_ingestion_delivery" });
+    expect(complete).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    { ...v1(), authentication: { version: 2, attemptId: "attempt-1" } },
+    { ...v1(), ownerToken: "injected" },
+    { ...v1(), extra: true },
+    Object.defineProperty(v1(), "extra", { enumerable: false, value: true }),
+    Object.assign(v1(), { [Symbol("hidden")]: true }),
+    Object.assign(Object.create({ extra: true }), v1()),
+    Object.assign([], v1()),
+    null,
+  ])("fails malformed or unknown delivery closed when a safe run id is available", async (data) => {
+    const { processor, complete } = setup();
+    if (data === null) return expect(processor({ data })).rejects.toEqual(new AuthenticatedIngestionInvalidJobError());
+    await processor({ data });
+    expect(complete).toHaveBeenCalledWith({ runId: "run-1", status: "failed", reason: "invalid_authenticated_ingestion_delivery" });
+  });
+
+  it("does not invoke outer or nested getters and leaks no hostile value", async () => {
+    let outerRead = false;
+    let nestedRead = false;
+    const nested = Object.defineProperty({ version: 1 }, "attemptId", { enumerable: true, get: () => { nestedRead = true; throw new Error("raw-nested-sentinel"); } });
+    const { processor, complete } = setup();
+    await processor({ data: { ...v1(), authentication: nested } });
+    await expect(processor(Object.defineProperty({}, "data", { enumerable: true, get: () => { outerRead = true; throw new Error("raw-outer-sentinel"); } }) as { data: unknown })).rejects.toEqual(new AuthenticatedIngestionInvalidJobError());
+    expect(nestedRead).toBe(false); expect(outerRead).toBe(false);
+    expect(JSON.stringify(complete.mock.calls)).not.toMatch(/raw-(nested|outer)-sentinel/);
+  });
+
+  it.each([
+    Object.defineProperty({ version: 1, attemptId: "attempt-1" }, "hidden", { value: true }),
+    Object.assign({ version: 1, attemptId: "attempt-1" }, { [Symbol("hidden")]: true }),
+    Object.assign(Object.create({ extra: true }), { version: 1, attemptId: "attempt-1" }),
+    { version: 1, attemptId: "attempt-1", extra: true },
+    null,
+    [],
+  ])("rejects nested hostile records without changing the terminal reason", async (authentication) => {
+    const { processor, complete } = setup();
+    await processor({ data: { ...v1(), authentication } });
+    expect(complete).toHaveBeenCalledWith({ runId: "run-1", status: "failed", reason: "invalid_authenticated_ingestion_delivery" });
+  });
+
+  it("rejects forged signals without leaks while native signals preserve disabled semantics", async () => {
+    const controller = new AbortController();
+    const { processor, complete } = setup();
+    await processor({ data: v1(), signal: controller.signal });
+    const forged = Object.create(AbortSignal.prototype);
+    Object.defineProperty(forged, "aborted", { get: () => { throw new Error("raw-signal-sentinel"); } });
+    await processor({ data: v1(), signal: forged } as never);
+    await processor({ data: v1(), signal: new Proxy(controller.signal, { get() { throw new Error("raw-proxy-sentinel"); } }) } as never);
+    expect(complete.mock.calls.map(([outcome]) => outcome)).toEqual([
+      { runId: "run-1", bankId: "popular", status: "needs_admin_action", reason: "authenticated_ingestion_disabled" },
+      { runId: "run-1", status: "failed", reason: "invalid_authenticated_ingestion_delivery" },
+      { runId: "run-1", status: "failed", reason: "invalid_authenticated_ingestion_delivery" },
+    ]);
+    expect(JSON.stringify(complete.mock.calls)).not.toMatch(/raw-(signal|proxy)-sentinel/);
+  });
+
+  it("exposes only terminal completion at its dependency boundary and has no product wiring", async () => {
+    const compatible: (job: { data: unknown; signal?: AbortSignal }) => Promise<{ status: string; inserted: number; skipped: number }> = createDisabledAuthenticatedIngestionProcessor({ complete: async () => ({ status: "failed", inserted: 0, skipped: 0 }) });
+    // @ts-expect-error The disabled processor cannot receive a probe or other high-level capability.
+    createDisabledAuthenticatedIngestionProcessor({ complete: async () => ({ status: "failed", inserted: 0, skipped: 0 }), probe: {} });
+    expect(compatible).toBeTypeOf("function");
+    const source = await readFile(new URL("./authenticated-ingestion-activation.ts", import.meta.url), "utf8");
+    expect(source).not.toMatch(/probe|precondition|credential|browser|collection|scraper|owner.?token|lock|process\.env|bullmq|prisma|ingestion-worker/i);
+  });
+});

--- a/src/worker/authenticated-ingestion-activation.test.ts
+++ b/src/worker/authenticated-ingestion-activation.test.ts
@@ -16,9 +16,14 @@ function setup() {
 }
 
 describe("resolveAuthenticatedIngestionActivation", () => {
-  it.each(["enabled", undefined, "", " ", " enabled", "enabled ", "ENABLED", "Enabled", "true", "1", "disabled", "no"])
+  it.each([
+    "enabled", undefined, "", " ", " enabled", "enabled ", "ENABLED", "Enabled", "true", "1", "disabled", "no",
+    "enabled\0", "еnabled", "enablеd", "ｅｎａｂｌｅｄ",
+    `en${String.fromCharCode(0x200d)}abled`, `en${String.fromCharCode(0x200c)}abled`, `en${String.fromCharCode(0xfeff)}abled`,
+    "\tenabled", "enabled\t", "\nenabled", "enabled\n", new String("enabled") as unknown,
+  ])
     ("recognizes only the exact raw value %j", (raw) => {
-      const result = resolveAuthenticatedIngestionActivation(raw);
+      const result = resolveAuthenticatedIngestionActivation(raw as string | undefined);
       expect(result).toEqual(raw === "enabled" ? { status: "enabled" } : { status: "disabled" });
       expect(Object.isFrozen(result)).toBe(true);
     });

--- a/src/worker/authenticated-ingestion-activation.ts
+++ b/src/worker/authenticated-ingestion-activation.ts
@@ -1,0 +1,31 @@
+import {
+  AuthenticatedIngestionInvalidJobError,
+  classifyAuthenticatedIngestionDeliveryJob,
+  type AuthenticatedIngestionTerminalOutcome,
+} from "./authenticated-ingestion-delivery";
+
+export type AuthenticatedIngestionActivation = Readonly<{ status: "enabled" | "disabled" }>;
+
+export function resolveAuthenticatedIngestionActivation(raw: string | undefined): AuthenticatedIngestionActivation {
+  return Object.freeze(raw === "enabled" ? { status: "enabled" } : { status: "disabled" });
+}
+
+export type DisabledAuthenticatedIngestionProcessorDependencies<TResult> = Readonly<{
+  complete: (outcome: AuthenticatedIngestionTerminalOutcome) => Promise<TResult>;
+}>;
+
+export function createDisabledAuthenticatedIngestionProcessor<TResult>(
+  dependencies: DisabledAuthenticatedIngestionProcessorDependencies<TResult>,
+): (job: Readonly<{ data: unknown; signal?: AbortSignal }>) => Promise<TResult> {
+  return async (job) => {
+    const delivery = classifyAuthenticatedIngestionDeliveryJob(job);
+    if (delivery.kind === "invalid") {
+      if (delivery.runId === undefined) throw new AuthenticatedIngestionInvalidJobError();
+      return dependencies.complete({ runId: delivery.runId, status: "failed", reason: "invalid_authenticated_ingestion_delivery" });
+    }
+    if (delivery.kind === "legacy") {
+      return dependencies.complete({ runId: delivery.runId, bankId: delivery.bankId, status: "needs_admin_action", reason: "legacy_authenticated_ingestion_delivery" });
+    }
+    return dependencies.complete({ runId: delivery.runId, bankId: delivery.bankId, status: "needs_admin_action", reason: "authenticated_ingestion_disabled" });
+  };
+}

--- a/src/worker/authenticated-ingestion-delivery.ts
+++ b/src/worker/authenticated-ingestion-delivery.ts
@@ -4,7 +4,7 @@ type DeliveryJob = Readonly<{ data: unknown; signal?: AbortSignal }>;
 export type IngestionData = Readonly<{ runId: string; bankId: string; accountFingerprint: string }>;
 type Identity = Readonly<{ bankCode: string; runId: string; attemptId: string }>;
 type OperatorReason = "temporary_authentication_problem" | "protected_authentication_step_detected" | "bank_login_configuration_requires_review" | "authentication_attempt_requires_review" | "identity_conflict" | "restoration_state_conflict";
-type TerminalReason = OperatorReason | "legacy_authenticated_ingestion_delivery" | "invalid_authenticated_ingestion_delivery" | "invalid_authenticated_ingestion_precondition" | "authentication_precondition_requires_review";
+type TerminalReason = OperatorReason | "legacy_authenticated_ingestion_delivery" | "invalid_authenticated_ingestion_delivery" | "invalid_authenticated_ingestion_precondition" | "authentication_precondition_requires_review" | "authenticated_ingestion_disabled";
 
 export type AuthenticatedIngestionTerminalOutcome = Readonly<{ runId: string; bankId?: string; status: "needs_admin_action" | "failed"; reason: TerminalReason }>;
 export type AuthenticatedIngestionAuthenticationInput = Readonly<{ identity: Identity; ownerToken: string; job: Readonly<{ data: IngestionData }>; signal?: AbortSignal }>;
@@ -53,6 +53,11 @@ function aborted(value: AbortSignal): boolean | null {
   try { return readNativeAbortSignal?.call(value) ?? null; } catch { return null; }
 }
 
+export type AuthenticatedIngestionDeliveryClassification =
+  | Readonly<{ kind: "v1"; runId: string; bankId: string }>
+  | Readonly<{ kind: "legacy"; runId: string; bankId: string }>
+  | Readonly<{ kind: "invalid"; runId?: string }>;
+
 function parseData(value: unknown): Readonly<{ kind: "v1"; data: IngestionData; identity: Identity }> | Readonly<{ kind: "legacy"; data: IngestionData }> | null {
   const v1 = exact(value, ["runId", "bankId", "accountFingerprint", "authentication"]);
   if (v1) {
@@ -62,6 +67,19 @@ function parseData(value: unknown): Readonly<{ kind: "v1"; data: IngestionData; 
   const legacy = exact(value, ["runId", "bankId", "accountFingerprint"]) ?? exact(value, ["runId", "bankId", "accountFingerprint", "expiredEventId"]);
   if (legacy && isNonblank(legacy.runId) && isNonblank(legacy.bankId) && isNonblank(legacy.accountFingerprint) && (legacy.expiredEventId === undefined || isNonblank(legacy.expiredEventId))) return { kind: "legacy", data: { runId: legacy.runId, bankId: legacy.bankId, accountFingerprint: legacy.accountFingerprint } };
   return null;
+}
+
+export function classifyAuthenticatedIngestionDeliveryJob(job: DeliveryJob): AuthenticatedIngestionDeliveryClassification {
+  let data: unknown; let jobSignal: AbortSignal | null | undefined;
+  try { const envelope = exact(job, ["data"]) ?? exact(job, ["data", "signal"]); data = envelope?.data; jobSignal = signal(envelope?.signal); } catch { data = undefined; jobSignal = null; }
+  const parsed = (() => { try { return parseData(data); } catch { return null; } })();
+  if (!parsed || jobSignal === null) {
+    const runId = safeRunId(data);
+    return Object.freeze(runId ? { kind: "invalid" as const, runId } : { kind: "invalid" as const });
+  }
+  return Object.freeze(parsed.kind === "v1"
+    ? { kind: "v1" as const, runId: parsed.data.runId, bankId: parsed.data.bankId }
+    : { kind: "legacy" as const, runId: parsed.data.runId, bankId: parsed.data.bankId });
 }
 
 function preconditionDecision(value: unknown): "authenticated" | "retry_delivery" | "in_progress" | "cancelled" | OperatorReason | "invalid_authenticated_ingestion_precondition" | "authentication_precondition_requires_review" {


### PR DESCRIPTION
Closes #130

## Summary
- Adds an inert, fail-closed authenticated-ingestion activation policy: only the primitive raw value `enabled` activates it.
- Keeps terminal behavior terminal-only for V1, legacy, and invalid payloads; no product composition is activated by this slice.
- Shares the strict frozen delivery classifier without exposing sensitive capabilities, owner tokens, or collections.

## Review Path
Review `src/worker/authenticated-ingestion-activation.ts` first, then its hostile-input contract tests, then the delivery classifier boundary.

## Activation Contract
| Concern | Contract |
| --- | --- |
| Enabled value | Raw primitive string `enabled` only. |
| Disabled values | Exhaustive hostile variants are disabled, including boxed strings, whitespace/control characters, Unicode homoglyphs, zero-width characters, and non-string values. |
| Payload handling | V1, legacy, and invalid payloads remain terminal-only and cannot activate collection or delivery behavior. |
| Classification | A strict shared frozen classifier is used for the terminal boundary. |
| Sensitive state | Zero sensitive capability, owner token, or collection is returned or exposed. |
| Authority | No `process.env` lookup and no caller-provided activation authority. |

## Chain Context
`#129` -> `📍 WU6d.5b (this PR)` -> `WU6d.5c attempts` -> `WU6d.5d in-memory` -> `WU6d.5e shutdown` -> `WU6d.5f lock` -> `WU6d.5g builder` -> `WU6d.5h activator`

This child targets the open, unmerged head of #129 and MUST remain open and unmerged as the base for the next slice.

## Changes
| File | Change |
| --- | --- |
| `src/worker/authenticated-ingestion-activation.ts` | Adds the strict raw-value activation resolver and terminal-only processor. |
| `src/worker/authenticated-ingestion-activation.test.ts` | Covers enabled, disabled, hostile, V1, legacy, invalid, and non-exposure behavior. |
| `src/worker/authenticated-ingestion-delivery.ts` | Exposes the frozen strict shared classifier and terminal reason support. |

Review budget: 3 files, +177/-1 (178 changed lines).

## Commits
- `75740a0 feat(worker): add fail-closed ingestion activation policy`
- `c340f1f test(worker): harden activation value matching`

## Verification Evidence
- [x] Focused tests: 45 passing.
- [x] Full suite: 1917 passing, 2 skipped.
- [x] Lint, typecheck, Prisma validation, and `git diff --check` passed.
- [x] Runtime harness: N/A; this is an inert terminal-only policy with no product caller.

## Exclusions
- No product wiring, collection activation, capability issuance, owner-token flow, environment activation, or caller authority.
- No CI or review runs are expected because repository checks are disabled/inert.

## Rollback
Revert both commits or remove only the three listed files' WU6d.5b changes; no production composition path is affected.

## PR Type
- [x] New feature
- [ ] Bug fix
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Checklist
- [x] Linked approved issue #130.
- [x] Added exactly one `type:*` label.
- [x] Used conventional commits with no AI attribution.
- [x] Kept this work unit scoped and independently reviewable.