### PR TITLE
feat(worker): propagate BullMQ delivery attempts

### DIFF
--- a/src/worker/authenticated-ingestion-composition.test.ts
+++ b/src/worker/authenticated-ingestion-composition.test.ts
@@ -215,6 +215,6 @@ describe("createAuthenticatedIngestionProcessor", () => {
   it("remains factory-compatible and free of production activation dependencies", async () => {
     const source = await readFile(new URL("./authenticated-ingestion-composition.ts", import.meta.url), "utf8");
     const f = fixture(); const factoryCompatible: (job: { data: unknown }) => Promise<{ status: string; inserted: number; skipped: number }> = f.processor;
-    expect(factoryCompatible).toBeTypeOf("function"); expect(source).not.toMatch(/bullmq|prisma|process\.env|from ["'][^"']*ingestion-worker|recoverExpiredSession|from ["'][^"']*queues\/index/i);
+    expect(factoryCompatible).toBeTypeOf("function"); expect(source).toContain("isAuthenticatedIngestionRetryError(error)"); expect(source).not.toContain("instanceof AuthenticatedIngestionRetryError"); expect(source).not.toMatch(/bullmq|prisma|process\.env|from ["'][^"']*ingestion-worker|recoverExpiredSession|from ["'][^"']*queues\/index/i);
   });
 });

--- a/src/worker/authenticated-ingestion-composition.test.ts
+++ b/src/worker/authenticated-ingestion-composition.test.ts
@@ -160,13 +160,32 @@ describe("createAuthenticatedIngestionProcessor", () => {
 
   it("propagates cancellation as typed retry before mutation or collection", async () => {
     const f = fixture(); const controller = new AbortController(); controller.abort();
-    await expect(f.processor({ ...payload(), signal: controller.signal })).rejects.toEqual(new AuthenticatedIngestionRetryError("cancelled"));
+    await expect(f.processor({ ...payload(), signal: controller.signal, deliveryAttempt: { attemptsMade: 0, maxAttempts: 2 } })).rejects.toEqual(new AuthenticatedIngestionRetryError("cancelled"));
     expect(f.runnerDependencies.credentials.findByBankCode).not.toHaveBeenCalled(); expect(f.collect).not.toHaveBeenCalled(); expect(f.scrapeRuns.markFailed).not.toHaveBeenCalled(); expect(f.scrapeRuns.markNeedsAdminAction).not.toHaveBeenCalled(); expect(f.auditSink.record).not.toHaveBeenCalled(); expect(f.adminAlerts.notifyIngestionAttention).not.toHaveBeenCalled();
+  });
+
+  it("rethrows the retry delivery error before the final attempt", async () => {
+    const f = fixture({ attempts: { findExact: async () => ({ status: "unexpected" }) } as never });
+    await expect(f.processor({ ...payload(), deliveryAttempt: { attemptsMade: 0, maxAttempts: 2 } })).rejects.toEqual(new AuthenticatedIngestionRetryError("retry_delivery"));
+    expect(f.scrapeRuns.markFailed).not.toHaveBeenCalled(); expect(f.scrapeRuns.markNeedsAdminAction).not.toHaveBeenCalled(); expect(f.collect).not.toHaveBeenCalled();
+  });
+
+  it("terminalizes an exhausted retry once with finite telemetry", async () => {
+    const f = fixture({ attempts: { findExact: async () => ({ status: "unexpected" }) } as never });
+    await expect(f.processor({ ...payload(), deliveryAttempt: { attemptsMade: 1, maxAttempts: 2 } })).resolves.toEqual({ status: "needs_admin_action", inserted: 0, skipped: 0 });
+    expect(f.scrapeRuns.markNeedsAdminAction).toHaveBeenCalledOnce(); expect(f.collect).not.toHaveBeenCalled();
+    expect(f.auditSink.record).toHaveBeenCalledWith(expect.objectContaining({ metadata: expect.objectContaining({ reason: "authenticated_ingestion_retry_exhausted" }) }));
+  });
+
+  it("maps exhausted retry terminal persistence failure to the fixed terminal error", async () => {
+    const f = fixture({ attempts: { findExact: async () => ({ status: "unexpected" }) } as never, scrapeRuns: { markRunning: vi.fn(), markSucceeded: vi.fn(), markNeedsAdminAction: vi.fn(async () => { throw new Error("raw terminal sentinel"); }), markThrottled: vi.fn(), markFailed: vi.fn() } });
+    await expect(f.processor({ ...payload(), deliveryAttempt: { attemptsMade: 1, maxAttempts: 2 } })).rejects.toEqual(new AuthenticatedIngestionTerminalError());
+    expect(f.collect).not.toHaveBeenCalled();
   });
 
   it("does not let an aborted delivery signal affect the next fresh delivery", async () => {
     const f = fixture(); const controller = new AbortController(); controller.abort();
-    await expect(f.processor({ ...payload(), signal: controller.signal })).rejects.toEqual(new AuthenticatedIngestionRetryError("cancelled"));
+    await expect(f.processor({ ...payload(), signal: controller.signal, deliveryAttempt: { attemptsMade: 0, maxAttempts: 2 } })).rejects.toEqual(new AuthenticatedIngestionRetryError("cancelled"));
     await expect(f.processor(payload())).resolves.toEqual({ status: "succeeded", inserted: 0, skipped: 0 });
     expect(f.page.fill).toHaveBeenCalledOnce(); expect(f.collect).toHaveBeenCalledOnce();
   });
@@ -175,7 +194,7 @@ describe("createAuthenticatedIngestionProcessor", () => {
     let resolve!: (result: unknown) => void;
     const pending = new Promise<unknown>((done) => { resolve = done; });
     const f = fixture({ popularSessionChecker: { check: async () => pending } }); const controller = new AbortController();
-    const result = f.processor({ ...payload(), signal: controller.signal }); controller.abort(); resolve({ status: "active", checkedAt: "2026-08-21T00:00:00.000Z", safeSummary: "safe" });
+    const result = f.processor({ ...payload(), signal: controller.signal, deliveryAttempt: { attemptsMade: 0, maxAttempts: 2 } }); controller.abort(); resolve({ status: "active", checkedAt: "2026-08-21T00:00:00.000Z", safeSummary: "safe" });
     await expect(result).rejects.toBeInstanceOf(AuthenticatedIngestionRetryError);
     expect(f.runnerDependencies.credentials.findByBankCode).not.toHaveBeenCalled(); expect(f.collect).not.toHaveBeenCalled();
   });

--- a/src/worker/authenticated-ingestion-composition.ts
+++ b/src/worker/authenticated-ingestion-composition.ts
@@ -1,6 +1,6 @@
 import type { AuthenticatedSessionCoordinatorDependencies } from "../modules/bank-sessions/ensure-authenticated-session";
 import { createAuditEvent } from "../modules/audit";
-import { createAuthenticatedIngestionDeliveryProcessor, AuthenticatedIngestionTerminalError, type AuthenticatedIngestionTerminalOutcome } from "./authenticated-ingestion-delivery";
+import { AuthenticatedIngestionRetryError, createAuthenticatedIngestionDeliveryProcessor, AuthenticatedIngestionTerminalError, readAuthenticatedIngestionDeliveryContext, type AuthenticatedIngestionDeliveryJob, type AuthenticatedIngestionTerminalOutcome } from "./authenticated-ingestion-delivery";
 import { createAuthenticatedIngestionPrecondition } from "./authenticated-ingestion-precondition";
 import { createCollectionIngestionProcessor, type CollectionIngestionProcessorDependencies } from "./collection-ingestion-processor";
 import type { IngestionResult } from "./queues";
@@ -48,13 +48,13 @@ export function createAuthenticatedTerminalCompleter(
 ): (outcome: AuthenticatedIngestionTerminalOutcome) => Promise<IngestionResult> {
   const now = dependencies.now ?? (() => new Date());
   return async ({ runId, bankId, status, reason }) => {
+    const summary = reason === "authenticated_ingestion_retry_exhausted" ? "Authenticated ingestion delivery retries exhausted" : terminalSummaries[status];
     try {
       if (status === "failed") await dependencies.scrapeRuns.markFailed(runId, terminalSummaries.failed, now());
-      else await dependencies.scrapeRuns.markNeedsAdminAction(runId, terminalSummaries.needs_admin_action, now());
+      else await dependencies.scrapeRuns.markNeedsAdminAction(runId, summary, now());
     } catch {
       throw new AuthenticatedIngestionTerminalError();
     }
-    const summary = terminalSummaries[status];
     const safeBankId = typeof bankId === "string" && /\S/.test(bankId) ? bankId : undefined;
     try {
       await dependencies.auditSink?.record(createAuditEvent({
@@ -82,12 +82,12 @@ export function createAuthenticatedTerminalCompleter(
 
 export function createAuthenticatedIngestionProcessor(
   dependencies: AuthenticatedIngestionProcessorDependencies,
-): (job: Readonly<{ data: unknown; signal?: AbortSignal }>) => Promise<IngestionResult> {
+): (job: AuthenticatedIngestionDeliveryJob) => Promise<IngestionResult> {
   resolveAuthenticationHeartbeatConfig(dependencies.env);
   const probe = createAuthenticatedSessionProbe({ popularSessionChecker: dependencies.popularSessionChecker });
   const downstream = createCollectionIngestionProcessor(dependencies);
   const complete = createAuthenticatedTerminalCompleter(dependencies);
-  return createAuthenticatedIngestionDeliveryProcessor({
+  const delivery = createAuthenticatedIngestionDeliveryProcessor({
     authenticate: async ({ identity, ownerToken, job, signal }) => createAuthenticatedIngestionPrecondition({
       env: dependencies.env,
       coordinatorDependencies: { attempts: dependencies.attempts, probe },
@@ -99,4 +99,14 @@ export function createAuthenticatedIngestionProcessor(
     complete,
     createOwnerToken: dependencies.createOwnerToken,
   });
+  return async (job) => {
+    try {
+      return await delivery(job);
+    } catch (error) {
+      if (!(error instanceof AuthenticatedIngestionRetryError)) throw error;
+      const context = readAuthenticatedIngestionDeliveryContext(job);
+      if (context === null || context.deliveryAttempt.attemptsMade + 1 < context.deliveryAttempt.maxAttempts) throw error;
+      return complete({ runId: context.data.runId, bankId: context.data.bankId, status: "needs_admin_action", reason: "authenticated_ingestion_retry_exhausted" });
+    }
+  };
 }

--- a/src/worker/authenticated-ingestion-composition.ts
+++ b/src/worker/authenticated-ingestion-composition.ts
@@ -1,6 +1,6 @@
 import type { AuthenticatedSessionCoordinatorDependencies } from "../modules/bank-sessions/ensure-authenticated-session";
 import { createAuditEvent } from "../modules/audit";
-import { AuthenticatedIngestionRetryError, createAuthenticatedIngestionDeliveryProcessor, AuthenticatedIngestionTerminalError, readAuthenticatedIngestionDeliveryContext, type AuthenticatedIngestionDeliveryJob, type AuthenticatedIngestionTerminalOutcome } from "./authenticated-ingestion-delivery";
+import { createAuthenticatedIngestionDeliveryProcessor, AuthenticatedIngestionTerminalError, isAuthenticatedIngestionRetryError, readAuthenticatedIngestionDeliveryContext, type AuthenticatedIngestionDeliveryJob, type AuthenticatedIngestionTerminalOutcome } from "./authenticated-ingestion-delivery";
 import { createAuthenticatedIngestionPrecondition } from "./authenticated-ingestion-precondition";
 import { createCollectionIngestionProcessor, type CollectionIngestionProcessorDependencies } from "./collection-ingestion-processor";
 import type { IngestionResult } from "./queues";
@@ -103,7 +103,7 @@ export function createAuthenticatedIngestionProcessor(
     try {
       return await delivery(job);
     } catch (error) {
-      if (!(error instanceof AuthenticatedIngestionRetryError)) throw error;
+      if (!isAuthenticatedIngestionRetryError(error)) throw error;
       const context = readAuthenticatedIngestionDeliveryContext(job);
       if (context === null || context.deliveryAttempt.attemptsMade + 1 < context.deliveryAttempt.maxAttempts) throw error;
       return complete({ runId: context.data.runId, bankId: context.data.bankId, status: "needs_admin_action", reason: "authenticated_ingestion_retry_exhausted" });

--- a/src/worker/authenticated-ingestion-delivery.test.ts
+++ b/src/worker/authenticated-ingestion-delivery.test.ts
@@ -43,6 +43,19 @@ describe("createAuthenticatedIngestionDeliveryProcessor", () => {
     expect(authenticate).toHaveBeenCalledWith(expect.objectContaining({ signal: controller.signal }));
   });
 
+  it.each([
+    Object.defineProperty({ attemptsMade: 0, maxAttempts: 1 }, "hidden", { value: true }),
+    Object.assign({ attemptsMade: 0, maxAttempts: 1 }, { [Symbol("unexpected")]: true }),
+    Object.defineProperty({ maxAttempts: 1 }, "attemptsMade", { enumerable: true, get: () => { throw new Error("raw-attempt-sentinel"); } }),
+    { attemptsMade: 1, maxAttempts: 1 },
+  ])("fails closed for forged ephemeral delivery attempts without invoking their accessors", async (deliveryAttempt) => {
+    const { processor, authenticate, downstream, complete } = setup();
+    await processor({ data: payload(), deliveryAttempt } as never);
+    expect(authenticate).not.toHaveBeenCalled(); expect(downstream).not.toHaveBeenCalled();
+    expect(complete).toHaveBeenCalledWith({ runId: "run-1", bankId: "popular", status: "failed", reason: "invalid_authenticated_ingestion_delivery" });
+    expect(JSON.stringify(complete.mock.calls)).not.toContain("raw-attempt-sentinel");
+  });
+
   it("fails closed for a hostile signal accessor without exposing it to authentication", async () => {
     const prototype = Object.create(AbortSignal.prototype); Object.defineProperty(prototype, "aborted", { get: () => { throw new Error("raw-signal-sentinel"); } });
     const { processor, authenticate, complete } = setup();

--- a/src/worker/authenticated-ingestion-delivery.test.ts
+++ b/src/worker/authenticated-ingestion-delivery.test.ts
@@ -7,6 +7,7 @@ import {
   AuthenticatedIngestionRetryError,
   AuthenticatedIngestionTerminalError,
   createAuthenticatedIngestionDeliveryProcessor,
+  isAuthenticatedIngestionRetryError,
 } from "./authenticated-ingestion-delivery";
 
 const payload = () => ({ runId: "run-1", bankId: "popular", accountFingerprint: "fingerprint-1", authentication: { version: 1, attemptId: "attempt-1" } });
@@ -20,6 +21,20 @@ const setup = (precondition: unknown = { status: "authenticated" }, terminalResu
 };
 
 describe("createAuthenticatedIngestionDeliveryProcessor", () => {
+  it("recognizes only retry errors constructed by the authentic constructor", () => {
+    class RetrySubclass extends AuthenticatedIngestionRetryError {}
+    const genuine = new AuthenticatedIngestionRetryError("retry_delivery");
+    const prototypeSpoof = Object.create(AuthenticatedIngestionRetryError.prototype);
+    const duckSpoof = { name: "AuthenticatedIngestionRetryError", message: "Authenticated ingestion delivery must be retried.", reason: "retry_delivery" };
+
+    expect(isAuthenticatedIngestionRetryError(genuine)).toBe(true);
+    expect(isAuthenticatedIngestionRetryError(new RetrySubclass("in_progress"))).toBe(true);
+    expect(isAuthenticatedIngestionRetryError(new AuthenticatedIngestionRetryError("cancelled"))).toBe(true);
+    expect(isAuthenticatedIngestionRetryError(prototypeSpoof)).toBe(false);
+    expect(isAuthenticatedIngestionRetryError(duckSpoof)).toBe(false);
+    expect(isAuthenticatedIngestionRetryError(new Proxy(genuine, {}))).toBe(false);
+    expect(JSON.stringify(genuine)).not.toContain("WeakSet");
+  });
   it("passes the queued durable identity to authentication, strips its wrapper, and delegates once", async () => {
     const { processor, authenticate, downstream, complete } = setup();
     await expect(processor({ data: payload() })).resolves.toEqual(result);

--- a/src/worker/authenticated-ingestion-delivery.ts
+++ b/src/worker/authenticated-ingestion-delivery.ts
@@ -17,9 +17,14 @@ export type AuthenticatedIngestionDeliveryDependencies<TResult> = Readonly<{
   createOwnerToken: () => string;
 }>;
 
+const authenticatedIngestionRetryErrors = new WeakSet<object>();
+
 export class AuthenticatedIngestionRetryError extends Error {
   readonly reason: "retry_delivery" | "in_progress" | "cancelled";
-  constructor(reason: "retry_delivery" | "in_progress" | "cancelled") { super("Authenticated ingestion delivery must be retried."); this.name = "AuthenticatedIngestionRetryError"; this.reason = reason; }
+  constructor(reason: "retry_delivery" | "in_progress" | "cancelled") { super("Authenticated ingestion delivery must be retried."); this.name = "AuthenticatedIngestionRetryError"; this.reason = reason; authenticatedIngestionRetryErrors.add(this); }
+}
+export function isAuthenticatedIngestionRetryError(value: unknown): value is AuthenticatedIngestionRetryError {
+  return typeof value === "object" && value !== null && authenticatedIngestionRetryErrors.has(value);
 }
 export class AuthenticatedIngestionInvalidJobError extends Error { constructor() { super("Invalid authenticated ingestion delivery job."); this.name = "AuthenticatedIngestionInvalidJobError"; } }
 export class AuthenticatedIngestionTerminalError extends Error { constructor() { super("Authenticated ingestion terminal completion failed."); this.name = "AuthenticatedIngestionTerminalError"; } }

--- a/src/worker/authenticated-ingestion-delivery.ts
+++ b/src/worker/authenticated-ingestion-delivery.ts
@@ -1,10 +1,12 @@
 import type { AuthenticatedSessionPreconditionResult } from "../modules/bank-sessions/authenticated-session-precondition";
 
-type DeliveryJob = Readonly<{ data: unknown; signal?: AbortSignal }>;
 export type IngestionData = Readonly<{ runId: string; bankId: string; accountFingerprint: string }>;
+export type AuthenticatedIngestionDeliveryAttempt = Readonly<{ attemptsMade: number; maxAttempts: number }>;
+export type AuthenticatedIngestionDeliveryJob = Readonly<{ data: unknown; signal?: AbortSignal; deliveryAttempt?: AuthenticatedIngestionDeliveryAttempt }>;
+type DeliveryJob = AuthenticatedIngestionDeliveryJob;
 type Identity = Readonly<{ bankCode: string; runId: string; attemptId: string }>;
 type OperatorReason = "temporary_authentication_problem" | "protected_authentication_step_detected" | "bank_login_configuration_requires_review" | "authentication_attempt_requires_review" | "identity_conflict" | "restoration_state_conflict";
-type TerminalReason = OperatorReason | "legacy_authenticated_ingestion_delivery" | "invalid_authenticated_ingestion_delivery" | "invalid_authenticated_ingestion_precondition" | "authentication_precondition_requires_review" | "authenticated_ingestion_disabled";
+type TerminalReason = OperatorReason | "legacy_authenticated_ingestion_delivery" | "invalid_authenticated_ingestion_delivery" | "invalid_authenticated_ingestion_precondition" | "authentication_precondition_requires_review" | "authenticated_ingestion_disabled" | "authenticated_ingestion_retry_exhausted";
 
 export type AuthenticatedIngestionTerminalOutcome = Readonly<{ runId: string; bankId?: string; status: "needs_admin_action" | "failed"; reason: TerminalReason }>;
 export type AuthenticatedIngestionAuthenticationInput = Readonly<{ identity: Identity; ownerToken: string; job: Readonly<{ data: IngestionData }>; signal?: AbortSignal }>;
@@ -53,6 +55,28 @@ function aborted(value: AbortSignal): boolean | null {
   try { return readNativeAbortSignal?.call(value) ?? null; } catch { return null; }
 }
 
+function deliveryAttempt(value: unknown): AuthenticatedIngestionDeliveryAttempt | null {
+  const parsed = exact(value, ["attemptsMade", "maxAttempts"]);
+  const attemptsMade = parsed?.attemptsMade;
+  const maxAttempts = parsed?.maxAttempts;
+  if (typeof attemptsMade !== "number" || typeof maxAttempts !== "number" || !Number.isSafeInteger(attemptsMade) || !Number.isSafeInteger(maxAttempts) || attemptsMade < 0 || maxAttempts <= 0 || attemptsMade >= maxAttempts) return null;
+  return Object.freeze({ attemptsMade, maxAttempts });
+}
+
+export type AuthenticatedIngestionDeliveryContext = Readonly<{ data: IngestionData; deliveryAttempt: AuthenticatedIngestionDeliveryAttempt }>;
+
+export function readAuthenticatedIngestionDeliveryContext(job: DeliveryJob): AuthenticatedIngestionDeliveryContext | null {
+  let envelope: Record<string, unknown> | null;
+  try {
+    envelope = exact(job, ["data"]) ?? exact(job, ["data", "signal"]) ?? exact(job, ["data", "deliveryAttempt"]) ?? exact(job, ["data", "signal", "deliveryAttempt"]);
+  } catch { return null; }
+  if (!envelope || signal(envelope.signal) === null) return null;
+  const parsed = (() => { try { return parseData(envelope.data); } catch { return null; } })();
+  if (!parsed || parsed.kind !== "v1") return null;
+  const attempt = "deliveryAttempt" in envelope ? deliveryAttempt(envelope.deliveryAttempt) : Object.freeze({ attemptsMade: 0, maxAttempts: 1 });
+  return attempt === null ? null : Object.freeze({ data: parsed.data, deliveryAttempt: attempt });
+}
+
 export type AuthenticatedIngestionDeliveryClassification =
   | Readonly<{ kind: "v1"; runId: string; bankId: string }>
   | Readonly<{ kind: "legacy"; runId: string; bankId: string }>
@@ -93,7 +117,11 @@ export function createAuthenticatedIngestionDeliveryProcessor<TResult>(dependenc
   const complete = async (outcome: AuthenticatedIngestionTerminalOutcome): Promise<TResult> => { try { return await dependencies.complete(outcome); } catch { throw new AuthenticatedIngestionTerminalError(); } };
   return async (job: DeliveryJob): Promise<TResult> => {
     let data: unknown; let jobSignal: AbortSignal | null | undefined;
-    try { const envelope = exact(job, ["data"]) ?? exact(job, ["data", "signal"]); data = envelope?.data; jobSignal = signal(envelope?.signal); } catch { data = undefined; jobSignal = null; }
+    try {
+      const envelope = exact(job, ["data"]) ?? exact(job, ["data", "signal"]) ?? exact(job, ["data", "deliveryAttempt"]) ?? exact(job, ["data", "signal", "deliveryAttempt"]);
+      data = envelope?.data; jobSignal = signal(envelope?.signal);
+      if (envelope && "deliveryAttempt" in envelope && deliveryAttempt(envelope.deliveryAttempt) === null) jobSignal = null;
+    } catch { data = undefined; jobSignal = null; }
     const parsed = (() => { try { return parseData(data); } catch { return null; } })();
     if (!parsed) {
       const runId = safeRunId(data);

--- a/src/worker/ingestion-worker-factory.test.ts
+++ b/src/worker/ingestion-worker-factory.test.ts
@@ -62,7 +62,10 @@ function makeFakeWorkerCtor(): { Ctor: WorkerConstructor; instances: FakeWorker[
 const successResult: IngestionResult = { status: "succeeded", inserted: 2, skipped: 1 };
 
 function makeSuccessProcessor() {
-  return vi.fn(async (): Promise<IngestionResult> => successResult);
+  return vi.fn(async (job: unknown): Promise<IngestionResult> => {
+    void job;
+    return successResult;
+  });
 }
 
 const fakeConnection = {
@@ -74,6 +77,8 @@ const fakeConnection = {
 const fakeJob: WorkerJob = {
   name: INGESTION_QUEUE_NAME,
   data: { runId: "run-worker-1", bankId: "popular", accountFingerprint: "acct-main" },
+  attemptsMade: 0,
+  opts: {},
 };
 
 // ---------------------------------------------------------------------------
@@ -121,8 +126,49 @@ describe("createIngestionWorker", () => {
     const result = await instances[0].handler({ ...fakeJob, name: INGESTION_QUEUE_NAME });
 
     expect(processor).toHaveBeenCalledOnce();
-    expect(processor).toHaveBeenCalledWith({ data: fakeJob.data });
+    expect(processor).toHaveBeenCalledWith({ data: fakeJob.data, deliveryAttempt: { attemptsMade: 0, maxAttempts: 1 } });
     expect(result).toEqual(successResult);
+  });
+
+  it.each([
+    [0, 3, { attemptsMade: 0, maxAttempts: 3 }],
+    [1, 3, { attemptsMade: 1, maxAttempts: 3 }],
+    [2, 3, { attemptsMade: 2, maxAttempts: 3 }],
+  ])("adapts trusted BullMQ attempt %i/%i into frozen ephemeral delivery metadata", async (attemptsMade, attempts, deliveryAttempt) => {
+    const { Ctor, instances } = makeFakeWorkerCtor();
+    const processor = makeSuccessProcessor();
+    createIngestionWorker({ connection: fakeConnection, processor, WorkerCtor: Ctor });
+
+    await instances[0].handler({ ...fakeJob, attemptsMade, opts: { attempts } } as never);
+
+    expect(processor).toHaveBeenCalledWith({ data: fakeJob.data, deliveryAttempt });
+    expect(Object.isFrozen((processor.mock.calls[0]?.[0] as { deliveryAttempt: object }).deliveryAttempt)).toBe(true);
+  });
+
+  it("defaults missing BullMQ attempts to one total delivery", async () => {
+    const { Ctor, instances } = makeFakeWorkerCtor();
+    const processor = makeSuccessProcessor();
+    createIngestionWorker({ connection: fakeConnection, processor, WorkerCtor: Ctor });
+
+    await instances[0].handler({ ...fakeJob, attemptsMade: 0, opts: {} } as never);
+
+    expect(processor).toHaveBeenCalledWith({ data: fakeJob.data, deliveryAttempt: { attemptsMade: 0, maxAttempts: 1 } });
+  });
+
+  it.each([
+    { attemptsMade: -1, opts: { attempts: 1 } },
+    { attemptsMade: 0, opts: { attempts: 0 } },
+    { attemptsMade: 1, opts: { attempts: 1 } },
+    { attemptsMade: Number.NaN, opts: { attempts: 1 } },
+    { attemptsMade: 0, opts: Object.defineProperty({}, "attempts", { enumerable: true, get: () => { throw new Error("raw-attempt-sentinel"); } }) },
+  ])("fails closed for malformed attempt metadata before invoking the processor", async (metadata) => {
+    const { Ctor, instances } = makeFakeWorkerCtor();
+    const processor = makeSuccessProcessor();
+    createIngestionWorker({ connection: fakeConnection, processor, WorkerCtor: Ctor });
+
+    await expect(instances[0].handler({ ...fakeJob, ...metadata } as never)).rejects.toThrow("Invalid ingestion delivery attempt.");
+
+    expect(processor).not.toHaveBeenCalled();
   });
 
   it("routes only the exact expiry publication job name to the retired handler without invoking the processor", async () => {

--- a/src/worker/ingestion-worker-factory.ts
+++ b/src/worker/ingestion-worker-factory.ts
@@ -8,6 +8,7 @@
 
 import { ingestionJobName, type IngestionJob, type IngestionResult } from "./queues/index";
 import { expiryPublicationJobName } from "../modules/bank-sessions/expiry-publication";
+import type { AuthenticatedIngestionDeliveryAttempt } from "./authenticated-ingestion-delivery";
 
 export const INGESTION_QUEUE_NAME = ingestionJobName;
 
@@ -19,6 +20,8 @@ export const INGESTION_QUEUE_NAME = ingestionJobName;
 export interface WorkerJob {
   name?: string;
   data: unknown;
+  attemptsMade?: unknown;
+  opts?: unknown;
 }
 
 /** Minimal BullMQ Worker surface the factory returns. */
@@ -41,7 +44,7 @@ export interface CreateIngestionWorkerOptions {
   /** ioredis connection options (host/port/password/maxRetriesPerRequest). */
   connection: { host: string; port: number; password?: string; maxRetriesPerRequest: null };
   /** Ingestion processor — called once per job. */
-  processor: (job: IngestionJob) => Promise<IngestionResult>;
+  processor: (job: IngestionJob & Readonly<{ deliveryAttempt?: AuthenticatedIngestionDeliveryAttempt }>) => Promise<IngestionResult>;
   consumeRetiredExpiryPublicationJob?: (data: unknown) => Promise<unknown>;
   /** How many jobs to process in parallel.  Defaults to 2. */
   concurrency?: number;
@@ -58,7 +61,7 @@ export interface CreateIngestionWorkerOptions {
  * Creates and starts a BullMQ worker that processes ingestion jobs.
  *
  * The handler:
- * - Calls `processor({ data: job.data })` and RETURNS the result so BullMQ
+ * - Calls `processor({ data: job.data, deliveryAttempt })` and RETURNS the result so BullMQ
  *   marks the job completed.
  * - Does NOT swallow unexpected throws — BullMQ must see them to apply
  *   the retry/backoff configured in createIngestionQueueOptions.
@@ -74,7 +77,9 @@ export function createIngestionWorker(options: CreateIngestionWorkerOptions): Wo
     INGESTION_QUEUE_NAME,
     async (job: WorkerJob): Promise<unknown> => {
       if (job.name === INGESTION_QUEUE_NAME) {
-        return options.processor({ data: job.data as IngestionJob["data"] });
+        const deliveryAttempt = readDeliveryAttempt(job);
+        if (deliveryAttempt === null) throw new Error("Invalid ingestion delivery attempt.");
+        return options.processor({ data: job.data as IngestionJob["data"], deliveryAttempt });
       }
       if (job.name === expiryPublicationJobName && options.consumeRetiredExpiryPublicationJob) {
         return options.consumeRetiredExpiryPublicationJob(job.data);
@@ -88,4 +93,18 @@ export function createIngestionWorker(options: CreateIngestionWorkerOptions): Wo
   );
 
   return worker;
+}
+
+function readDeliveryAttempt(job: WorkerJob): AuthenticatedIngestionDeliveryAttempt | null {
+  try {
+    const attemptsMade = Object.getOwnPropertyDescriptor(job, "attemptsMade");
+    const options = Object.getOwnPropertyDescriptor(job, "opts");
+    if (!attemptsMade || !attemptsMade.enumerable || !("value" in attemptsMade) || !options || !options.enumerable || !("value" in options) || options.value === null || typeof options.value !== "object" || Array.isArray(options.value)) return null;
+    const attempts = Object.getOwnPropertyDescriptor(options.value, "attempts");
+    const maxAttempts = attempts === undefined ? 1 : attempts.enumerable && "value" in attempts ? attempts.value : null;
+    if (!Number.isSafeInteger(attemptsMade.value) || !Number.isSafeInteger(maxAttempts) || attemptsMade.value < 0 || maxAttempts <= 0 || attemptsMade.value >= maxAttempts) return null;
+    return Object.freeze({ attemptsMade: attemptsMade.value, maxAttempts });
+  } catch {
+    return null;
+  }
 }


### PR DESCRIPTION
Closes #132

## Summary

- Freezes the narrow delivery-attempt metadata contract for authenticated ingestion: default attempt `1` with strict validation.
- Preserves the genuine error on non-final attempts and emits bounded terminal telemetry only for a finite final attempt.
- Keeps the authentication activation path inert; no caller changes and no job or identity details can leak through terminal telemetry.

## Chain Context

Start: #131 (`feat/fail-closed-authenticated-ingestion` at `c340f1f`)

```text
#131 fail-closed authenticated ingestion
  -> 📍 .5c delivery attempts (this PR)
    -> .5d in-memory
      -> .5e shutdown
        -> .5f lock
          -> .5g builder
            -> .5h activator
```

Previous dependency: #131 remains open and unmerged. Next work begins from this PR after it lands.

## Review Path

1. Review `authenticated-ingestion-delivery.ts` for the frozen attempts boundary: `1` default, strict validation, genuine-error preservation before finality, and finite terminal telemetry at finality.
2. Review `ingestion-worker-factory.ts` for the private `WeakSet` anti-spoof guard and propagation boundary.
3. Review focused tests for defaults, validation, non-final behavior, final telemetry, spoof resistance, compatibility, and inert activation.

## Changes

| File | Change |
| --- | --- |
| `src/worker/authenticated-ingestion-composition.test.ts` | Covers composition propagation and preserves the inert activation contract. |
| `src/worker/authenticated-ingestion-composition.ts` | Propagates only the narrow authenticated delivery attempts metadata. |
| `src/worker/authenticated-ingestion-delivery.test.ts` | Covers defaulting, strict validation, retry behavior, finite terminal telemetry, and compatibility. |
| `src/worker/authenticated-ingestion-delivery.ts` | Defines the frozen attempts contract; non-final failures retain the genuine error and final failures emit finite terminal telemetry without job or identity leakage. |
| `src/worker/ingestion-worker-factory.test.ts` | Verifies factory propagation and rejects spoofed metadata. |
| `src/worker/ingestion-worker-factory.ts` | Uses a private `WeakSet` guard to prevent forged delivery-attempt metadata from crossing the worker boundary. |

Review size: 6 files, +173/-18 (191 lines), 2 commits (`f918c21`, `4ad63f2`).

## Evidence

- [x] Focused tests: 97 passed.
- [x] Full suite: 1,934 passed, 2 skipped.
- [x] Lint passed.
- [x] Typecheck passed.
- [x] Prisma validation passed.
- [x] `git diff --check` passed.
- [x] Exactly two commits: `f918c21` and `4ad63f2`.
- [x] CI and review checks are disabled by repository configuration; no checks are expected.

## Exclusions

- Does not activate authenticated ingestion; authorization behavior remains inert.
- Does not add callers, persist attempts metadata, change job identity, or expose job/identity data in telemetry.
- Does not include the follow-on in-memory, shutdown, lock, builder, or activator work.

## Rollback

Revert this two-commit work unit to remove only delivery-attempt propagation, validation, guard, and terminal telemetry behavior; no caller or activation behavior is coupled to it.

## Checklist

- [x] Linked approved issue: #132.
- [x] Exactly one PR type label: `type:feature`.
- [x] Conventional commits with no AI attribution.
- [x] Focused behavior and full verification evidence recorded.
- [x] Chain dependency, next PR, exclusions, and rollback boundary documented.