### PR TITLE
feat(worker): enforce lock before credential decryption

### DIFF
--- a/src/worker/scraper/lock-before-decrypt-credential-capability.test.ts
+++ b/src/worker/scraper/lock-before-decrypt-credential-capability.test.ts
@@ -1,0 +1,104 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it, vi } from "vitest";
+import { createLockBeforeDecryptCredentialCapability } from "./lock-before-decrypt-credential-capability";
+
+type Deferred<T> = { promise: Promise<T>; resolve(value: T): void };
+function deferred<T>(): Deferred<T> { let resolve!: (value: T) => void; return { promise: new Promise((done) => { resolve = done; }), resolve }; }
+function input(bankCode = "popular", signal?: AbortSignal) { return Object.freeze(signal ? { bankCode, signal } : { bankCode }); }
+function dependencies(events: string[], overrides: Partial<Parameters<typeof createLockBeforeDecryptCredentialCapability<{ secret: string }, string>>[0]> = {}) {
+  const release = vi.fn(async () => { events.push("release"); return true; });
+  return {
+    release,
+    capability: createLockBeforeDecryptCredentialCapability<{ secret: string }, string>({
+      isSupportedBank: (bankCode) => bankCode === "popular" || bankCode === "banreservas",
+      lock: { acquire: async ({ bankCode }) => { events.push(`acquire:${bankCode}`); return { release }; } },
+      loadCredential: async (bankCode) => { events.push(`load:${bankCode}`); return { secret: "credential-secret" }; },
+      executeProtected: async ({ bankCode, credential }) => { events.push(`execute:${bankCode}:${credential.secret}`); return "ok"; },
+      ...overrides,
+    }),
+  };
+}
+
+describe("createLockBeforeDecryptCredentialCapability", () => {
+  it("fails closed for malformed, mutable, accessor, symbol, blank, and forged-signal input without dependencies", async () => {
+    const events: string[] = []; const { capability } = dependencies(events); const forged = Object.freeze({ aborted: false }) as unknown as AbortSignal;
+    const accessor = Object.freeze(Object.defineProperty({ bankCode: "popular" }, "signal", { enumerable: true, get: () => { throw new Error("must not read"); } }));
+    for (const value of [null, Object.freeze({}), Object.freeze({ bankCode: "" }), Object.freeze({ bankCode: " ", extra: true }), { bankCode: "popular" }, accessor, Object.freeze({ bankCode: "popular", signal: forged }), Object.freeze({ bankCode: "popular", [Symbol("x")]: true })]) {
+      await expect(capability.run(value as never)).resolves.toEqual({ status: "invalid_input" });
+    }
+    expect(events).toEqual([]);
+  });
+
+  it("rejects unsupported or pre-aborted banks before lock acquisition", async () => {
+    const events: string[] = []; const { capability } = dependencies(events); const controller = new AbortController(); controller.abort();
+    await expect(capability.run(input("other"))).resolves.toEqual({ status: "unsupported_bank" });
+    await expect(capability.run(input("popular", controller.signal))).resolves.toEqual({ status: "cancelled" });
+    expect(events).toEqual([]);
+  });
+
+  it("maps busy or unavailable locks safely without secret work", async () => {
+    for (const acquired of [async () => null, async () => { throw new Error("redis-token://secret"); }]) {
+      const events: string[] = []; const { capability, release } = dependencies(events, { lock: { acquire: acquired } });
+      await expect(capability.run(input())).resolves.toEqual({ status: acquired.toString().includes("throw") ? "lock_unavailable" : "lock_busy" });
+      expect([events, release]).toEqual([[], expect.any(Function)]);
+      expect(release).not.toHaveBeenCalled();
+    }
+  });
+
+  it("releases a lease arriving after cancellation without loading or executing", async () => {
+    const events: string[] = []; const waiting = deferred<{ release(): Promise<boolean> } | null>(); const controller = new AbortController();
+    const { capability, release } = dependencies(events, { lock: { acquire: async () => { events.push("acquire"); return waiting.promise; } } });
+    const running = capability.run(input("popular", controller.signal)); controller.abort(); waiting.resolve({ release });
+    await expect(running).resolves.toEqual({ status: "cancelled" }); expect(events).toEqual(["acquire", "release"]);
+  });
+
+  it("cancels after acquire or load before protected execution", async () => {
+    for (const phase of ["acquire", "load"] as const) {
+      const events: string[] = []; const controller = new AbortController(); const { capability } = dependencies(events, {
+        lock: { acquire: async () => { events.push("acquire"); if (phase === "acquire") controller.abort(); return { release: async () => { events.push("release"); return true; } }; } },
+        loadCredential: async () => { events.push("load"); if (phase === "load") controller.abort(); return { secret: "credential-secret" }; },
+      });
+      await expect(capability.run(input("popular", controller.signal))).resolves.toEqual({ status: "cancelled" });
+      expect(events).toEqual(phase === "acquire" ? ["acquire", "release"] : ["acquire", "load", "release"]);
+    }
+  });
+
+  it("acquires, loads, executes, and releases in exact order", async () => {
+    const events: string[] = []; const { capability } = dependencies(events);
+    await expect(capability.run(input())).resolves.toEqual({ status: "completed", result: "ok" });
+    expect(events).toEqual(["acquire:popular", "load:popular", "execute:popular:credential-secret", "release"]);
+  });
+
+  it("contains loader and execution failures while releasing exactly once", async () => {
+    for (const [loadCredential, executeProtected, status] of [[async () => null, undefined, "credential_unavailable"], [async () => undefined as unknown as { secret: string }, undefined, "credential_unavailable"], [async () => { throw new Error("password"); }, undefined, "credential_unavailable"], [undefined, async () => { throw new Error("https://bank/secret"); }, "execution_failed"]] as const) {
+      const events: string[] = []; const { capability, release } = dependencies(events, { ...(loadCredential && { loadCredential }), ...(executeProtected && { executeProtected }) });
+      await expect(capability.run(input())).resolves.toEqual({ status }); expect(release).toHaveBeenCalledTimes(1); expect(events).not.toContain(expect.stringMatching(/^execute/) as never);
+    }
+  });
+
+  it("preserves completed and failed outcomes when release fails and swallows an observer failure", async () => {
+    for (const [releaseResult, executeProtected, expected] of [[false, undefined, { status: "completed", result: "ok" }], ["throw", async () => { throw new Error("secret"); }, { status: "execution_failed" }]] as const) {
+      const events: string[] = []; const observeReleaseFailure = vi.fn(() => { throw new Error("observer-secret"); });
+      const release = async () => { events.push("release"); if (releaseResult === "throw") throw new Error("token"); return false; };
+      const { capability } = dependencies(events, { lock: { acquire: async () => ({ release }) }, observeReleaseFailure, ...(executeProtected && { executeProtected }) });
+      await expect(capability.run(input())).resolves.toEqual(expected); expect(observeReleaseFailure).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it("freezes inputs and outcomes, isolates imports, and never leaks thrown diagnostics", async () => {
+    const events: string[] = []; const secret = { password: "password", token: "lock-token", url: "https://bank.example" }; const { capability } = dependencies(events, { executeProtected: async () => { throw secret; } });
+    const request = input(); const outcome = await capability.run(request);
+    expect([Object.isFrozen(request), Object.isFrozen(outcome), JSON.stringify(outcome)]).toEqual([true, true, '{"status":"execution_failed"}']);
+    const source = readFileSync(new URL("./lock-before-decrypt-credential-capability.ts", import.meta.url), "utf8");
+    expect(source).not.toMatch(/^import /m); expect(source).not.toContain("export async function");
+  });
+
+  it("serializes same-bank work while allowing another bank and exposes no trigger identity", async () => {
+    const held = new Set<string>(); const events: string[] = []; const capability = createLockBeforeDecryptCredentialCapability<{ secret: string }, string>({
+      isSupportedBank: () => true, lock: { acquire: async ({ bankCode }) => { events.push(`acquire:${bankCode}`); if (held.has(bankCode)) return null; held.add(bankCode); return { release: async () => { held.delete(bankCode); return true; } }; } },
+      loadCredential: async (bankCode) => { events.push(`load:${bankCode}`); return { secret: bankCode }; }, executeProtected: async ({ bankCode }) => { events.push(`execute:${bankCode}`); return bankCode; },
+    });
+    await expect(Promise.all([capability.run(input("popular")), capability.run(input("popular")), capability.run(input("banreservas"))])).resolves.toEqual([{ status: "completed", result: "popular" }, { status: "lock_busy" }, { status: "completed", result: "banreservas" }]);
+    expect(events).toEqual(["acquire:popular", "acquire:popular", "acquire:banreservas", "load:popular", "load:banreservas", "execute:popular", "execute:banreservas"]);
+  });
+});

--- a/src/worker/scraper/lock-before-decrypt-credential-capability.test.ts
+++ b/src/worker/scraper/lock-before-decrypt-credential-capability.test.ts
@@ -29,11 +29,29 @@ describe("createLockBeforeDecryptCredentialCapability", () => {
     expect(events).toEqual([]);
   });
 
+  it("fails closed for forged native prototypes, reflection traps, hidden fields, and undefined signals", async () => {
+    const events: string[] = []; const { capability } = dependencies(events); const controller = new AbortController();
+    const hiddenBankCode = Object.freeze(Object.defineProperty({}, "bankCode", { value: "popular" }));
+    const hiddenSignal = Object.freeze(Object.defineProperty({ bankCode: "popular" }, "signal", { value: controller.signal }));
+    const throwing = new Proxy({}, { getPrototypeOf: () => { throw new Error("trap"); } }); const revoked = Proxy.revocable(Object.freeze({ bankCode: "popular" }), {}); revoked.revoke();
+    for (const value of [Object.freeze({ bankCode: "popular", signal: Object.create(AbortSignal.prototype) }), throwing, revoked.proxy, hiddenBankCode, hiddenSignal, Object.freeze({ bankCode: "popular", signal: undefined })]) {
+      await expect(capability.run(value)).resolves.toEqual({ status: "invalid_input" });
+    }
+    expect(events).toEqual([]);
+  });
+
   it("rejects unsupported or pre-aborted banks before lock acquisition", async () => {
     const events: string[] = []; const { capability } = dependencies(events); const controller = new AbortController(); controller.abort();
     await expect(capability.run(input("other"))).resolves.toEqual({ status: "unsupported_bank" });
     await expect(capability.run(input("popular", controller.signal))).resolves.toEqual({ status: "cancelled" });
     expect(events).toEqual([]);
+  });
+
+  it("accepts genuine native signals and safely observes their cancellation", async () => {
+    const events: string[] = []; const { capability } = dependencies(events); const active = new AbortController(); const cancelled = new AbortController(); cancelled.abort();
+    await expect(capability.run(input("popular", active.signal))).resolves.toEqual({ status: "completed", result: "ok" });
+    await expect(capability.run(input("popular", cancelled.signal))).resolves.toEqual({ status: "cancelled" });
+    expect(events).toEqual(["acquire:popular", "load:popular", "execute:popular:credential-secret", "release"]);
   });
 
   it("maps busy or unavailable locks safely without secret work", async () => {

--- a/src/worker/scraper/lock-before-decrypt-credential-capability.ts
+++ b/src/worker/scraper/lock-before-decrypt-credential-capability.ts
@@ -12,25 +12,25 @@ type Dependencies<TCredential, TResult> = Readonly<{
   executeProtected(input: Readonly<{ bankCode: string; credential: TCredential; signal?: AbortSignal }>): Promise<TResult>;
   observeReleaseFailure?(): void;
 }>;
+const nativeAbortSignalAborted = typeof AbortSignal === "undefined" ? undefined : Object.getOwnPropertyDescriptor(AbortSignal.prototype, "aborted")?.get;
 
 function outcome<TResult>(status: LockBeforeDecryptOutcome<TResult>["status"], result?: TResult): LockBeforeDecryptOutcome<TResult> {
   return Object.freeze(status === "completed" ? { status, result: result as TResult } : { status });
 }
 
 function parseRequest(value: unknown): Request | null {
-  if (value === null || typeof value !== "object" || Object.getPrototypeOf(value) !== Object.prototype || !Object.isFrozen(value)) return null;
-  const descriptors = Object.getOwnPropertyDescriptors(value);
-  const keys = Object.keys(descriptors);
-  if (Object.getOwnPropertySymbols(value).length || !keys.includes("bankCode") || keys.some((key) => key !== "bankCode" && key !== "signal")) return null;
-  const bankCode = descriptors.bankCode;
-  const signal = descriptors.signal;
-  if (!bankCode || "get" in bankCode || "set" in bankCode || typeof bankCode.value !== "string" || !bankCode.value.trim()) return null;
-  if (signal && ("get" in signal || "set" in signal || !isNativeSignal(signal.value))) return null;
-  return Object.freeze(signal ? { bankCode: bankCode.value, signal: signal.value } : { bankCode: bankCode.value });
+  try {
+    if (value === null || typeof value !== "object" || Object.getPrototypeOf(value) !== Object.prototype || !Object.isFrozen(value)) return null;
+    const descriptors = Object.getOwnPropertyDescriptors(value); const keys = Object.keys(descriptors); const bankCode = descriptors.bankCode; const signal = descriptors.signal;
+    if (Object.getOwnPropertySymbols(value).length || !keys.includes("bankCode") || keys.some((key) => key !== "bankCode" && key !== "signal")) return null;
+    if (!bankCode || !bankCode.enumerable || "get" in bankCode || "set" in bankCode || typeof bankCode.value !== "string" || !bankCode.value.trim()) return null;
+    if (signal && (!signal.enumerable || "get" in signal || "set" in signal || signal.value === undefined || readNativeAbortState(signal.value) === null)) return null;
+    return Object.freeze(signal ? { bankCode: bankCode.value, signal: signal.value } : { bankCode: bankCode.value });
+  } catch { return null; }
 }
 
-function isNativeSignal(value: unknown): value is AbortSignal {
-  return typeof AbortSignal !== "undefined" && value instanceof AbortSignal;
+function readNativeAbortState(value: unknown): boolean | null {
+  try { return nativeAbortSignalAborted?.call(value) ?? null; } catch { return null; }
 }
 
 export function createLockBeforeDecryptCredentialCapability<TCredential, TResult>(dependencies: Dependencies<TCredential, TResult>) {
@@ -39,15 +39,15 @@ export function createLockBeforeDecryptCredentialCapability<TCredential, TResult
       const request = parseRequest(value);
       if (!request) return outcome("invalid_input");
       try { if (!dependencies.isSupportedBank(request.bankCode)) return outcome("unsupported_bank"); } catch { return outcome("unsupported_bank"); }
-      if (request.signal?.aborted) return outcome("cancelled");
+      if (readNativeAbortState(request.signal) === true) return outcome("cancelled");
       let lease: Lease | null;
       try { lease = await dependencies.lock.acquire(request); } catch { return outcome("lock_unavailable"); }
       if (!lease) return outcome("lock_busy");
       try {
-        if (request.signal?.aborted) return outcome("cancelled");
+        if (readNativeAbortState(request.signal) === true) return outcome("cancelled");
         let credential: TCredential | null;
         try { credential = await dependencies.loadCredential(request.bankCode); } catch { return outcome("credential_unavailable"); }
-        if (credential == null || request.signal?.aborted) return outcome(credential == null ? "credential_unavailable" : "cancelled");
+        if (credential == null || readNativeAbortState(request.signal) === true) return outcome(credential == null ? "credential_unavailable" : "cancelled");
         try { return outcome("completed", await dependencies.executeProtected(Object.freeze({ bankCode: request.bankCode, credential, ...(request.signal && { signal: request.signal }) }))); } catch { return outcome("execution_failed"); }
       } finally {
         let releaseFailed = false;

--- a/src/worker/scraper/lock-before-decrypt-credential-capability.ts
+++ b/src/worker/scraper/lock-before-decrypt-credential-capability.ts
@@ -1,0 +1,59 @@
+export type LockBeforeDecryptOutcome<TResult> = Readonly<
+  | { status: "completed"; result: TResult }
+  | { status: "invalid_input" | "unsupported_bank" | "cancelled" | "lock_busy" | "lock_unavailable" | "credential_unavailable" | "execution_failed" }
+>;
+
+type Lease = Readonly<{ release(): Promise<boolean> }>;
+type Request = Readonly<{ bankCode: string; signal?: AbortSignal }>;
+type Dependencies<TCredential, TResult> = Readonly<{
+  isSupportedBank(bankCode: string): boolean;
+  lock: Readonly<{ acquire(input: Request): Promise<Lease | null> }>;
+  loadCredential(bankCode: string): Promise<TCredential | null>;
+  executeProtected(input: Readonly<{ bankCode: string; credential: TCredential; signal?: AbortSignal }>): Promise<TResult>;
+  observeReleaseFailure?(): void;
+}>;
+
+function outcome<TResult>(status: LockBeforeDecryptOutcome<TResult>["status"], result?: TResult): LockBeforeDecryptOutcome<TResult> {
+  return Object.freeze(status === "completed" ? { status, result: result as TResult } : { status });
+}
+
+function parseRequest(value: unknown): Request | null {
+  if (value === null || typeof value !== "object" || Object.getPrototypeOf(value) !== Object.prototype || !Object.isFrozen(value)) return null;
+  const descriptors = Object.getOwnPropertyDescriptors(value);
+  const keys = Object.keys(descriptors);
+  if (Object.getOwnPropertySymbols(value).length || !keys.includes("bankCode") || keys.some((key) => key !== "bankCode" && key !== "signal")) return null;
+  const bankCode = descriptors.bankCode;
+  const signal = descriptors.signal;
+  if (!bankCode || "get" in bankCode || "set" in bankCode || typeof bankCode.value !== "string" || !bankCode.value.trim()) return null;
+  if (signal && ("get" in signal || "set" in signal || !isNativeSignal(signal.value))) return null;
+  return Object.freeze(signal ? { bankCode: bankCode.value, signal: signal.value } : { bankCode: bankCode.value });
+}
+
+function isNativeSignal(value: unknown): value is AbortSignal {
+  return typeof AbortSignal !== "undefined" && value instanceof AbortSignal;
+}
+
+export function createLockBeforeDecryptCredentialCapability<TCredential, TResult>(dependencies: Dependencies<TCredential, TResult>) {
+  return Object.freeze({
+    async run(value: unknown): Promise<LockBeforeDecryptOutcome<TResult>> {
+      const request = parseRequest(value);
+      if (!request) return outcome("invalid_input");
+      try { if (!dependencies.isSupportedBank(request.bankCode)) return outcome("unsupported_bank"); } catch { return outcome("unsupported_bank"); }
+      if (request.signal?.aborted) return outcome("cancelled");
+      let lease: Lease | null;
+      try { lease = await dependencies.lock.acquire(request); } catch { return outcome("lock_unavailable"); }
+      if (!lease) return outcome("lock_busy");
+      try {
+        if (request.signal?.aborted) return outcome("cancelled");
+        let credential: TCredential | null;
+        try { credential = await dependencies.loadCredential(request.bankCode); } catch { return outcome("credential_unavailable"); }
+        if (credential == null || request.signal?.aborted) return outcome(credential == null ? "credential_unavailable" : "cancelled");
+        try { return outcome("completed", await dependencies.executeProtected(Object.freeze({ bankCode: request.bankCode, credential, ...(request.signal && { signal: request.signal }) }))); } catch { return outcome("execution_failed"); }
+      } finally {
+        let releaseFailed = false;
+        try { releaseFailed = !(await lease.release()); } catch { releaseFailed = true; }
+        if (releaseFailed) try { dependencies.observeReleaseFailure?.(); } catch {}
+      }
+    },
+  });
+}


### PR DESCRIPTION
Closes #142

## PR Type
- [x] New feature

## Summary
- Adds an inert generic lock-before-decrypt credential capability with no production caller or import.
- Enforces the lock, cancellation, credential, and protected-execution boundary before later production wiring.

## Review Path
Review the runtime contract, construction binding, and outcome/release behavior in that order. Focus on the fixed sequence and the native cancellation-signal hardening.

## Chain Context
#141 -> this PR -> WU6d.5g

## Changes
| File | Change |
|---|---|
| src/worker/scraper/lock-before-decrypt-credential-capability.ts | Defines the generic capability, safe outcomes, policy-bound construction, and guarded execution flow. |
| src/worker/scraper/lock-before-decrypt-credential-capability.test.ts | Covers validation, ordering, cancellation, release, and native signal boundary behavior. |

## Review Size
- 2 new files, 181 additions, 0 deletions.
- 2 commits: 38300fa feature and 626198d native-signal boundary fix.

## Verification Evidence
- Focused tests: 12/12 passed.
- Full suite: 1989 passed, 2 skipped.
- Lint, typecheck, Prisma validation, and diff check passed at HEAD.
- The repository has no CI workflows; review state is disabled/unmanaged.

## Exclusions
- No production caller or import; no schema, configuration, or documentation change.
- Runtime accepts only an exact frozen bankCode and a native optional cancellation signal. It accepts no plaintext credential, token, trigger, or callback runtime input.
- Construction binds supported-bank policy, a bank-only lock port, credential loader/decrypt adapter, and protected execution.
- Current legacy auto-login remains unchanged. WU6d.5g must supply real bank-scoped distributed lock, credential, and browser adapters; WU6d.5h alone activates the behavior.
- The earlier read-only session probe means this claim is zero protected login/browser mutation before lock, not zero total CDP observation.

## Rollback
- This inert, unreferenced capability can be abandoned with its child branch; it does not activate production behavior.
- Do not merge a child state into main; only the tracker merges after the completed chain.

## Checklist
- [x] Linked approved issue #142 with Closes #142.
- [x] Exactly one PR type selected: New feature.
- [x] Conventional commits with no Co-Authored-By trailers.
- [x] Validation -> supported -> abort -> bank lock -> abort -> credential load/decrypt -> abort -> protected execution -> owner release in finally.
- [x] Safe outcomes are preserved; a fixed observed release failure does not replace the outcome.
- [x] Native signal getter/proxy hardening is covered.
- [x] No scripts changed; shellcheck is not applicable.
