### PR TITLE
feat(worker): add owned authenticated ingestion Redis lock

### DIFF
--- a/src/worker/authenticated-ingestion-redis-resource.test.ts
+++ b/src/worker/authenticated-ingestion-redis-resource.test.ts
@@ -48,6 +48,33 @@ describe("createAuthenticatedIngestionRedisResource", () => {
     expect(resource.lock).toBe(lock);
   });
 
+  it("contains override boundary failures before creating a client and treats undefined as a default", async () => {
+    const throwing = arrange();
+    const throwingProxy = new Proxy({}, { ownKeys: () => { throw new Error("secret override"); } });
+    await expect(createAuthenticatedIngestionRedisResource(validConfig(), throwingProxy as never)).rejects.toThrow("Unable to create authenticated ingestion Redis resource.");
+    expect(throwing.calls.client).toBe(0);
+
+    const fallback = arrange();
+    await (await createAuthenticatedIngestionRedisResource(validConfig(), { ...fallback.factories, createLock: undefined })).close();
+    expect(fallback.calls).toMatchObject({ client: 1, lock: 0, disconnect: 1 });
+
+    const malformed = arrange();
+    await expect(createAuthenticatedIngestionRedisResource(validConfig(), { ...malformed.factories, createClient: true } as never)).rejects.toThrow("Unable to create authenticated ingestion Redis resource.");
+    expect(malformed.calls.client).toBe(0);
+  });
+
+  it("rejects malformed factory products and disconnects an acquired client once", async () => {
+    for (const override of [
+      (factories: AuthenticatedIngestionRedisResourceFactories, client: Client, calls: { client: number }) => ({ ...factories, createClient: () => { calls.client += 1; return ({ ...client, eval: undefined }) as never; } }),
+      (factories: AuthenticatedIngestionRedisResourceFactories) => ({ ...factories, createStore: () => ({ acquireSlot: async () => null }) as never }),
+      (factories: AuthenticatedIngestionRedisResourceFactories) => ({ ...factories, createLock: () => ({ acquire: undefined }) as never }),
+    ]) {
+      const { calls, client, factories } = arrange();
+      await expect(createAuthenticatedIngestionRedisResource(validConfig(), override(factories, client, calls))).rejects.toThrow("Unable to create authenticated ingestion Redis resource.");
+      expect(calls).toMatchObject({ client: 1, disconnect: 1, quit: 0 });
+    }
+  });
+
   it("disconnects wait and terminal clients, but quits ready clients", async () => {
     for (const status of ["wait", "end", "close"]) {
       const { calls, factories } = arrange(status);
@@ -74,14 +101,16 @@ describe("createAuthenticatedIngestionRedisResource", () => {
 
   it("disconnects when status access fails and cleans up partial construction without leaking details", async () => {
     const { calls, client, factories } = arrange();
-    Object.defineProperty(client, "status", { get: () => { throw new Error("redis://secret@host"); } });
+    let reads = 0;
+    Object.defineProperty(client, "status", { get: () => ++reads === 1 ? "wait" : (() => { throw new Error("redis://secret@host"); })() });
     await (await createAuthenticatedIngestionRedisResource(validConfig(), factories)).close();
     expect(calls.disconnect).toBe(1);
 
     const unreadable = arrange();
     Object.defineProperty(unreadable.client, "status", { get: () => { throw new Error("secret"); } });
     unreadable.client.disconnect = () => { unreadable.calls.disconnect += 1; throw new Error("secret"); };
-    await expect((await createAuthenticatedIngestionRedisResource(validConfig(), unreadable.factories)).close()).rejects.toThrow("Unable to close authenticated ingestion Redis resource.");
+    await expect(createAuthenticatedIngestionRedisResource(validConfig(), unreadable.factories)).rejects.toThrow("Unable to create authenticated ingestion Redis resource.");
+    expect(unreadable.calls.disconnect).toBe(1);
 
     const broken = arrange();
     await expect(createAuthenticatedIngestionRedisResource(validConfig(), { ...broken.factories, createStore: () => { throw new Error("redis://secret@host"); } })).rejects.toThrow("Unable to create authenticated ingestion Redis resource.");

--- a/src/worker/authenticated-ingestion-redis-resource.test.ts
+++ b/src/worker/authenticated-ingestion-redis-resource.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import { createAuthenticatedIngestionRedisResource, type AuthenticatedIngestionRedisResourceFactories } from "./authenticated-ingestion-redis-resource";
+
+type Client = { status: string; eval(): Promise<unknown>; quit(): Promise<void>; disconnect(): void | Promise<void> };
+const validConfig = () => Object.freeze({ redisUrl: "rediss://user:secret@cache.example:6380/2?tls=true", ttlMs: 30_000, renewIntervalMs: 10_000 });
+
+function arrange(status = "wait") {
+  const calls = { client: 0, store: 0, lock: 0, quit: 0, disconnect: 0, options: undefined as unknown, url: undefined as unknown };
+  const client: Client = { status, eval: async () => null, quit: async () => { calls.quit += 1; }, disconnect: () => { calls.disconnect += 1; } };
+  const store = { acquireSlot: async () => null, renewIfOwner: async () => false, releaseIfOwner: async () => false };
+  const lock = Object.freeze({ acquire: async () => null });
+  const factories: AuthenticatedIngestionRedisResourceFactories = {
+    createClient: (url, options) => { calls.client += 1; calls.url = url; calls.options = options; return client; },
+    createStore: (input) => { calls.store += 1; expect(input).toEqual({ client }); return store; },
+    createLock: (input) => { calls.lock += 1; expect(input).toEqual({ store, ttlMs: 30_000, renewIntervalMs: 10_000 }); return lock; },
+  };
+  return { calls, client, factories, lock };
+}
+
+describe("createAuthenticatedIngestionRedisResource", () => {
+  it("rejects malformed, mutable, accessor, symbol, and extra configuration before creating a client", async () => {
+    const { calls, factories } = arrange();
+    const accessor = Object.freeze(Object.defineProperty({ redisUrl: "redis://cache.example", ttlMs: 30_000, renewIntervalMs: 10_000 }, "redisUrl", { enumerable: true, get: () => "redis://cache.example" }));
+    const invalid = [
+      { redisUrl: "redis://cache.example", ttlMs: 30_000, renewIntervalMs: 10_000 },
+      Object.freeze({ redisUrl: "redis://cache.example", ttlMs: 30_000, renewIntervalMs: 10_000, extra: true }),
+      Object.freeze({ redisUrl: "redis://cache.example", ttlMs: 30_000, renewIntervalMs: 10_000, [Symbol("extra")]: true }),
+      accessor,
+      Object.freeze({ redisUrl: "redis://cache.example", ttlMs: 30_000, renewIntervalMs: 30_000 }),
+    ];
+    for (const config of invalid) await expect(createAuthenticatedIngestionRedisResource(config, factories)).rejects.toThrow("Invalid authenticated ingestion Redis resource configuration.");
+    expect(calls.client).toBe(0);
+  });
+
+  it("preserves valid Redis URLs and creates a lazy client without commands", async () => {
+    for (const redisUrl of ["redis://user:pass@cache.example:6379/3?name=worker", "rediss://user:pass@cache.example:6380/3?tls=true"]) {
+      const { calls, factories } = arrange();
+      await createAuthenticatedIngestionRedisResource(Object.freeze({ redisUrl, ttlMs: 30_000, renewIntervalMs: 10_000 }), factories);
+      expect(calls).toMatchObject({ client: 1, url: redisUrl, options: { lazyConnect: true, maxRetriesPerRequest: 3, connectTimeout: 5000, commandTimeout: 5000 } });
+    }
+  });
+
+  it("returns only a frozen lock and close function", async () => {
+    const { factories, lock } = arrange();
+    const resource = await createAuthenticatedIngestionRedisResource(validConfig(), factories);
+    expect(Object.isFrozen(resource)).toBe(true);
+    expect(Reflect.ownKeys(resource)).toEqual(["lock", "close"]);
+    expect(resource.lock).toBe(lock);
+  });
+
+  it("disconnects wait and terminal clients, but quits ready clients", async () => {
+    for (const status of ["wait", "end", "close"]) {
+      const { calls, factories } = arrange(status);
+      await (await createAuthenticatedIngestionRedisResource(validConfig(), factories)).close();
+      expect(calls).toMatchObject({ quit: 0, disconnect: 1 });
+    }
+    const { calls, factories } = arrange("ready");
+    await (await createAuthenticatedIngestionRedisResource(validConfig(), factories)).close();
+    expect(calls).toMatchObject({ quit: 1, disconnect: 0 });
+  });
+
+  it("falls back to disconnect, protects concurrent close identity, and returns a safe error", async () => {
+    const { calls, client, factories } = arrange("ready");
+    client.quit = async () => { calls.quit += 1; throw new Error("secret"); };
+    const resource = await createAuthenticatedIngestionRedisResource(validConfig(), factories);
+    expect(resource.close()).toBe(resource.close());
+    await resource.close();
+    expect(calls).toMatchObject({ quit: 1, disconnect: 1 });
+
+    client.disconnect = () => { calls.disconnect += 1; throw new Error("secret"); };
+    const failing = await createAuthenticatedIngestionRedisResource(validConfig(), factories);
+    await expect(failing.close()).rejects.toThrow("Unable to close authenticated ingestion Redis resource.");
+  });
+
+  it("disconnects when status access fails and cleans up partial construction without leaking details", async () => {
+    const { calls, client, factories } = arrange();
+    Object.defineProperty(client, "status", { get: () => { throw new Error("redis://secret@host"); } });
+    await (await createAuthenticatedIngestionRedisResource(validConfig(), factories)).close();
+    expect(calls.disconnect).toBe(1);
+
+    const unreadable = arrange();
+    Object.defineProperty(unreadable.client, "status", { get: () => { throw new Error("secret"); } });
+    unreadable.client.disconnect = () => { unreadable.calls.disconnect += 1; throw new Error("secret"); };
+    await expect((await createAuthenticatedIngestionRedisResource(validConfig(), unreadable.factories)).close()).rejects.toThrow("Unable to close authenticated ingestion Redis resource.");
+
+    const broken = arrange();
+    await expect(createAuthenticatedIngestionRedisResource(validConfig(), { ...broken.factories, createStore: () => { throw new Error("redis://secret@host"); } })).rejects.toThrow("Unable to create authenticated ingestion Redis resource.");
+    expect(broken.calls).toMatchObject({ client: 1, disconnect: 1, quit: 0 });
+
+    const brokenLock = arrange();
+    await expect(createAuthenticatedIngestionRedisResource(validConfig(), { ...brokenLock.factories, createLock: () => { throw new Error("secret"); } })).rejects.toThrow("Unable to create authenticated ingestion Redis resource.");
+    expect(brokenLock.calls).toMatchObject({ client: 1, disconnect: 1, quit: 0 });
+  });
+
+  it("rejects invalid URL boundaries without echoing credentials", async () => {
+    const { calls, factories } = arrange();
+    for (const redisUrl of ["http://cache.example", "redis:///0", "redis://cache.example:99999", "redis://cache.example/#fragment", "redis://user:secret@cache.example/\n"]) {
+      await expect(createAuthenticatedIngestionRedisResource(Object.freeze({ redisUrl, ttlMs: 30_000, renewIntervalMs: 10_000 }), factories)).rejects.toThrow("Invalid authenticated ingestion Redis resource configuration.");
+    }
+    expect(calls.client).toBe(0);
+  });
+});

--- a/src/worker/authenticated-ingestion-redis-resource.ts
+++ b/src/worker/authenticated-ingestion-redis-resource.ts
@@ -1,0 +1,107 @@
+import Redis from "ioredis";
+import { MAX_LOCK_TTL_MS, type LockStore } from "../modules/bank-auto-login-lock";
+import { createRenewableBankAuthenticationLock, type RenewableBankAuthenticationLock } from "../modules/bank-auto-login-lock/renewable-bank-authentication-lock";
+import { RedisLockStore, type RedisEvalClient } from "../modules/bank-auto-login-lock/redis-store";
+
+type RedisClient = RedisEvalClient & Readonly<{ status: string; quit(): Promise<unknown>; disconnect(): void | Promise<void> }>;
+type RedisOptions = Readonly<{ lazyConnect: true; maxRetriesPerRequest: 3; connectTimeout: 5000; commandTimeout: 5000 }>;
+export type AuthenticatedIngestionRedisResourceConfig = Readonly<{ redisUrl: string; ttlMs: number; renewIntervalMs: number }>;
+export type AuthenticatedIngestionRedisResource = Readonly<{ lock: RenewableBankAuthenticationLock; close(): Promise<void> }>;
+export type AuthenticatedIngestionRedisResourceFactories = Readonly<{
+  createClient(redisUrl: string, options: RedisOptions): RedisClient;
+  createStore(input: Readonly<{ client: RedisEvalClient }>): LockStore;
+  createLock(input: Readonly<{ store: LockStore; ttlMs: number; renewIntervalMs: number }>): RenewableBankAuthenticationLock;
+}>;
+
+const CLIENT_OPTIONS: RedisOptions = Object.freeze({ lazyConnect: true, maxRetriesPerRequest: 3, connectTimeout: 5000, commandTimeout: 5000 });
+const INVALID_CONFIGURATION = "Invalid authenticated ingestion Redis resource configuration.";
+const CONSTRUCTION_ERROR = "Unable to create authenticated ingestion Redis resource.";
+const CLOSE_ERROR = "Unable to close authenticated ingestion Redis resource.";
+const TERMINAL_STATUSES = new Set(["wait", "end", "close"]);
+
+const defaults: AuthenticatedIngestionRedisResourceFactories = {
+  createClient: (redisUrl, options) => new Redis(redisUrl, options),
+  createStore: ({ client }) => new RedisLockStore({ client }),
+  createLock: ({ store, ttlMs, renewIntervalMs }) => createRenewableBankAuthenticationLock({ store, ttlMs, renewIntervalMs }),
+};
+
+function parseConfig(value: unknown): AuthenticatedIngestionRedisResourceConfig | null {
+  try {
+    if (value === null || typeof value !== "object" || Array.isArray(value) || !Object.isFrozen(value)) return null;
+    const prototype = Object.getPrototypeOf(value);
+    const keys = Reflect.ownKeys(value);
+    if ((prototype !== Object.prototype && prototype !== null) || keys.length !== 3 || keys.some((key) => typeof key !== "string" || !["redisUrl", "ttlMs", "renewIntervalMs"].includes(key))) return null;
+    const descriptors = Object.getOwnPropertyDescriptors(value);
+    if (Object.values(descriptors).some((descriptor) => !descriptor.enumerable || !("value" in descriptor))) return null;
+    const { redisUrl, ttlMs, renewIntervalMs } = descriptors as Record<string, PropertyDescriptor>;
+    if (typeof redisUrl.value !== "string" || !validRedisUrl(redisUrl.value) || !positiveInteger(ttlMs.value) || !positiveInteger(renewIntervalMs.value) || ttlMs.value > MAX_LOCK_TTL_MS || renewIntervalMs.value >= ttlMs.value) return null;
+    return Object.freeze({ redisUrl: redisUrl.value, ttlMs: ttlMs.value, renewIntervalMs: renewIntervalMs.value });
+  } catch {
+    return null;
+  }
+}
+
+function positiveInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}
+
+function validRedisUrl(redisUrl: string): boolean {
+  if (!redisUrl || redisUrl !== redisUrl.trim() || /[\u0000-\u001F\u007F]/.test(redisUrl)) return false;
+  try {
+    const parsed = new URL(redisUrl);
+    return (parsed.protocol === "redis:" || parsed.protocol === "rediss:") && parsed.hostname.length > 0 && parsed.hash.length === 0;
+  } catch {
+    return false;
+  }
+}
+
+async function disconnect(client: RedisClient): Promise<boolean> {
+  try {
+    await client.disconnect();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function closeClient(client: RedisClient): Promise<void> {
+  let status: string;
+  try {
+    status = client.status;
+  } catch {
+    if (await disconnect(client)) return;
+    throw new Error(CLOSE_ERROR);
+  }
+  // A lazy or terminal client must never be connected merely to close it.
+  if (TERMINAL_STATUSES.has(status)) {
+    if (await disconnect(client)) return;
+    throw new Error(CLOSE_ERROR);
+  }
+  try {
+    await client.quit();
+  } catch {
+    if (await disconnect(client)) return;
+    throw new Error(CLOSE_ERROR);
+  }
+}
+
+export async function createAuthenticatedIngestionRedisResource(
+  config: AuthenticatedIngestionRedisResourceConfig,
+  overrides: Partial<AuthenticatedIngestionRedisResourceFactories> = {},
+): Promise<AuthenticatedIngestionRedisResource> {
+  const parsed = parseConfig(config);
+  if (!parsed) throw new Error(INVALID_CONFIGURATION);
+  const factories = { ...defaults, ...overrides };
+  let client: RedisClient | undefined;
+  try {
+    client = factories.createClient(parsed.redisUrl, CLIENT_OPTIONS);
+    const store = factories.createStore({ client });
+    const lock = factories.createLock({ store, ttlMs: parsed.ttlMs, renewIntervalMs: parsed.renewIntervalMs });
+    let closePromise: Promise<void> | undefined;
+    const close = () => closePromise ??= closeClient(client!);
+    return Object.freeze({ lock, close });
+  } catch {
+    if (client) await disconnect(client);
+    throw new Error(CONSTRUCTION_ERROR);
+  }
+}

--- a/src/worker/authenticated-ingestion-redis-resource.ts
+++ b/src/worker/authenticated-ingestion-redis-resource.ts
@@ -25,6 +25,51 @@ const defaults: AuthenticatedIngestionRedisResourceFactories = {
   createLock: ({ store, ttlMs, renewIntervalMs }) => createRenewableBankAuthenticationLock({ store, ttlMs, renewIntervalMs }),
 };
 
+function resolveFactories(overrides: unknown): AuthenticatedIngestionRedisResourceFactories | null {
+  try {
+    if (overrides === undefined) return defaults;
+    if (overrides === null || typeof overrides !== "object" || Array.isArray(overrides)) return null;
+    const keys = Reflect.ownKeys(overrides);
+    if (keys.some((key) => typeof key !== "string" || !["createClient", "createStore", "createLock"].includes(key))) return null;
+    const descriptors = Object.getOwnPropertyDescriptors(overrides);
+    if (Object.values(descriptors).some((descriptor) => !descriptor.enumerable || !("value" in descriptor))) return null;
+    const { createClient, createStore, createLock } = descriptors as Record<string, PropertyDescriptor>;
+    if ([createClient, createStore, createLock].some((descriptor) => descriptor !== undefined && descriptor.value !== undefined && typeof descriptor.value !== "function")) return null;
+    // Explicit undefined deliberately retains the corresponding production default.
+    return {
+      createClient: createClient?.value === undefined ? defaults.createClient : createClient.value as AuthenticatedIngestionRedisResourceFactories["createClient"],
+      createStore: createStore?.value === undefined ? defaults.createStore : createStore.value as AuthenticatedIngestionRedisResourceFactories["createStore"],
+      createLock: createLock?.value === undefined ? defaults.createLock : createLock.value as AuthenticatedIngestionRedisResourceFactories["createLock"],
+    };
+  } catch {
+    return null;
+  }
+}
+
+function hasFunctions(value: unknown, keys: readonly string[]): value is Record<string, (...args: never[]) => unknown> {
+  try {
+    return value !== null && typeof value === "object" && keys.every((key) => typeof (value as Record<string, unknown>)[key] === "function");
+  } catch {
+    return false;
+  }
+}
+
+function isRedisClient(value: unknown): value is RedisClient {
+  try {
+    return hasFunctions(value, ["eval", "quit", "disconnect"]) && typeof value.status === "string";
+  } catch {
+    return false;
+  }
+}
+
+function isLockStore(value: unknown): value is LockStore {
+  return hasFunctions(value, ["acquireSlot", "renewIfOwner", "releaseIfOwner"]);
+}
+
+function isRenewableLock(value: unknown): value is RenewableBankAuthenticationLock {
+  return hasFunctions(value, ["acquire"]);
+}
+
 function parseConfig(value: unknown): AuthenticatedIngestionRedisResourceConfig | null {
   try {
     if (value === null || typeof value !== "object" || Array.isArray(value) || !Object.isFrozen(value)) return null;
@@ -55,9 +100,12 @@ function validRedisUrl(redisUrl: string): boolean {
   }
 }
 
-async function disconnect(client: RedisClient): Promise<boolean> {
+async function disconnect(client: unknown): Promise<boolean> {
   try {
-    await client.disconnect();
+    if (client === null || typeof client !== "object") return false;
+    const method = (client as { disconnect?: unknown }).disconnect;
+    if (typeof method !== "function") return false;
+    await method.call(client);
     return true;
   } catch {
     return false;
@@ -87,21 +135,26 @@ async function closeClient(client: RedisClient): Promise<void> {
 
 export async function createAuthenticatedIngestionRedisResource(
   config: AuthenticatedIngestionRedisResourceConfig,
-  overrides: Partial<AuthenticatedIngestionRedisResourceFactories> = {},
+  overrides?: Partial<AuthenticatedIngestionRedisResourceFactories>,
 ): Promise<AuthenticatedIngestionRedisResource> {
   const parsed = parseConfig(config);
   if (!parsed) throw new Error(INVALID_CONFIGURATION);
-  const factories = { ...defaults, ...overrides };
-  let client: RedisClient | undefined;
+  const factories = resolveFactories(overrides);
+  if (!factories) throw new Error(CONSTRUCTION_ERROR);
+  let client: unknown;
   try {
     client = factories.createClient(parsed.redisUrl, CLIENT_OPTIONS);
-    const store = factories.createStore({ client });
+    if (!isRedisClient(client)) throw new Error(CONSTRUCTION_ERROR);
+    const ownedClient = client;
+    const store = factories.createStore({ client: ownedClient });
+    if (!isLockStore(store)) throw new Error(CONSTRUCTION_ERROR);
     const lock = factories.createLock({ store, ttlMs: parsed.ttlMs, renewIntervalMs: parsed.renewIntervalMs });
+    if (!isRenewableLock(lock)) throw new Error(CONSTRUCTION_ERROR);
     let closePromise: Promise<void> | undefined;
-    const close = () => closePromise ??= closeClient(client!);
+    const close = () => closePromise ??= closeClient(ownedClient);
     return Object.freeze({ lock, close });
   } catch {
-    if (client) await disconnect(client);
+    await disconnect(client);
     throw new Error(CONSTRUCTION_ERROR);
   }
 }


### PR DESCRIPTION
Closes #152

## Type
- [x] New feature

## Chain
`#151 -> this -> g3a3 resource bundle -> g3b processor -> 5h`

## Changes
| File | Change |
| --- | --- |
| `src/worker/authenticated-ingestion-redis-resource.ts` | Adds an inert, owned Redis lock resource factory with exact explicit Redis configuration, full URL preservation, lazy ioredis options, `RedisLockStore`, and a renewable lock. |
| `src/worker/authenticated-ingestion-redis-resource.test.ts` | Covers resource construction, factory/product validation, ownership, lifecycle cleanup, partial failures, and error containment without a network connection. |

## Evidence
- Two commits: `014ae28` and `d525a0d`.
- Diff from `feat/authenticated-ingestion-data-seams`: 2 new files, +291/-0.
- Focused coverage: 9 passing.
- Historical full suite: 2040 passing, 2 skipped.
- No gates were re-run for this publication-only work unit; CI is disabled/no CI is expected.
- The resource never connects while waiting, ending, or closing; those states disconnect. An active client quits with a disconnect fallback. Repeated close calls share the same promise, and partial/factory failures clean up acquired clients without leaks.

## Exclusions
- No environment, global, or default configuration.
- No Prisma, SMTP, browser, processor, production caller, activation, or runtime wiring.
- No live Redis or network activity.

## Rollback
Revert `014ae28` and `d525a0d` (or close this PR before merge); the resource is inert and has no production caller.