### PR TITLE
feat(worker): add explicit authenticated ingestion data seams

### DIFF
--- a/src/modules/bank-credentials/key-resolver.ts
+++ b/src/modules/bank-credentials/key-resolver.ts
@@ -1,4 +1,6 @@
 const AES_KEY_LENGTH_BYTES = 32;
+const BASE64_KEY_RE = /^[A-Za-z0-9+/]+={0,2}$/;
+const CANONICAL_32_BYTE_BASE64_RE = /^[A-Za-z0-9+/]{42}[AEIMQUYcgkosw048]=$/;
 
 function assertSupportedVersion(version: number): void {
   if (version !== 1) {
@@ -7,16 +9,13 @@ function assertSupportedVersion(version: number): void {
 }
 
 export function createCredentialKeyResolver(encodedKey: string): (version?: number) => Buffer {
-  const key = decodeKey(encodedKey);
-  if (key.length !== AES_KEY_LENGTH_BYTES) {
-    throw new Error(
-      `RD_SYNC_BANK_CREDENTIAL_KEY decoded to ${key.length} bytes, expected ${AES_KEY_LENGTH_BYTES}.`,
-    );
-  }
+  validateEncodedKey(encodedKey);
 
   return (version: number = 1): Buffer => {
     assertSupportedVersion(version);
-    return Buffer.from(key);
+    const key = decodeKey(encodedKey);
+    if (key.length !== AES_KEY_LENGTH_BYTES) throw new Error(`RD_SYNC_BANK_CREDENTIAL_KEY decoded to ${key.length} bytes, expected ${AES_KEY_LENGTH_BYTES}.`);
+    return key;
   };
 }
 
@@ -46,6 +45,19 @@ function decodeKey(value: string): Buffer {
     }
   }
 
+  throw new Error(
+    "RD_SYNC_BANK_CREDENTIAL_KEY is not valid base64 or hex. " +
+      "Expected a base64-encoded 32-byte key or a 64-char hex string.",
+  );
+}
+
+function validateEncodedKey(value: string): void {
+  if (/^[0-9a-fA-F]{64}$/.test(value) || CANONICAL_32_BYTE_BASE64_RE.test(value)) return;
+  if (BASE64_KEY_RE.test(value) && value.length % 4 === 0) {
+    const padding = value.endsWith("==") ? 2 : value.endsWith("=") ? 1 : 0;
+    const length = value.length / 4 * 3 - padding;
+    if (length !== AES_KEY_LENGTH_BYTES) throw new Error(`RD_SYNC_BANK_CREDENTIAL_KEY decoded to ${length} bytes, expected ${AES_KEY_LENGTH_BYTES}.`);
+  }
   throw new Error(
     "RD_SYNC_BANK_CREDENTIAL_KEY is not valid base64 or hex. " +
       "Expected a base64-encoded 32-byte key or a 64-char hex string.",

--- a/src/modules/bank-credentials/key-resolver.ts
+++ b/src/modules/bank-credentials/key-resolver.ts
@@ -1,9 +1,27 @@
 const AES_KEY_LENGTH_BYTES = 32;
 
-export function resolveCredentialKey(version: number = 1): Buffer {
+function assertSupportedVersion(version: number): void {
   if (version !== 1) {
     throw new Error(`Unsupported key version: ${version}. Only version 1 is currently supported.`);
   }
+}
+
+export function createCredentialKeyResolver(encodedKey: string): (version?: number) => Buffer {
+  const key = decodeKey(encodedKey);
+  if (key.length !== AES_KEY_LENGTH_BYTES) {
+    throw new Error(
+      `RD_SYNC_BANK_CREDENTIAL_KEY decoded to ${key.length} bytes, expected ${AES_KEY_LENGTH_BYTES}.`,
+    );
+  }
+
+  return (version: number = 1): Buffer => {
+    assertSupportedVersion(version);
+    return Buffer.from(key);
+  };
+}
+
+export function resolveCredentialKey(version: number = 1): Buffer {
+  assertSupportedVersion(version);
 
   const raw = process.env.RD_SYNC_BANK_CREDENTIAL_KEY;
   if (!raw || raw.trim() === "") {
@@ -13,14 +31,7 @@ export function resolveCredentialKey(version: number = 1): Buffer {
     );
   }
 
-  const key = decodeKey(raw.trim());
-  if (key.length !== AES_KEY_LENGTH_BYTES) {
-    throw new Error(
-      `RD_SYNC_BANK_CREDENTIAL_KEY decoded to ${key.length} bytes, expected ${AES_KEY_LENGTH_BYTES}.`,
-    );
-  }
-
-  return key;
+  return createCredentialKeyResolver(raw.trim())(version);
 }
 
 function decodeKey(value: string): Buffer {

--- a/src/modules/bank-credentials/repository.ts
+++ b/src/modules/bank-credentials/repository.ts
@@ -16,6 +16,22 @@ export interface BankCredentialMetadata {
   lastRotatedAt: Date | null;
 }
 
+export type BankAuthenticationMaterial = Readonly<{
+  bankCode: string;
+  isActive: boolean;
+  keyVersion: number;
+  encryptedUsernameEnvelope: string;
+  encryptedPasswordEnvelope: string;
+}>;
+
+const authenticationMaterialSelect = {
+  bankCode: true,
+  isActive: true,
+  keyVersion: true,
+  encryptedUsernameEnvelope: true,
+  encryptedPasswordEnvelope: true,
+} as const;
+
 export class BankCredentialRepository {
   constructor(private readonly prisma: PrismaClient) {}
 
@@ -51,6 +67,18 @@ export class BankCredentialRepository {
     return this.prisma.bankCredential.findUnique({
       where: { bankCode },
       select: { bankCode: true, isActive: true, keyVersion: true, lastRotatedAt: true },
+    });
+  }
+
+  async findAuthenticationMaterialByBankCode(bankCode: string): Promise<BankAuthenticationMaterial | null> {
+    if (!/^[a-z][a-z0-9_-]{0,31}$/.test(bankCode)) throw new Error("Invalid bank code");
+    const row = await this.prisma.bankCredential.findUnique({ where: { bankCode }, select: authenticationMaterialSelect });
+    return row === null ? null : Object.freeze({
+      bankCode: row.bankCode,
+      isActive: row.isActive,
+      keyVersion: row.keyVersion,
+      encryptedUsernameEnvelope: row.encryptedUsernameEnvelope,
+      encryptedPasswordEnvelope: row.encryptedPasswordEnvelope,
     });
   }
 }

--- a/src/modules/persistence/authenticated-ingestion-data-seams.test.ts
+++ b/src/modules/persistence/authenticated-ingestion-data-seams.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { readFileSync } from "node:fs";
 
 const { prismaPg, prismaClient } = vi.hoisted(() => ({ prismaPg: vi.fn(), prismaClient: vi.fn() }));
 
@@ -64,6 +65,9 @@ describe("authenticated ingestion data seams", () => {
   });
 
   it("returns fresh version-one key copies without reading environment after construction", () => {
+    const source = readFileSync(new URL("../bank-credentials/key-resolver.ts", import.meta.url), "utf8");
+    const factory = source.slice(source.indexOf("export function createCredentialKeyResolver"), source.indexOf("export function resolveCredentialKey"));
+    expect(factory.slice(0, factory.indexOf("return (version"))).not.toMatch(/decodeKey\(|Buffer\.from|process\.env/);
     const resolver = createCredentialKeyResolver("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
     const first = resolver(1);
     first.fill(0);
@@ -72,5 +76,7 @@ describe("authenticated ingestion data seams", () => {
     expect(() => resolver(2)).toThrow("Unsupported key version");
     expect(() => createCredentialKeyResolver("not-a-key")).toThrow("not valid base64 or hex");
     expect(() => createCredentialKeyResolver("AA==")).toThrow("decoded to 1 bytes");
+    const canonical = Buffer.alloc(32).toString("base64");
+    expect(() => createCredentialKeyResolver(`${canonical.slice(0, -2)}B=`)).toThrow("not valid base64 or hex");
   });
 });

--- a/src/modules/persistence/authenticated-ingestion-data-seams.test.ts
+++ b/src/modules/persistence/authenticated-ingestion-data-seams.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { prismaPg, prismaClient } = vi.hoisted(() => ({ prismaPg: vi.fn(), prismaClient: vi.fn() }));
+
+vi.mock("@prisma/adapter-pg", () => ({ PrismaPg: prismaPg }));
+vi.mock("../../generated/prisma/client", () => ({ PrismaClient: prismaClient }));
+
+import { BankCredentialRepository } from "../bank-credentials/repository";
+import { createCredentialKeyResolver } from "../bank-credentials/key-resolver";
+import { PrismaAuditSink } from "./prisma-audit-sink";
+import { createPrismaClient } from "./prisma-client";
+import { PrismaScrapeRunRepository } from "./prisma-scrape-run-repository";
+import { PrismaTransactionRepository } from "./prisma-transaction-repository";
+
+afterEach(() => vi.clearAllMocks());
+
+describe("authenticated ingestion data seams", () => {
+  it("builds an explicit Prisma client from the supplied URL without connecting", () => {
+    const previous = process.env.DATABASE_URL;
+    process.env.DATABASE_URL = "postgresql://ignored.example/test";
+    const client = { $connect: vi.fn() };
+    prismaClient.mockImplementation(function () { return client; });
+
+    expect(createPrismaClient("postgres://user:pass@db.example:5432/rd_sync")).toBe(client);
+    expect(prismaPg).toHaveBeenCalledWith({ connectionString: "postgres://user:pass@db.example:5432/rd_sync" });
+    expect(client.$connect).not.toHaveBeenCalled();
+    process.env.DATABASE_URL = previous;
+  });
+
+  it("keeps injected Prisma clients instead of resolving the default", async () => {
+    const client = {
+      bank: { upsert: vi.fn().mockResolvedValue({ id: "bank-1" }) },
+      scrapeRun: { findMany: vi.fn().mockResolvedValue([]) },
+      transaction: { findMany: vi.fn().mockResolvedValue([]) },
+      auditEvent: { findMany: vi.fn().mockResolvedValue([]) },
+    };
+
+    await expect(new PrismaScrapeRunRepository(client as never).list({})).resolves.toEqual([]);
+    await expect(new PrismaTransactionRepository(client as never).list({})).resolves.toEqual([]);
+    await expect(new PrismaAuditSink(client as never).list()).resolves.toEqual([]);
+    expect(prismaClient).not.toHaveBeenCalled();
+  });
+
+  it("projects and freezes only authentication material", async () => {
+    const findUnique = vi.fn().mockResolvedValue({
+      bankCode: "popular", isActive: true, keyVersion: 1,
+      encryptedUsernameEnvelope: "username", encryptedPasswordEnvelope: "password",
+    });
+    const repository = new BankCredentialRepository({ bankCredential: { findUnique } } as never);
+
+    const result = await repository.findAuthenticationMaterialByBankCode("popular");
+    expect(findUnique).toHaveBeenCalledWith({ where: { bankCode: "popular" }, select: {
+      bankCode: true, isActive: true, keyVersion: true,
+      encryptedUsernameEnvelope: true, encryptedPasswordEnvelope: true,
+    } });
+    expect(result).toEqual({ bankCode: "popular", isActive: true, keyVersion: 1, encryptedUsernameEnvelope: "username", encryptedPasswordEnvelope: "password" });
+    expect(Object.isFrozen(result)).toBe(true);
+    await expect(repository.findAuthenticationMaterialByBankCode("bad code")).rejects.toThrow("Invalid bank code");
+    expect(findUnique).toHaveBeenCalledTimes(1);
+    findUnique.mockResolvedValueOnce(null);
+    await expect(repository.findAuthenticationMaterialByBankCode("popular")).resolves.toBeNull();
+    findUnique.mockRejectedValueOnce(new Error("query unavailable"));
+    await expect(repository.findAuthenticationMaterialByBankCode("popular")).rejects.toThrow("query unavailable");
+  });
+
+  it("returns fresh version-one key copies without reading environment after construction", () => {
+    const resolver = createCredentialKeyResolver("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+    const first = resolver(1);
+    first.fill(0);
+    expect(resolver(1).toString("hex")).toBe("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+    expect(createCredentialKeyResolver(Buffer.alloc(32, 7).toString("base64"))(1)).toHaveLength(32);
+    expect(() => resolver(2)).toThrow("Unsupported key version");
+    expect(() => createCredentialKeyResolver("not-a-key")).toThrow("not valid base64 or hex");
+    expect(() => createCredentialKeyResolver("AA==")).toThrow("decoded to 1 bytes");
+  });
+});

--- a/src/modules/persistence/prisma-audit-sink.ts
+++ b/src/modules/persistence/prisma-audit-sink.ts
@@ -6,13 +6,15 @@
  * does not re-redact.
  */
 
-import type { Prisma } from "../../generated/prisma/client";
+import type { Prisma, PrismaClient } from "../../generated/prisma/client";
 import type { AuditSink, AuditEvent, AuditListOptions } from "../audit/index";
 import { getPrismaClient } from "./prisma-client";
 
 export class PrismaAuditSink implements AuditSink {
+  constructor(private readonly client?: PrismaClient) {}
+
   private get prisma() {
-    return getPrismaClient();
+    return this.client ?? getPrismaClient();
   }
 
   async record(event: AuditEvent): Promise<void> {

--- a/src/modules/persistence/prisma-client.ts
+++ b/src/modules/persistence/prisma-client.ts
@@ -30,6 +30,14 @@ const globalRegistry = globalThis as typeof globalThis & {
   __rdSyncPrismaClient?: PrismaClient;
 };
 
+export function createPrismaClient(databaseUrl: string): PrismaClient {
+  if (typeof databaseUrl !== "string" || databaseUrl.trim() === "") {
+    throw new Error("A PostgreSQL connection string is required.");
+  }
+
+  return new PrismaClient({ adapter: new PrismaPg({ connectionString: databaseUrl }) });
+}
+
 /**
  * Return the globalThis-anchored PrismaClient singleton.
  * Throws a clear error if DATABASE_URL is not set.
@@ -43,8 +51,7 @@ export function getPrismaClient(): PrismaClient {
       );
     }
 
-    const adapter = new PrismaPg({ connectionString });
-    globalRegistry.__rdSyncPrismaClient = new PrismaClient({ adapter });
+    globalRegistry.__rdSyncPrismaClient = createPrismaClient(connectionString);
   }
 
   return globalRegistry.__rdSyncPrismaClient;

--- a/src/modules/persistence/prisma-scrape-run-repository.ts
+++ b/src/modules/persistence/prisma-scrape-run-repository.ts
@@ -10,7 +10,7 @@
  * - Sorting: filterScrapeRuns sorts by updatedAt desc; we replicate that.
  */
 
-import type { Prisma } from "../../generated/prisma/client";
+import type { Prisma, PrismaClient } from "../../generated/prisma/client";
 import type {
   ScrapeRunRecord,
   ScrapeRunFilters,
@@ -65,8 +65,10 @@ function mapRow(row: ScrapeRunRow): ScrapeRunRecord {
 }
 
 export class PrismaScrapeRunRepository {
+  constructor(private readonly client?: PrismaClient) {}
+
   private get prisma() {
-    return getPrismaClient();
+    return this.client ?? getPrismaClient();
   }
 
   async createQueued(input: CreateQueuedScrapeRunInput): Promise<ScrapeRunRecord> {

--- a/src/modules/persistence/prisma-transaction-repository.ts
+++ b/src/modules/persistence/prisma-transaction-repository.ts
@@ -14,7 +14,7 @@
  *   which exactly matches normalizeAmount output ("5424.00").
  */
 
-import type { Prisma } from "../../generated/prisma/client";
+import type { Prisma, PrismaClient } from "../../generated/prisma/client";
 import type {
   TransactionRecord,
   TransactionFilters,
@@ -91,8 +91,10 @@ const transactionSelect = {
 } as const;
 
 export class PrismaTransactionRepository {
+  constructor(private readonly client?: PrismaClient) {}
+
   private get prisma() {
-    return getPrismaClient();
+    return this.client ?? getPrismaClient();
   }
 
   async upsertMany(records: readonly TransactionRecord[]): Promise<UpsertResult> {


### PR DESCRIPTION
Closes #150

## Type
- [x] New feature

## Summary
- Adds explicit, inert authenticated-ingestion data seams without constructing clients or resources during import.
- Preserves existing credential resolver behavior while deferring fresh key-byte materialization until the future lock boundary.

## Chain
`#149 -> this PR -> WU6d.5g3a2 owned Redis -> WU6d.5g3a3 resources -> WU6d.5g3b processor -> WU6d.5h`

## Changes
| File | Change |
|---|---|
| `src/modules/bank-credentials/key-resolver.ts` | Adds explicit canonical key resolution with deferred fresh Buffer materialization; keeps the environment resolver legacy-compatible. |
| `src/modules/bank-credentials/repository.ts` | Projects exactly the five credential-material fields. |
| `src/modules/bank-credentials/authenticated-ingestion-data-seams.test.ts` | Covers the inert seam contracts. |
| `src/modules/persistence/prisma-client.ts` | Exposes explicit `createPrismaClient` construction without environment loading. |
| `src/modules/persistence/prisma-audit-sink.ts` | Supports lazily injected optional Prisma while preserving defaults. |
| `src/modules/persistence/prisma-scrape-run-repository.ts` | Supports lazily injected optional Prisma while preserving defaults. |
| `src/modules/persistence/prisma-transaction-repository.ts` | Supports lazily injected optional Prisma while preserving defaults. |

## Size
- 7 files changed, `+163/-17` (180 changed lines) against exact base `feat/protected-auto-login-execution` at `fc3ca953`.

## Evidence
- [x] Full suite: 2031 passed, 2 skipped.
- [x] All required local gates passed.
- [x] Parent #149 is OPEN and CLEAN; this branch starts at its head `fc3ca953`.
- [x] Repository CI is disabled/unmanaged; no CI checks are expected.

## Exclusions
- No Redis, SMTP, browser, processor, activation, production caller, or live resource construction.
- No clients or resources are constructed on import.

## Rollback
- [x] Safe to abandon before activation: this PR is inert and has no production caller.
- [x] Retain legacy resolver behavior through the environment resolver.

## Checklist
- [x] Linked approved issue #150.
- [x] Exactly one `type:*` label will be applied: `type:feature`.
- [x] Conventional commits only; no `Co-Authored-By` trailers.