### PR TITLE
feat(worker): activate authenticated ingestion exactly

### DIFF
--- a/src/worker/authenticated-ingestion-production-activation.test.ts
+++ b/src/worker/authenticated-ingestion-production-activation.test.ts
@@ -1,0 +1,82 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it, vi } from "vitest";
+import { activateAuthenticatedIngestionProduction } from "./authenticated-ingestion-production-activation";
+import { createIngestionWorkerShutdown } from "./ingestion-worker-shutdown";
+
+const enabledEnv = Object.freeze({
+  RD_SYNC_AUTHENTICATED_INGESTION: "enabled",
+  DATABASE_URL: "postgresql://user:secret@db.example:5432/rd",
+  RD_SYNC_REDIS_URL: "rediss://user:secret@cache.example:6380/2",
+  RD_SYNC_BANK_CREDENTIAL_KEY: "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff",
+  RD_SYNC_ALERT_SMTP_URL: "smtps://user:secret@mail.example:465",
+  RD_SYNC_ADMIN_EMAIL: "ops@example.com",
+  RD_SYNC_AUTHENTICATED_INGESTION_LOCK_TTL_MS: "30000",
+  RD_SYNC_AUTHENTICATED_INGESTION_LOCK_RENEW_INTERVAL_MS: "10000",
+});
+
+describe("activateAuthenticatedIngestionProduction", () => {
+  it("keeps legacy processor construction inside the composition-root legacy factory", async () => {
+    const source = await readFile(new URL("./ingestion-worker.ts", import.meta.url), "utf8");
+
+    expect(source).toMatch(/createLegacy:\s*\(\)\s*=>\s*createIngestionProcessor\(/);
+    expect(source).not.toContain("const legacyProcessor = createIngestionProcessor");
+  });
+
+  it.each([undefined, "", "true", "Enabled", "enabled "])("keeps legacy processing isolated for %j", async (activation) => {
+    const createLegacy = vi.fn(() => "legacy");
+    const loadProduction = vi.fn();
+
+    await expect(activateAuthenticatedIngestionProduction({
+      env: { ...enabledEnv, RD_SYNC_AUTHENTICATED_INGESTION: activation },
+      createLegacy,
+      loadProduction,
+    })).resolves.toEqual({ kind: "legacy", processor: "legacy" });
+
+    expect(createLegacy).toHaveBeenCalledOnce();
+    expect(loadProduction).not.toHaveBeenCalled();
+  });
+
+  it("creates the owned production bundle and processor only for the exact enabled value", async () => {
+    const resources = { closeLock: vi.fn(), closePrisma: vi.fn() };
+    const createResources = vi.fn(async () => resources);
+    const createProcessor = vi.fn(() => "authenticated");
+    const loadProduction = vi.fn(async () => ({ createResources, createProcessor }));
+
+    const result = await activateAuthenticatedIngestionProduction({ env: enabledEnv, createLegacy: vi.fn(() => "legacy"), loadProduction });
+
+    expect(result).toEqual({ kind: "authenticated", processor: "authenticated", closeLock: resources.closeLock, closePrisma: resources.closePrisma });
+    expect(createResources).toHaveBeenCalledWith({ databaseUrl: enabledEnv.DATABASE_URL, redisUrl: enabledEnv.RD_SYNC_REDIS_URL, credentialKey: enabledEnv.RD_SYNC_BANK_CREDENTIAL_KEY, smtpUrl: enabledEnv.RD_SYNC_ALERT_SMTP_URL, adminEmail: enabledEnv.RD_SYNC_ADMIN_EMAIL, redisLockTtlMs: 30000, redisLockRenewIntervalMs: 10000 });
+    expect(createProcessor).toHaveBeenCalledWith(resources);
+  });
+
+  it("fails closed without constructing legacy processing when enabled configuration or production construction fails", async () => {
+    const createLegacy = vi.fn(() => "legacy");
+    const loadProduction = vi.fn(async () => { throw new Error("secret"); });
+
+    await expect(activateAuthenticatedIngestionProduction({ env: { ...enabledEnv, DATABASE_URL: "" }, createLegacy, loadProduction })).rejects.toThrow("Authenticated ingestion production activation failed.");
+    await expect(activateAuthenticatedIngestionProduction({ env: enabledEnv, createLegacy, loadProduction })).rejects.toThrow("Authenticated ingestion production activation failed.");
+    expect(createLegacy).not.toHaveBeenCalled();
+  });
+
+  it("closes owned lock and Prisma once after the worker closes", async () => {
+    const calls: string[] = [];
+    const resources = { closeLock: vi.fn(async () => { calls.push("lock"); }), closePrisma: vi.fn(async () => { calls.push("prisma"); }) };
+    const activated = await activateAuthenticatedIngestionProduction({
+      env: enabledEnv,
+      createLegacy: vi.fn(() => "legacy"),
+      loadProduction: async () => ({ createResources: async () => resources, createProcessor: () => "authenticated" }),
+    });
+    if (activated.kind !== "authenticated") throw new Error("expected authenticated activation");
+    const shutdown = createIngestionWorkerShutdown({
+      timeoutMs: 100,
+      worker: { pauseIntake: async () => { calls.push("pause"); }, abortActive: () => { calls.push("abort"); }, awaitActiveDrain: async () => {}, gracefulClose: async () => { calls.push("close"); }, forceClose: async () => { calls.push("force"); } },
+      hooks: { closeLock: activated.closeLock, closePrisma: activated.closePrisma },
+    });
+
+    await Promise.all([shutdown(), shutdown()]);
+
+    expect(calls).toEqual(["pause", "abort", "close", "lock", "prisma"]);
+    expect(resources.closeLock).toHaveBeenCalledOnce();
+    expect(resources.closePrisma).toHaveBeenCalledOnce();
+  });
+});

--- a/src/worker/authenticated-ingestion-production-activation.ts
+++ b/src/worker/authenticated-ingestion-production-activation.ts
@@ -1,0 +1,62 @@
+import { resolveAuthenticatedIngestionActivation } from "./authenticated-ingestion-activation-config";
+
+export type AuthenticatedIngestionProductionConfig = Readonly<{
+  databaseUrl: string;
+  redisUrl: string;
+  redisLockTtlMs: number;
+  redisLockRenewIntervalMs: number;
+  credentialKey: string;
+  smtpUrl: string;
+  adminEmail: string;
+}>;
+
+type ProductionModule<TResource, TProcessor> = Readonly<{
+  createResources(config: AuthenticatedIngestionProductionConfig): Promise<TResource>;
+  createProcessor(resources: TResource): TProcessor;
+}>;
+
+export type AuthenticatedIngestionProductionActivation<TProcessor> =
+  | Readonly<{ kind: "legacy"; processor: TProcessor }>
+  | Readonly<{ kind: "authenticated"; processor: TProcessor; closeLock: () => Promise<void>; closePrisma: () => Promise<void> }>;
+
+export type AuthenticatedIngestionProductionActivationDependencies<TResource, TProcessor> = Readonly<{
+  env: Record<string, string | undefined>;
+  createLegacy(): TProcessor;
+  loadProduction(): Promise<ProductionModule<TResource, TProcessor>>;
+}>;
+
+const ACTIVATION_ERROR = "Authenticated ingestion production activation failed.";
+const positiveInteger = (value: string | undefined): number | null => {
+  if (value === undefined || !/^[1-9]\d*$/.test(value)) return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+};
+
+function readConfig(env: Record<string, string | undefined>): AuthenticatedIngestionProductionConfig | null {
+  const databaseUrl = env.DATABASE_URL;
+  const redisUrl = env.RD_SYNC_REDIS_URL;
+  const credentialKey = env.RD_SYNC_BANK_CREDENTIAL_KEY;
+  const smtpUrl = env.RD_SYNC_ALERT_SMTP_URL;
+  const adminEmail = env.RD_SYNC_ADMIN_EMAIL;
+  const redisLockTtlMs = positiveInteger(env.RD_SYNC_AUTHENTICATED_INGESTION_LOCK_TTL_MS);
+  const redisLockRenewIntervalMs = positiveInteger(env.RD_SYNC_AUTHENTICATED_INGESTION_LOCK_RENEW_INTERVAL_MS);
+  if (typeof databaseUrl !== "string" || !databaseUrl || typeof redisUrl !== "string" || !redisUrl || typeof credentialKey !== "string" || !credentialKey || typeof smtpUrl !== "string" || !smtpUrl || typeof adminEmail !== "string" || !adminEmail || redisLockTtlMs === null || redisLockRenewIntervalMs === null) return null;
+  return Object.freeze({ databaseUrl, redisUrl, credentialKey, smtpUrl, adminEmail, redisLockTtlMs, redisLockRenewIntervalMs });
+}
+
+export async function activateAuthenticatedIngestionProduction<TResource extends Readonly<{ closeLock: () => Promise<void>; closePrisma: () => Promise<void> }>, TProcessor>(
+  dependencies: AuthenticatedIngestionProductionActivationDependencies<TResource, TProcessor>,
+): Promise<AuthenticatedIngestionProductionActivation<TProcessor>> {
+  if (resolveAuthenticatedIngestionActivation(dependencies.env.RD_SYNC_AUTHENTICATED_INGESTION).status !== "enabled") {
+    return Object.freeze({ kind: "legacy", processor: dependencies.createLegacy() });
+  }
+  const config = readConfig(dependencies.env);
+  if (!config) throw new Error(ACTIVATION_ERROR);
+  try {
+    const production = await dependencies.loadProduction();
+    const resources = await production.createResources(config);
+    return Object.freeze({ kind: "authenticated", processor: production.createProcessor(resources), closeLock: resources.closeLock, closePrisma: resources.closePrisma });
+  } catch {
+    throw new Error(ACTIVATION_ERROR);
+  }
+}

--- a/src/worker/ingestion-worker.ts
+++ b/src/worker/ingestion-worker.ts
@@ -26,8 +26,10 @@
 // tsx does not auto-load .env, so the worker process needs this explicitly.
 import "dotenv/config";
 
+import { randomUUID } from "node:crypto";
 import { Worker } from "bullmq";
 
+import { createCdpSessionChecker } from "../modules/bank-sessions";
 import { buildRedisConnectionOptions } from "./queues/bullmq-queue";
 import { createIngestionWorker, type WorkerConstructor } from "./ingestion-worker-factory";
 import { createIngestionWorkerShutdown, installIngestionWorkerShutdown } from "./ingestion-worker-shutdown";
@@ -53,6 +55,7 @@ import { defaultTransactionRepository } from "../app/api/transactions/defaults";
 import { defaultAuditSink } from "../app/api/audit/defaults";
 import { createIngestionProcessor } from "./queues";
 import { createProductionAutoLoginOutcomeHook } from "./auto-login-composition";
+import { activateAuthenticatedIngestionProduction } from "./authenticated-ingestion-production-activation";
 
 // ---------------------------------------------------------------------------
 // Fail fast if required env vars are absent
@@ -142,14 +145,40 @@ const runScrapeTimeAutoLogin = createScrapeTimeAutoLoginRunner({
   afterAutoLoginOutcome: createProductionAutoLoginOutcomeHook(defaultAuditSink),
 });
 
-const processor = createIngestionProcessor({
-  scrapeRuns: defaultScrapeRunRepository,
-  transactions: defaultTransactionRepository,
-  adminAlerts: resolveDefaultAlertSink(),
-  auditSink: defaultAuditSink,
-  resolveScraper: resolveDefaultScraper,
-  runScrapeTimeAutoLogin,
-  expiryEpisodes,
+const activatedProcessor = await activateAuthenticatedIngestionProduction({
+  env: process.env,
+  createLegacy: () => createIngestionProcessor({
+    scrapeRuns: defaultScrapeRunRepository,
+    transactions: defaultTransactionRepository,
+    adminAlerts: resolveDefaultAlertSink(),
+    auditSink: defaultAuditSink,
+    resolveScraper: resolveDefaultScraper,
+    runScrapeTimeAutoLogin,
+    expiryEpisodes,
+  }),
+  loadProduction: async () => {
+    const [resourcesModule, processorModule] = await Promise.all([
+      import("./authenticated-ingestion-production-resources"),
+      import("./authenticated-ingestion-production-processor"),
+    ]);
+    return {
+      createResources: resourcesModule.createAuthenticatedIngestionProductionResources,
+      createProcessor: (resources) => processorModule.createAuthenticatedIngestionProductionProcessor(resources, {
+        env: process.env,
+        popularSessionChecker: createCdpSessionChecker({ cdpUrl: resolveBankBrowserEnv(popularBankCode, process.env).cdpUrl }),
+        createOwnerToken: randomUUID,
+        resolveScraper: resolveDefaultScraper,
+        adapterRegistry: bankAdapterRegistry,
+        cdpUrlForBankCode: (bankCode) => resolveBankBrowserEnv(bankCode, process.env).cdpUrl || undefined,
+        ensureBrowser: createScrapeTimeAutoLoginBrowserOpener({
+          trustedLoginUrl: popularPortalConfig.baseUrl,
+          visibleSelectorTimeoutMs: parseAutoLoginSelectorTimeoutMs(process.env.RD_SYNC_AUTOLOGIN_SELECTOR_TIMEOUT_MS),
+          ensureBrowserRuntime: createEnsureBrowserForBank(popularBankCode, process.env),
+          acquireBrowserSlot: createAcquireBrowserSlotFromEnv(process.env),
+        }),
+      }),
+    };
+  },
 });
 
 const consumeRetiredExpiryPublicationJob = createRetiredExpiryPublicationConsumer({
@@ -162,7 +191,7 @@ const consumeRetiredExpiryPublicationJob = createRetiredExpiryPublicationConsume
 
 const worker = createIngestionWorker({
   connection,
-  processor,
+  processor: activatedProcessor.processor,
   consumeRetiredExpiryPublicationJob,
   concurrency: 2,
   // Bind the real bullmq Worker at the composition root; the factory stays
@@ -186,10 +215,12 @@ const shutdown = createIngestionWorkerShutdown({
   timeoutMs: SHUTDOWN_GRACE_MS,
   hooks: {
     stopExpiryScheduling: () => expiryRuntime.stopScheduling(),
-    // The default lock has no owned client-close hook; WU6d.5g owns that adapter.
-    closeLock: async () => undefined,
+    closeLock: activatedProcessor.kind === "authenticated" ? activatedProcessor.closeLock : async () => undefined,
     closeExpiryOutbox: () => expiryRuntime.shutdown(),
-    closePrisma: () => prisma.$disconnect(),
+    closePrisma: async () => {
+      if (activatedProcessor.kind === "authenticated") await activatedProcessor.closePrisma();
+      await prisma.$disconnect();
+    },
   },
 });
 


### PR DESCRIPTION
Closes #158

## Summary

- Activate authenticated ingestion only for the exact enabled environment value.
- Dynamically load production resources and processor while keeping legacy construction lazy and isolated.
- Fail closed on enabled-path configuration or construction failures and own authenticated shutdown resources.

## Changes

| File | Change |
| --- | --- |
| src/worker/authenticated-ingestion-production-activation.ts | Adds exact-env production activation and fail-closed configuration parsing. |
| src/worker/authenticated-ingestion-production-activation.test.ts | Covers isolation, exact activation, failure behavior, lazy legacy construction, and shutdown ownership. |
| src/worker/ingestion-worker.ts | Selects the activated processor and closes owned resources in the existing shutdown lifecycle. |

## Test plan

- [x] pnpm test — 2,059 passed, 2 skipped
- [x] pnpm lint
- [x] pnpm typecheck
- [x] git diff --check
- [x] Eager-legacy construction regression passes
- [x] Changed-line count: 199 (187 additions + 12 deletions), below the 400-line budget
- [x] Runtime harness: N/A — executing the standalone worker requires prohibited live Redis, PostgreSQL, browser, and credential configuration

## Safety and rollback

- Every value except exact enabled keeps authenticated production modules unloaded.
- Explicit enabled failures do not fall back to legacy processing.
- No live deployment or external service activity was performed.
- Rollback boundary: revert this PR to restore the existing legacy worker selection while retaining all inert resources and processor code through PR #157.
- Review-driven development is disabled/unmanaged; repository-required local gates are recorded above.

## Chain

- Parent/base: #157 (feat/inert-authenticated-ingestion-production-processor)
- This unit: WU6d.5h final activation code slice
- Live cutover still requires the stop, drain, recreate, and rollback procedure in tracker #111.
- DO NOT MERGE this child independently; only tracker #111 merges to main.